### PR TITLE
Box station Update

### DIFF
--- a/Resources/Prototypes/Maps/box.yml
+++ b/Resources/Prototypes/Maps/box.yml
@@ -42,3 +42,4 @@
         MailCarrier: [ 2, 2 ]
         Paramedic: [ 1, 2 ]
         Cyborg: [ 2, 3 ]
+        ForensicMantis: [ 1, 1 ]


### PR DESCRIPTION
Box station tweaks to help get the map a bit more up to speed

-Removed death grilles in maints
-Added space law books to sec
-Renamed more airlocks
-Atmos tweaks a la Emisse
-Rigged Cargo up to use all that empty space with some conveyers
-Rotated some APCs so they're usable
-New Cloning setup has been added
-A few more disablers in sec
-Singularity now has a Generator in the center roundstart, and the PA has some wiring underneath the power box so that doesn't have to be removed and done in the beginning of a round
-Donuts
-Fixed Mantis spawn

