### PR TITLE
move drones for torun

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -186,7 +186,6 @@
       - Syringe
       - PillCanister
       - ChemistryEmptyBottle01
-      - Drone
       - Flash
       - MicroManipulatorStockPart
       - ScanningModuleStockPart

--- a/Resources/Prototypes/Nyanotrasen/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Structures/Machines/lathe.yml
@@ -163,6 +163,7 @@
       - AirAlarmElectronics
       - FireAlarmElectronics
       - HolofanProjector
+      - Drone
       - RCDAmmo # Below is shared with other lathes
       - FlashlightLantern
       - Bucket


### PR DESCRIPTION
:cl: Rane
- fix: Drones are now in the engineering techfab, where you would expect them.
