### PR TITLE
Changes to the Syndicate Diplomat role

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Catalog/Fills/Backpacks/nyano_jobs.yml
+++ b/Resources/Prototypes/Nyanotrasen/Catalog/Fills/Backpacks/nyano_jobs.yml
@@ -36,3 +36,45 @@
       - id: CigPackBlack
       - id: BoxForensicPad
       - id: HandLabeler
+
+- type: entity
+  noSpawn: true
+  parent: ClothingBackpack
+  id: ClothingBackpackSyndicateDiplomatFilled
+  components:
+    - type: StorageFill
+      contents:
+      - id: BoxSurvivalSyndicate
+      - id: Lighter
+      - id: CigPackSyndicate
+      - id: RubberStampSyndicate
+      - id: CyberPen
+      - id: BalloonSyn
+
+- type: entity
+  noSpawn: true
+  parent: ClothingBackpackDuffelSyndicate
+  id: ClothingBackpackDuffelSyndicateDiplomatFilled
+  components:
+    - type: StorageFill
+      contents:
+      - id: BoxSurvivalSyndicate
+      - id: Lighter
+      - id: CigPackSyndicate
+      - id: RubberStampSyndicate
+      - id: CyberPen
+      - id: BalloonSyn
+
+- type: entity
+  noSpawn: true
+  parent: ClothingBackpackSatchel
+  id: ClothingBackpackSatchelSyndicateDiplomatFilled
+  components:
+    - type: StorageFill
+      contents:
+      - id: BoxSurvivalSyndicate
+      - id: Lighter
+      - id: CigPackSyndicate
+      - id: RubberStampSyndicate
+      - id: CyberPen
+      - id: BalloonSyn

--- a/Resources/Prototypes/Nyanotrasen/Markers/Spawners/jobs.yml
+++ b/Resources/Prototypes/Nyanotrasen/Markers/Spawners/jobs.yml
@@ -117,3 +117,15 @@
     layers:
       - state: green
       - state: miner
+
+- type: entity
+  id: SpawnPointSyndicateDiplomat
+  parent: SpawnPointJobBase
+  name: SyndicateDiplomat
+  components:
+  - type: SpawnPoint
+    job_id: SyndicateDiplomat
+  - type: Sprite
+    layers:
+      - state: green
+      - state: librarian #That works, I guess?

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Fun/syndicatediplomat.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Fun/syndicatediplomat.yml
@@ -8,25 +8,22 @@
   supervisors: "the Syndicate"
   access:
   - Service
-#  - Brig (Yeah no)
+  - Maintenance
   setPreference: false
 
 - type: startingGear
   id: SyndicateDiplomat
   equipment:
     jumpsuit: ClothingUniformJumpsuitOperative
-    back: ClothingBackpackDuffelSyndicate # It's empty
+    back: ClothingBackpackDuffelSyndicateDiplomatFilled # It's no longer empty
     eyes: ClothingEyesGlassesBeer # They just look cool
     ears: ClothingHeadsetAltSyndicate
-    head: ClothingHeadPyjamaSyndicateRed
+    head: ClothingHeadHatHairflower
     gloves: ClothingHandsGlovesCombat
-    outerClothing: ClothingOuterCoatJensen # He never asked for this
+    outerClothing: ClothingOuterVest
     neck: ClothingNeckLawyerbadge
     shoes: ClothingShoesLeather
     id: SyndicateDiplomatPDA
-    pocket1: RubberStampSyndicate
-    pocket2: CyberPen
-    belt: ClothingBeltUtility
-  innerclothingskirt: ClothingUniformJumpsuitOperative
-  satchel: ClothingBackpackDuffelSyndicate
-  duffelbag: ClothingBackpackDuffelSyndicate
+  innerclothingskirt: ClothingUniformJumpskirtOperative
+  satchel: ClothingBackpackSatchelSyndicateDiplomatFilled
+  duffelbag: ClothingBackpackDuffelSyndicateDiplomatFilled


### PR DESCRIPTION
Basically I tried to adjust the role to new standards.
Instead of having all items on the hotbar and pockets I added the backpack, satchel and duffel bag for the job and filled it with some goodies and a syndie balloon. Everyone loves balloons!

Also tried looking into a way to not make the late-join message display when joining as this role cause people usually go full monkey mode when they see this text appear with the name "Syndicate", but so far no clue on how to hide it.

:cl:
- change: Standard gear of the Syndicate Diplomat
- added: maintenance access to the role (Syndicate likes to lurk in the shadows)
- added: Filled Syndicate Diplomat Duffle bags/Satchels and Backpacks
- added: Spawn Object for the Syndicate Diplomat (It will need to be edited afterwards though as the "librarian" is used instead of a own ped in the icon)