### PR TITLE
Add supersynth pAI variant

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/pai.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/pai.yml
@@ -1,16 +1,13 @@
 # Placeholder PAIs, aka semi-automatic ghost roles
 
 - type: entity
+  abstract: true
   parent: BaseItem
-  id: PersonalAI
+  id: BasePersonalAI
   name: personal ai device
   description: Your electronic pal who's fun to be with!
   components:
   - type: Instrument
-    allowPercussion: false
-    handheld: false
-    bank: 1
-    program: 2
   - type: UserInterface
     interfaces:
     - key: enum.InstrumentUiKey.Key
@@ -56,3 +53,25 @@
           enum.PAIStatus.Searching: pai-searching-overlay
           enum.PAIStatus.On: pai-on-overlay
 
+- type: entity
+  parent: BasePersonalAI
+  id: PersonalAI
+  name: personal ai device
+  description: Your electronic pal who's fun to be with!
+  components:
+  - type: Instrument
+    allowPercussion: false
+    handheld: false
+    bank: 1
+    program: 2
+
+- type: entity
+  parent: BasePersonalAI
+  id: SupersynthPersonalAI
+  name: personal ai device (supersynth)
+  description: Your electronic pal who's fun to be with! New and improved audio playback system.
+  components:
+  - type: Instrument
+    allowPercussion: true
+    handheld: false
+    respectMidiLimits: false

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Fun/pai.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Fun/pai.yml
@@ -1,16 +1,17 @@
-# Placeholder PAIs, aka semi-automatic ghost roles
+# Custom pAI types with different instruments
+
+# Making a nyanotrasen-specific copy of the entire pAI entity is necessary
+# because the base class's instrument component's bank and program must be unassigned
+# to allow for supersynth qualities. Without this, we would have to modify the original file.
 
 - type: entity
+  abstract: true
   parent: BaseItem
-  id: PersonalAI
+  id: BaseNyanotrasenPersonalAI
   name: personal ai device
   description: Your electronic pal who's fun to be with!
   components:
   - type: Instrument
-    allowPercussion: false
-    handheld: false
-    bank: 1
-    program: 2
   - type: UserInterface
     interfaces:
     - key: enum.InstrumentUiKey.Key
@@ -55,4 +56,16 @@
           enum.PAIStatus.Off: pai-off-overlay
           enum.PAIStatus.Searching: pai-searching-overlay
           enum.PAIStatus.On: pai-on-overlay
+
+
+- type: entity
+  parent: BaseNyanotrasenPersonalAI
+  id: SupersynthNyanotrasenPersonalAI
+  name: personal ai device (supersynth)
+  description: Your electronic pal who's fun to be with! New and improved audio playback system indluded.
+  components:
+  - type: Instrument
+    allowPercussion: true
+    allowProgramChange: true
+    respectMidiLimits: false
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

The pAI's default soundbank sounds godawful with so many midis, mainly due to how loud its lower notes can wind up being. To help alleviate this issue I've created a new variant of the pAI with supersynth qualities, allowing admins to give them out as they see fit.

The pAI entity has also been abstracted so it's easier to add more variants with different soundbanks in the future.

**Changelog**

:cl: 0xEFF
- add: Supersynth pAI variant

