### PR TITLE
Gas Analyzer window adjustment

### DIFF
--- a/Content.Client/Atmos/UI/GasAnalyzerMenu.cs
+++ b/Content.Client/Atmos/UI/GasAnalyzerMenu.cs
@@ -145,7 +145,7 @@ namespace Content.Client.Atmos.UI
                 PanelOverride = new StyleBoxFlat { BackgroundColor = Color.FromHex("#525252ff") }
             });
             CloseButton.OnPressed += _ => Close();
-            SetSize = (300, 200);
+            SetSize = (300, 420);
         }
 
 


### PR DESCRIPTION
:cl:
- changed the Window Size from 300x200 -> 300x420. (dank)

Not really the most elegant solution to the issue but it will make due for the time being, that is making it readable when multiple gasses are on display.