### PR TITLE
Carrying + voice fix

### DIFF
--- a/Content.Server/Nyanotrasen/Carrying/CarryingSystem.cs
+++ b/Content.Server/Nyanotrasen/Carrying/CarryingSystem.cs
@@ -137,6 +137,7 @@ namespace Content.Server.Carrying
             EnsureComp<CarryingComponent>(carrier);
             ApplyCarrySlowdown(carrier, carried);
             var carriedComp = EnsureComp<BeingCarriedComponent>(carried);
+            EnsureComp<KnockedDownComponent>(carried);
             carriedComp.Carrier = carrier;
             _actionBlockerSystem.UpdateCanMove(carried);
         }
@@ -146,6 +147,7 @@ namespace Content.Server.Carrying
             RemComp<CarryingComponent>(carrier); // get rid of this first so we don't recusrively fire that event
             RemComp<CarryingSlowdownComponent>(carrier);
             RemComp<BeingCarriedComponent>(carried);
+            RemComp<KnockedDownComponent>(carried);
             _actionBlockerSystem.UpdateCanMove(carried);
             _virtualItemSystem.DeleteInHandsMatching(carrier, carried);
             Transform(carried).AttachToGridOrMap();

--- a/Resources/Prototypes/Entities/Mobs/Species/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/human.yml
@@ -327,7 +327,7 @@
 #  - type: Recyclable Turns out turning off recycler safeties without considering the instagib is a bad idea
 #    safe: false
   - type: Speech
-    speechSounds: Alto
+    speechSounds: Tenor
   - type: Vocal
   - type: Emoting
   - type: Grammar

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/felinid.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/felinid.yml
@@ -142,6 +142,8 @@
   - type: Thieving
     stealthy: true
     stealTime: 1.5
+  - type: Speech
+    speechSounds: Alto
 
 - type: entity
   save: false

--- a/Resources/Prototypes/Nyanotrasen/Entities/Structures/Research/oracle.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Structures/Research/oracle.yml
@@ -6,4 +6,4 @@
   components:
   - type: Oracle
   - type: Speech
-    speechSounds: Alto
+    speechSounds: Tenor

--- a/Resources/Prototypes/Nyanotrasen/Entities/Structures/Research/sophicscribe.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Structures/Research/sophicscribe.yml
@@ -6,4 +6,4 @@
   components:
   - type: SophicScribe
   - type: Speech
-    speechSounds: Alto
+    speechSounds: Tenor


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
Moved all current Alto speech sounds to Tenor. Felinids still use alto.
Ensures carried people stay knocked down.

