### PR TITLE
Update1003

### DIFF
--- a/Content.Server/Nyanotrasen/Abilities/Psionics/Abilities/PyrokinesisPowerSystem.cs
+++ b/Content.Server/Nyanotrasen/Abilities/Psionics/Abilities/PyrokinesisPowerSystem.cs
@@ -1,0 +1,60 @@
+using Content.Shared.Actions;
+using Content.Shared.Actions.ActionTypes;
+using Content.Shared.Abilities.Psionics;
+using Content.Server.Atmos.Components;
+using Content.Server.Atmos.EntitySystems;
+using Content.Server.Popups;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Player;
+
+namespace Content.Server.Abilities.Psionics
+{
+    public sealed class PyrokinesisPowerSystem : EntitySystem
+    {
+        [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+        [Dependency] private readonly SharedActionsSystem _actions = default!;
+        [Dependency] private readonly FlammableSystem _flammableSystem = default!;
+        [Dependency] private readonly SharedPsionicAbilitiesSystem _psionics = default!;
+        [Dependency] private readonly PopupSystem _popupSystem = default!;
+        public override void Initialize()
+        {
+            base.Initialize();
+            SubscribeLocalEvent<PyrokinesisPowerComponent, ComponentInit>(OnInit);
+            SubscribeLocalEvent<PyrokinesisPowerComponent, ComponentShutdown>(OnShutdown);
+            SubscribeLocalEvent<PyrokinesisPowerActionEvent>(OnPowerUsed);
+        }
+
+        private void OnInit(EntityUid uid, PyrokinesisPowerComponent component, ComponentInit args)
+        {
+            if (!_prototypeManager.TryIndex<EntityTargetActionPrototype>("Pyrokinesis", out var pyrokinesis))
+                return;
+
+            component.PyrokinesisPowerAction = new EntityTargetAction(pyrokinesis);
+            _actions.AddAction(uid, component.PyrokinesisPowerAction, null);
+
+            if (TryComp<PsionicComponent>(uid, out var psionic) && psionic.PsionicAbility == null)
+                psionic.PsionicAbility = component.PyrokinesisPowerAction;
+        }
+
+        private void OnShutdown(EntityUid uid, PyrokinesisPowerComponent component, ComponentShutdown args)
+        {
+            if (_prototypeManager.TryIndex<EntityTargetActionPrototype>("Pyrokinesis", out var pyrokinesis))
+                _actions.RemoveAction(uid, new EntityTargetAction(pyrokinesis), null);
+        }
+
+        private void OnPowerUsed(PyrokinesisPowerActionEvent args)
+        {
+            if (!TryComp<FlammableComponent>(args.Target, out var flammableComponent))
+                return;
+
+            flammableComponent.FireStacks += 5;
+            _flammableSystem.Ignite(args.Target, flammableComponent);
+            _popupSystem.PopupEntity(Loc.GetString("pyrokinesis-power-used", ("target", args.Target)), args.Target, Filter.Pvs(args.Target), Shared.Popups.PopupType.LargeCaution);
+
+            _psionics.LogPowerUsed(args.Performer, "pyrokinesis");
+            args.Handled = true;
+        }
+    }
+
+    public sealed class PyrokinesisPowerActionEvent : EntityTargetActionEvent {}
+}

--- a/Content.Server/Nyanotrasen/Abilities/Psionics/PsionicAbilitiesSystem.cs
+++ b/Content.Server/Nyanotrasen/Abilities/Psionics/PsionicAbilitiesSystem.cs
@@ -32,13 +32,29 @@ namespace Content.Server.Abilities.Psionics
             "PsionicRegenerationPower",
         };
 
+        public override void Initialize()
+        {
+            base.Initialize();
+            SubscribeLocalEvent<PsionicAwaitingPlayerComponent, PlayerAttachedEvent>(OnPlayerAttached);
+        }
+
+        private void OnPlayerAttached(EntityUid uid, PsionicAwaitingPlayerComponent component, PlayerAttachedEvent args)
+        {
+            Logger.Error("Received player attached...");
+            _euiManager.OpenEui(new AcceptPsionicsEui(uid, this), args.Player);
+            RemCompDeferred<PsionicAwaitingPlayerComponent>(uid);
+        }
+
         public void AddPsionics(EntityUid uid)
         {
             if (HasComp<PsionicComponent>(uid))
                 return;
 
             if (!TryComp<MindComponent>(uid, out var mind) || mind.Mind?.UserId == null)
+            {
+                AddComp<PsionicAwaitingPlayerComponent>(uid);
                 return;
+            }
 
             if (!_playerManager.TryGetSessionById(mind.Mind.UserId.Value, out var client))
                 return;

--- a/Content.Server/Nyanotrasen/Abilities/Psionics/PsionicAbilitiesSystem.cs
+++ b/Content.Server/Nyanotrasen/Abilities/Psionics/PsionicAbilitiesSystem.cs
@@ -40,12 +40,14 @@ namespace Content.Server.Abilities.Psionics
 
         private void OnPlayerAttached(EntityUid uid, PsionicAwaitingPlayerComponent component, PlayerAttachedEvent args)
         {
-            Logger.Error("Received player attached...");
-            _euiManager.OpenEui(new AcceptPsionicsEui(uid, this), args.Player);
+            if (TryComp<PsionicBonusChanceComponent>(uid, out var bonus) && bonus.Warn == true)
+                _euiManager.OpenEui(new AcceptPsionicsEui(uid, this), args.Player);
+            else
+                AddRandomPsionicPower(uid);
             RemCompDeferred<PsionicAwaitingPlayerComponent>(uid);
         }
 
-        public void AddPsionics(EntityUid uid)
+        public void AddPsionics(EntityUid uid, bool warn = true)
         {
             if (HasComp<PsionicComponent>(uid))
                 return;
@@ -59,8 +61,10 @@ namespace Content.Server.Abilities.Psionics
             if (!_playerManager.TryGetSessionById(mind.Mind.UserId.Value, out var client))
                 return;
 
-            if (!HasComp<GuaranteedPsionicComponent>(uid) && TryComp<ActorComponent>(uid, out var actor))
+            if (warn && TryComp<ActorComponent>(uid, out var actor))
                 _euiManager.OpenEui(new AcceptPsionicsEui(uid, this), client);
+            else
+                AddRandomPsionicPower(uid);
         }
 
         public void AddPsionics(EntityUid uid, string powerComp)

--- a/Content.Server/Nyanotrasen/Lamiae/LamiaSystem.cs
+++ b/Content.Server/Nyanotrasen/Lamiae/LamiaSystem.cs
@@ -1,14 +1,10 @@
 using Robust.Shared.Physics;
 using Content.Shared.Lamiae;
-using Content.Shared.Gravity;
 using Content.Shared.Damage;
-using Content.Shared.Humanoid;
-using Content.Shared.Humanoid.Prototypes;
 using Content.Server.Humanoid;
 using Content.Server.Access.Systems;
 using Robust.Server.GameObjects;
 using Robust.Shared.Prototypes;
-using Robust.Shared.GameObjects.Components.Localization;
 using Robust.Shared.Containers;
 using Robust.Shared.Map;
 using Robust.Shared.Physics.Systems;

--- a/Content.Server/Nyanotrasen/Psionics/Glimmer/Structures/GlimmerSourceComponent.cs
+++ b/Content.Server/Nyanotrasen/Psionics/Glimmer/Structures/GlimmerSourceComponent.cs
@@ -12,6 +12,6 @@ namespace Content.Server.Psionics.Glimmer
         /// Since glimmer is an int, we'll do it like this.
         /// </summary>
         [DataField("secondsPerGlimmer")]
-        public float SecondsPerGlimmer = 30f;
+        public float SecondsPerGlimmer = 15f;
     }
 }

--- a/Content.Server/Nyanotrasen/Psionics/PotentialPsionicComponent.cs
+++ b/Content.Server/Nyanotrasen/Psionics/PotentialPsionicComponent.cs
@@ -4,7 +4,7 @@ namespace Content.Server.Psionics
     public sealed class PotentialPsionicComponent : Component
     {
         [DataField("chance")]
-        public float Chance = 1f;
+        public float Chance = 0.04f;
 
         /// <summary>
         /// YORO (you only reroll once)

--- a/Content.Server/Nyanotrasen/Psionics/PotentialPsionicComponent.cs
+++ b/Content.Server/Nyanotrasen/Psionics/PotentialPsionicComponent.cs
@@ -4,7 +4,7 @@ namespace Content.Server.Psionics
     public sealed class PotentialPsionicComponent : Component
     {
         [DataField("chance")]
-        public float Chance = 0.04f;
+        public float Chance = 1f;
 
         /// <summary>
         /// YORO (you only reroll once)

--- a/Content.Server/Nyanotrasen/Psionics/PsionicAwaitingPlayerComponent.cs
+++ b/Content.Server/Nyanotrasen/Psionics/PsionicAwaitingPlayerComponent.cs
@@ -1,0 +1,9 @@
+namespace Content.Server.Psionics
+{
+    /// <summary>
+    /// Will open the 'accept psionics' UI when a player attaches.
+    /// </summary>
+    [RegisterComponent]
+    public sealed class PsionicAwaitingPlayerComponent : Component
+    {}
+}

--- a/Content.Server/Nyanotrasen/Psionics/PsionicBonusChanceComponent.cs
+++ b/Content.Server/Nyanotrasen/Psionics/PsionicBonusChanceComponent.cs
@@ -7,5 +7,12 @@ namespace Content.Server.Psionics
         public float Multiplier = 1f;
         [DataField("flatBonus")]
         public float FlatBonus = 0;
+
+        /// <summary>
+        /// Whether we should warn the user they are about to receive psionics.
+        /// It's here because AddComponentSpecial can't overwrite a component, and this is very role dependent.
+        /// </summary>
+        [DataField("warn")]
+        public bool Warn = true;
     }
 }

--- a/Content.Server/Nyanotrasen/Psionics/PsionicsSystem.cs
+++ b/Content.Server/Nyanotrasen/Psionics/PsionicsSystem.cs
@@ -50,6 +50,9 @@ namespace Content.Server.Psionics
 
         private void OnStartup(EntityUid uid, PotentialPsionicComponent component, MapInitEvent args)
         {
+            if (HasComp<PsionicComponent>(uid))
+                return;
+
             _rollers.Enqueue((component, uid));
         }
 

--- a/Content.Server/Nyanotrasen/Psionics/PsionicsSystem.cs
+++ b/Content.Server/Nyanotrasen/Psionics/PsionicsSystem.cs
@@ -24,7 +24,7 @@ namespace Content.Server.Psionics
         public override void Initialize()
         {
             base.Initialize();
-            SubscribeLocalEvent<PotentialPsionicComponent, PlayerSpawnCompleteEvent>(OnStartup);
+            SubscribeLocalEvent<PotentialPsionicComponent, MapInitEvent>(OnStartup);
             SubscribeLocalEvent<GuaranteedPsionicComponent, PlayerSpawnCompleteEvent>(OnGuaranteedStartup);
             SubscribeLocalEvent<AntiPsionicWeaponComponent, MeleeHitEvent>(OnMeleeHit);
             SubscribeLocalEvent<AntiPsionicWeaponComponent, StaminaMeleeHitEvent>(OnStamHit);
@@ -34,7 +34,7 @@ namespace Content.Server.Psionics
             SubscribeLocalEvent<PsionicComponent, MobStateChangedEvent>(OnMobStateChanged);
         }
 
-        private void OnStartup(EntityUid uid, PotentialPsionicComponent component, PlayerSpawnCompleteEvent args)
+        private void OnStartup(EntityUid uid, PotentialPsionicComponent component, MapInitEvent args)
         {
             RollPsionics(uid, component, false);
         }

--- a/Content.Shared/Nyanotrasen/Abilities/Psionics/Abilities/Pyrokinesis/PyrokinesisPowerComponent.cs
+++ b/Content.Shared/Nyanotrasen/Abilities/Psionics/Abilities/Pyrokinesis/PyrokinesisPowerComponent.cs
@@ -1,0 +1,10 @@
+using Content.Shared.Actions.ActionTypes;
+
+namespace Content.Shared.Abilities.Psionics
+{
+    [RegisterComponent]
+    public sealed class PyrokinesisPowerComponent : Component
+    {
+        public EntityTargetAction? PyrokinesisPowerAction = null;
+    }
+}

--- a/Content.Shared/Nyanotrasen/Abilities/Psionics/GuaranteedPsionicComponent.cs
+++ b/Content.Shared/Nyanotrasen/Abilities/Psionics/GuaranteedPsionicComponent.cs
@@ -1,9 +1,0 @@
-namespace Content.Shared.Abilities.Psionics
-{
-    [RegisterComponent]
-    public sealed class GuaranteedPsionicComponent : Component
-    {
-        [DataField("power")]
-        public string? PowerComponent;
-    }
-}

--- a/Resources/Locale/en-US/abilities/psionic.ftl
+++ b/Resources/Locale/en-US/abilities/psionic.ftl
@@ -59,3 +59,7 @@ psionic-burn-resist = Strange arcs dance across {THE($item)}!
 
 action-name-noospheric-zap = Noospheric Zap
 action-description-noospheric-zap = Shocks the conciousness of the target and leaves them stunned and stuttering.
+
+action-name-pyrokinesis = Pyrokinesis
+action-description-pyrokinesis = Light a flammable target on fire.
+pyrokinesis-power-used = A wisp of flame engulfs {THE($target)}, igniting {OBJECT($target)}!

--- a/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
@@ -259,6 +259,7 @@
       - id: SurvivalKnife
       - id: WeaponPistolViper
       - id: PinpointerNuclear
+      - id: PillCryptobiolin
 
 
 - type: entity
@@ -280,3 +281,4 @@
       - id: WeaponPistolViper
       - id: PinpointerNuclear
       - id: HandheldHealthAnalyzer
+      - id: PillCryptobiolin

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -32,6 +32,8 @@
       - id: ClothingUniformJumpsuitSecGrey
         prob: 0.3
       - id: ClothingHeadHelmetHelmet
+      - id: ClothingHeadHelmetInsulated
+        prob: 0.4
       - id: ClothingOuterArmorBulletproof
       - id: ClothingBeltSecurityFilled
       - id: Flash

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/sec.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/sec.yml
@@ -11,9 +11,10 @@
     RiotShield: 2
     RiotLaserShield: 2
     RiotBulletShield: 2
-  # security officers need to follow a diet regimen!
-    HyperlinkBookSpaceLaw: 2
+    ClothingHeadHelmetInsulated: 2
     ClothingHeadCage: 2
+    HyperlinkBookSpaceLaw: 2
+  # security officers need to follow a diet regimen!
   contrabandInventory:
     FoodDonutHomer: 12
     FoodBoxDonut: 2

--- a/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
@@ -214,6 +214,9 @@
       layer:
       - MobLayer
   - type: PotentialPsionic
+  - type: PsionicBonusChance
+    flatBonus: 1
+    warn: false
 
 - type: entity
   name: Ravager

--- a/Resources/Prototypes/Entities/Mobs/Player/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/human.yml
@@ -71,6 +71,7 @@
     randomizeName: false
   - type: PsionicBonusChance
     multiplier: 7
+    warn: false
 
 - type: entity
   name: ERT leader
@@ -214,3 +215,4 @@
     - type: RandomHumanoidAppearance
     - type: PsionicBonusChance
       multiplier: 7
+      warn: false

--- a/Resources/Prototypes/Maps/box.yml
+++ b/Resources/Prototypes/Maps/box.yml
@@ -3,6 +3,7 @@
   mapName: 'Box Station'
   mapPath: /Maps/box.yml
   minPlayers: 30
+  votable: false
   stations:
     Boxstation:
       mapNameTemplate: '{0} Box Station {1}'

--- a/Resources/Prototypes/Nyanotrasen/Actions/types.yml
+++ b/Resources/Prototypes/Nyanotrasen/Actions/types.yml
@@ -115,3 +115,12 @@
   useDelay: 120
   range: 8
   serverEvent: !type:NoosphericZapPowerActionEvent
+
+- type: entityTargetAction
+  id: Pyrokinesis
+  name: action-name-pyrokinesis
+  description: action-description-pyrokinesis
+  icon: Interface/VerbIcons/sentient.svg.192dpi.png
+  useDelay: 50
+  range: 8
+  serverEvent: !type:PyrokinesisPowerActionEvent

--- a/Resources/Prototypes/Nyanotrasen/Catalog/Fills/Vending/Inventories/forensicsdrobe.yml
+++ b/Resources/Prototypes/Nyanotrasen/Catalog/Fills/Vending/Inventories/forensicsdrobe.yml
@@ -6,6 +6,6 @@
     ClothingHeadHatFez: 2
     ClothingEyesGlassesSunglasses: 2
     ClothingHeadsetScience: 2
-    ClothingHeadTinfoil: 2
     ClothingHeadCage: 2
+    ClothingHeadHelmetInsulated: 1
     AntiPsychicKnife: 1

--- a/Resources/Prototypes/Nyanotrasen/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Clothing/Head/hats.yml
@@ -103,3 +103,23 @@
   - type: Clothing
     sprite: Nyanotrasen/Clothing/Head/Hats/cage.rsi
   - type: HeadCage
+
+- type: entity
+  parent: ClothingHeadTinfoil
+  id: ClothingHeadHelmetInsulated
+  name: insulative skullcap
+  description: Psionically insulates whoevers head is inside it. It has some protection from physical damage.
+  components:
+  - type: Sprite
+    sprite: Nyanotrasen/Clothing/Head/Helmets/insulative_skullcap.rsi
+  - type: Clothing
+    sprite: Nyanotrasen/Clothing/Head/Helmets/insulative_skullcap.rsi
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.85
+        Slash: 0.85
+        Piercing: 0.95
+        Radiation: 0.95
+  - type: TinfoilHat
+    destroyOnFry: false #At least while they aren't printable.

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/NPCs/familiars.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/NPCs/familiars.yml
@@ -76,6 +76,8 @@
   - type: Hands
   - type: RandomMetadata
     nameSegments: [names_golem]
+  - type: Psionic
+  - type: PyrokinesisPower
 
 - type: entity
   parent: WelderExperimental

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Medical/pills.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Medical/pills.yml
@@ -11,3 +11,17 @@
         reagents:
         - ReagentId: MindbreakerToxin
           Quantity: 20
+
+- type: entity
+  name: cryptobiolin
+  parent: Pill
+  id: PillCryptobiolin
+  description: A long-lasting drug which causes mild confusion, but renders you psionically insulated.
+  components:
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20
+        reagents:
+        - ReagentId: Cryptobiolin
+          Quantity: 20

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensic_mantis.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensic_mantis.yml
@@ -23,7 +23,9 @@
   special:
   - !type:AddComponentSpecial
     components:
-    - type: GuaranteedPsionic
+    - type: PsionicBonusChance
+      flatBonus: 1
+      warn: false
 
 - type: startingGear
   id: ForensicMantisGear

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/mystagogue.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/mystagogue.yml
@@ -25,10 +25,8 @@
   - !type:AddComponentSpecial
     components:
     - type: BibleUser #Lets them heal with bibles
-  - !type:AddComponentSpecial
-    components:
-    - type: GuaranteedPsionic
-      power: DispelPower
+    - type: Psionic
+    - type: DispelPower
 
 - type: startingGear
   id: MystagogueGear

--- a/Resources/Prototypes/Objectives/traitorObjectives.yml
+++ b/Resources/Prototypes/Objectives/traitorObjectives.yml
@@ -46,6 +46,7 @@
 - type: objective
   id: BecomePsionicObjective
   issuer: syndicate
+  difficultyOverride: 2.5
   prob: 0.75
   requirements:
     - !type:TraitorRequirement {}

--- a/Resources/Prototypes/Objectives/traitorObjectives.yml
+++ b/Resources/Prototypes/Objectives/traitorObjectives.yml
@@ -2,7 +2,7 @@
   id: CaptainIDStealObjective
   issuer: syndicate
   difficultyOverride: 2.75
-  prob: 0.2
+  prob: 0.05
   requirements:
     - !type:TraitorRequirement {}
     - !type:IncompatibleConditionsRequirement
@@ -19,7 +19,7 @@
 - type: objective
   id: KillRandomObjective
   issuer: syndicate
-  prob: 0.6
+  prob: 0.75
   requirements:
     - !type:TraitorRequirement {}
     - !type:IncompatibleConditionsRequirement
@@ -32,6 +32,7 @@
 - type: objective
   id: RandomTraitorAliveObjective
   issuer: syndicate
+  prob: 0.5
   requirements:
     - !type:TraitorRequirement {}
     - !type:IncompatibleConditionsRequirement
@@ -43,22 +44,9 @@
   canBeDuplicate: true
 
 - type: objective
-  id: DieObjective
-  issuer: syndicate
-  prob: 0.03
-  requirements:
-    - !type:TraitorRequirement {}
-    - !type:IncompatibleConditionsRequirement
-      conditions:
-        - StealCondition
-        - EscapeShuttleCondition
-  conditions:
-    - !type:DieCondition {}
-
-- type: objective
   id: BecomePsionicObjective
   issuer: syndicate
-  prob: 0.6
+  prob: 0.75
   requirements:
     - !type:TraitorRequirement {}
     - !type:IncompatibleConditionsRequirement
@@ -75,7 +63,7 @@
   id: CMOHyposprayStealObjective
   issuer: syndicate
   difficultyOverride: 2.75
-  prob: 0.2
+  prob: 0.1
   requirements:
     - !type:TraitorRequirement {}
     - !type:IncompatibleConditionsRequirement
@@ -92,7 +80,7 @@
   id: RDHardsuitStealObjective
   issuer: syndicate
   difficultyOverride: 2.75
-  prob: 0.2
+  prob: 0.1
   requirements:
     - !type:TraitorRequirement {}
     - !type:IncompatibleConditionsRequirement
@@ -110,7 +98,7 @@
 - type: objective
   id: NukeDiskStealObjective
   issuer: syndicate
-  prob: 0.2
+  prob: 0.1
   requirements:
     - !type:TraitorRequirement {}
     - !type:IncompatibleConditionsRequirement
@@ -138,7 +126,7 @@
 - type: objective
   id: IDComputerBoardStealObjective
   issuer: syndicate
-  prob: 0.2
+  prob: 0.1
   requirements:
     - !type:TraitorRequirement {}
     - !type:IncompatibleConditionsRequirement
@@ -155,7 +143,7 @@
   id: MagbootsStealObjective
   issuer: syndicate
   difficultyOverride: 2.75
-  prob: 0.2
+  prob: 0.1
   requirements:
     - !type:TraitorRequirement {}
     - !type:IncompatibleConditionsRequirement
@@ -171,7 +159,7 @@
 - type: objective
   id: SupplyConsoleBoardStealObjective
   issuer: syndicate
-  prob: 0.2
+  prob: 0.1
   requirements:
     - !type:TraitorRequirement {}
     - !type:IncompatibleConditionsRequirement
@@ -187,7 +175,7 @@
 - type: objective
   id: CorgiMeatStealObjective
   issuer: syndicate
-  prob: 0.2
+  prob: 0.1
   requirements:
     - !type:TraitorRequirement {}
     - !type:IncompatibleConditionsRequirement
@@ -204,7 +192,7 @@
   id: CaptainGunStealObjective
   issuer: syndicate
   difficultyOverride: 2.75
-  prob: 0.1
+  prob: 0.05
   requirements:
     - !type:TraitorRequirement {}
     - !type:IncompatibleConditionsRequirement
@@ -221,7 +209,7 @@
   id: CaptainJetpackStealObjective
   issuer: syndicate
   difficultyOverride: 2.75
-  prob: 0.1
+  prob: 0.05
   requirements:
     - !type:TraitorRequirement {}
     - !type:IncompatibleConditionsRequirement
@@ -236,7 +224,7 @@
 - type: objective
   id: MantisKnifeStealObjective
   issuer: syndicate
-  prob: 0.2
+  prob: 0.1
   requirements:
     - !type:TraitorRequirement {}
     - !type:IncompatibleConditionsRequirement
@@ -252,7 +240,7 @@
 - type: objective
   id: EscapeShuttleObjective
   issuer: syndicate
-  prob: 0.6
+  prob: 0.8
   requirements:
     - !type:TraitorRequirement {}
     - !type:IncompatibleConditionsRequirement


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

:cl:
- add: An armored, insulative skullcap is available in limited quantities for mantes and security.
- add: Ifrits now have a unique psionic power outside of the pool.
- add: Nuclear operatives now start with a cryptobiolin pill in their bag.
- tweak: Glimmer probers glimmer output doubled.
- tweak: Shuffled around traitor objective probabilities. Not final.
- tweak: Turned off biomass easy mode.
- tweak: Slightly reduced players per traitor.
- fix: Initial psionics rolls should be working for all entities now, including nukies and other intelligent beings.
- remove: Box has been removed from rotation until it gets air alarms and other polish passes.

