### PR TITLE
Update1004

### DIFF
--- a/Content.Server/Nyanotrasen/Abilities/Psionics/PsionicAbilitiesSystem.cs
+++ b/Content.Server/Nyanotrasen/Abilities/Psionics/PsionicAbilitiesSystem.cs
@@ -54,7 +54,7 @@ namespace Content.Server.Abilities.Psionics
 
             if (!TryComp<MindComponent>(uid, out var mind) || mind.Mind?.UserId == null)
             {
-                AddComp<PsionicAwaitingPlayerComponent>(uid);
+                EnsureComp<PsionicAwaitingPlayerComponent>(uid);
                 return;
             }
 

--- a/Resources/Locale/en-US/reagents/meta/toxins.ftl
+++ b/Resources/Locale/en-US/reagents/meta/toxins.ftl
@@ -54,3 +54,9 @@ reagent-desc-allicin = An organosulfur compound found in alliums like garlic, on
 
 reagent-name-pax = pax
 reagent-desc-pax = A psychiatric drug which prevents the patient from directly harming anyone.
+
+reagent-name-prometheum = prometheum
+reagent-desc-prometheum = A complex superdrug our bodies could produce if we could only unlock our potential.
+
+reagent-name-soulbreaker-toxin = soulbreaker toxin
+reagent-desc-soulbreaker-toxin = An anti-psionic about 4 times as powerful as mindbreaker toxin.

--- a/Resources/Prototypes/Catalog/Research/technologies.yml
+++ b/Resources/Prototypes/Catalog/Research/technologies.yml
@@ -183,6 +183,7 @@
   unlockedRecipes:
     - ShellShotgunBeanbag
     - ShellTranquilizer
+    - ShellSoulbreaker
     - CartridgePistolRubber
     - CartridgeMagnumRubber
     - CartridgeCaselessRifleRubber

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -313,7 +313,7 @@
   - type: Lathe
     idleState: icon
     runningState: icon
-    staticRecipes:
+    dynamicRecipes:
       - Flash
       - FlashPayload
       - Handcuffs
@@ -329,6 +329,8 @@
       - ShellShotgun
       - ShellShotgunBeanbag
       - ShellShotgunFlare
+      - ShellTranquilizer
+      - ShellSoulbreaker
       - CartridgeLightRifle
       - CartridgeCaselessRifleRubber
       - CartridgeLightRifleRubber

--- a/Resources/Prototypes/Nyanotrasen/Catalog/Fills/Boxes/ammunition.yml
+++ b/Resources/Prototypes/Nyanotrasen/Catalog/Fills/Boxes/ammunition.yml
@@ -1,0 +1,13 @@
+- type: entity
+  name: box of soulbreaker cartridges
+  parent: BoxAmmoProvider
+  id: BoxShellSoulbreaker
+  description: A box full of anti-psionic soulbreaker cartridges, designed for riot shotguns.
+  components:
+    - type: BallisticAmmoProvider
+      proto: ShellSoulbreaker
+      capacity: 12
+    - type: Sprite
+      layers:
+        - state: boxwide
+        - state: shellslug

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/NPCs/familiars.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/NPCs/familiars.yml
@@ -76,6 +76,7 @@
   - type: Hands
   - type: RandomMetadata
     nameSegments: [names_golem]
+  - type: PotentialPsionic
   - type: Psionic
   - type: PyrokinesisPower
 

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/shotgun.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/shotgun.yml
@@ -1,0 +1,23 @@
+- type: entity
+  id: ShellSoulbreaker
+  name: shell (.50 soulbreaker)
+  parent: BaseShellShotgun
+  components:
+  - type: Sprite
+    layers:
+      - state: practice
+        map: [ "enum.AmmoVisualLayers.Base" ]
+  - type: CartridgeAmmo
+    proto: PelletShotgunSoulbreaker
+    count: 1
+  - type: ChemicalAmmo
+  - type: SolutionContainerManager
+    solutions:
+      ammo:
+        reagents:
+        - ReagentId: SoulbreakerToxin
+          Quantity: 15
+  - type: SolutionTransfer
+    maxTransferAmount: 15
+  - type: SpentAmmoVisuals
+    state: "practice"

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Weapons/Guns/Projectiles/shotgun.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Weapons/Guns/Projectiles/shotgun.yml
@@ -1,0 +1,26 @@
+- type: entity
+  id: PelletShotgunSoulbreaker
+  name: pellet (.50 soulbreaker)
+  noSpawn: true
+  parent: BaseBulletPractice
+  components:
+  - type: Sprite
+    sprite: Objects/Weapons/Guns/Projectiles/projectiles2.rsi
+    state: buckshot
+  - type: Projectile
+    damage:
+      types:
+        Blunt: 1
+  - type: SolutionContainerManager
+    solutions:
+      ammo:
+        maxVol: 15
+  - type: RefillableSolution
+    solution: ammo
+  - type: DrainableSolution
+    solution: ammo
+  - type: SolutionInjectOnCollide
+    transferAmount: 15
+    blockSlots: NONE #tranquillizer darts shouldn't be blocked by a mask
+  - type: InjectableSolution
+    solution: ammo

--- a/Resources/Prototypes/Nyanotrasen/Reagents/psionic.yml
+++ b/Resources/Prototypes/Nyanotrasen/Reagents/psionic.yml
@@ -54,5 +54,5 @@
       - !type:ChemRemovePsionic
         conditions:
         - !type:ReagentThreshold
-          reagent: MindbreakerToxin
+          reagent: SoulbreakerToxin
           min: 5

--- a/Resources/Prototypes/Nyanotrasen/Reagents/psionic.yml
+++ b/Resources/Prototypes/Nyanotrasen/Reagents/psionic.yml
@@ -1,8 +1,8 @@
 - type: reagent
   id: PsionicRegenerationEssence
-  name: prometheum
+  name: reagent-name-prometheum
   group: Biological
-  desc: A thick, dark purplish substance.
+  desc: reagent-desc-prometheum
   flavor: metallic
   color: "#700055"
   physicalDesc: reagent-physical-desc-viscous
@@ -31,3 +31,28 @@
           types:
             Poison: -3
             Bloodloss: -3
+
+- type: reagent
+  id: SoulbreakerToxin
+  name: reagent-name-soulbreaker-toxin
+  group: Toxins
+  desc: reagent-desc-soulbreaker-toxin
+  flavor: bitter
+  color: "#FFFFF0"
+  physicalDesc: reagent-physical-desc-cloudy
+  plantMetabolism:
+  - !type:PlantAdjustToxins
+    amount: 40
+  metabolisms:
+    Poison:
+      effects:
+      - !type:HealthChange
+        probability: 0.4
+        damage:
+          groups:
+            Toxin: 2
+      - !type:ChemRemovePsionic
+        conditions:
+        - !type:ReagentThreshold
+          reagent: MindbreakerToxin
+          min: 5

--- a/Resources/Prototypes/Nyanotrasen/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/Nyanotrasen/Recipes/Lathes/security.yml
@@ -32,3 +32,16 @@
   materials:
     Steel: 400
     Bluespace: 20
+
+- type: latheRecipe
+  id: ShellSoulbreaker
+  icon:
+    sprite: Objects/Weapons/Guns/Ammunition/Casings/shotgun_shell.rsi
+    state: practice
+  result: ShellSoulbreaker
+  completetime: 4
+  materials:
+    Plastic: 15
+    Steel: 10
+    Bluespace: 10
+    Glass: 5

--- a/Resources/Prototypes/Roles/Antags/Suspicion/suspicion_traitor.yml
+++ b/Resources/Prototypes/Roles/Antags/Suspicion/suspicion_traitor.yml
@@ -2,5 +2,5 @@
   id: SuspicionTraitor
   name: roles-antag-suspicion-suspect-name
   antagonist: true
-  setPreference: true
+  setPreference: false
   objective: roles-antag-suspicion-suspect-objective


### PR DESCRIPTION
:cl: Rane
- add: Added soulbreaker toxin, currently only aquirable through soulbreaker shotgun shells. It's basically a much better mindbreaker toxin.
- add: Added soulbreaker shell recipe to non-lethal technology.
- tweak: Security techfab requires technologies to be unlocked to print its recipes again, I don't know what wiz den was thinking with changing that.
- fix: Ifrits can be targeted by psionic abilities.

