### PR TITLE
Saltern max pop upgrade

### DIFF
--- a/Resources/Prototypes/Maps/saltern.yml
+++ b/Resources/Prototypes/Maps/saltern.yml
@@ -3,7 +3,7 @@
   mapName: 'Saltern'
   mapPath: /Maps/saltern.yml
   minPlayers: 0
-  maxPlayers: 35
+  maxPlayers: 50
   fallback: true
   stations:
     Saltern:


### PR DESCRIPTION
Increases max from 35 to 50, Saltern fits well as a low-med pop station