### PR TITLE
Adds Spiral Station Map and proto files.

### DIFF
--- a/Resources/Prototypes/Maps/spiral94.yml
+++ b/Resources/Prototypes/Maps/spiral94.yml
@@ -1,0 +1,55 @@
+- type: gameMap
+  id: spiralstation
+  mapName: 'Spiral Station'
+  mapPath: /Maps/spiral94.yml
+  minPlayers: 40
+  stations:
+    Spiral:
+      mapNameTemplate: '{0} Spiral Station {1}'
+      nameGenerator:
+        !type:NanotrasenNameGenerator
+        prefixCreator: '14'
+      overflowJobs:
+        - Passenger
+      availableJobs:
+        Passenger: [ -1, -1 ]
+        Bartender: [ 3, 3 ]
+        Botanist: [ 4, 6 ]
+        Boxer: [ 1, 2 ]
+        Chef: [ 5, 7 ]
+        Clown: [ 3, 3 ]
+        Cyborg: [ 2, 2 ]
+        #ForensicMantis: [ 1, 1 ]
+        Janitor: [ 5, 5 ]
+        Mime: [ 2, 2 ]
+        Chaplain: [ 1, 1 ]
+        Librarian: [ 1, 1 ]
+        Musician: [ 1, 3 ]
+        ServiceWorker: [ 5, 5 ]
+        Captain: [ 1, 1 ]
+        HeadOfPersonnel: [ 1, 1 ]
+        ChiefEngineer: [ 1, 1 ]
+        StationEngineer: [ 6, 8 ]
+        AtmosphericTechnician: [ 1, 2 ]
+        TechnicalAssistant: [ 9, 9 ]
+        ChiefMedicalOfficer: [ 1, 1 ]
+        MailCarrier: [ 1, 2 ]
+        MedicalDoctor: [ 3, 6 ]
+        Paramedic: [ 1, 1 ]
+        Chemist: [ 3, 3 ]
+        MedicalIntern: [ 2, 2 ]
+        Mystagogue: [ 1, 1 ]
+        Epistemologist: [ 4, 6 ]
+        #ResearchDirector: [ 1, 1 ]
+        #Scientist: [ 4, 6 ]
+        HeadOfSecurity: [ 1, 1 ]
+        Warden: [ 1, 1 ]
+        SecurityOfficer: [ 9, 11 ]
+        SecurityCadet: [ 4, 4 ]
+        Cataloguer: [ 1, 1 ]
+        Lawyer: [ 1, 2 ]
+        Quartermaster: [ 1, 1 ]
+        CargoTechnician: [ 3, 6 ]
+        SalvageSpecialist: [ 4, 6 ]
+        #Reporter: [ 2, 2 ]
+        #Psychologist: [ 1, 1 ]


### PR DESCRIPTION

Welcome to Spiral Station.
Inspired by the world of Expanse, Spiral Station is based on Ceres, one of the first human colonies in the Outer Planets.

Like Ceres, Spiral Station has grown significantly in a confined space over the years. Older levels (Dock and Medina) have become less maintained while resources are diverted to the Central Command, District, and Plaza levels before trickling down through Midtown, rarely reaching Medina and Dock.

Moving through the station, you should feel this socio/economic divide and resource disparity. Pirates, smugglers, and gangs control the lower levels making it risky for Sec-Officers to travel there without a number of reinforcements. Likewise, several checkpoints are set up in strategic locations to restrict the travel of criminals, as well as to prevent violence and the flow of illicit goods into the upper levels.

While life in the slums of Medina is dismal, dark, and cramped, life in the Plaza level is spacious, clean, and secure. Illegal fighting dens and black markets are replaced with upscale restaurants and bars, a luscious park with an amphitheater, and the luxurious Plaza Hotel where department leaders are set up with all the best accommodations.

Mining on the asteroid is the primary reason the station was set up. Several tunnels lead into the heart of it, opening up many opportunities for exploration, looting, and acquiring essential resources.

The Central Line cuts through the middle of the asteroid creating a direct, expedited route from Docking to Command. While it is open access to the citizens of the upper levels it is closed off to only the essential departments on the Dock Level side due to a history of illegal activities and other security concerns. (Of course, where there’s a will…there’s always a way…)