### PR TITLE
QuantumSpinInverter Cost reduction

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Recipes/Lathes/bluespace.yml
+++ b/Resources/Prototypes/Nyanotrasen/Recipes/Lathes/bluespace.yml
@@ -7,8 +7,8 @@
   completetime: 5
   materials:
     Bluespace: 25
-    Glass: 500
-    Plastic: 500
+    Glass: 250
+    Plastic: 250
 
 - type: latheRecipe
   id: BluespaceBeaker


### PR DESCRIPTION

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

The quantum spin inverter in it's current state costs far too many resources for the effect it has. Admittedly, when you make it the one use teleport is VERY powerful. However, considering that epistemics tends to not be provided too many resources by cargo and usually it's members don't care about moving since they are usually just sitting in epistemics, it disproportionally benefits syndies and those with cargo access who can actually get the resources needed to make a bunch of the things. A cost reduction would allow more people to use it than just syndies and also make using it less of a commitment. I myself find that i use them as a emergency TP only. Being cheaper would allow people to use it for more frivolous uses such as on box teleporting straight from cargo to epistemics. Furthermore, it would provide epistemics the capability to distribute the things to others outside of the department due to decreased cost.

<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

🆑 
 - Tweak: Buffed the QuantumSpinInverter by halving it's non bluespace material costs.

