### PR TITLE
Update1020

### DIFF
--- a/Content.Server/Nyanotrasen/Psionics/Glimmer/GlimmerReactiveSystem.cs
+++ b/Content.Server/Nyanotrasen/Psionics/Glimmer/GlimmerReactiveSystem.cs
@@ -20,6 +20,7 @@ namespace Content.Server.Psionics.Glimmer
             SubscribeLocalEvent<SharedGlimmerReactiveComponent, ComponentInit>(OnComponentInit);
             SubscribeLocalEvent<SharedGlimmerReactiveComponent, ComponentRemove>(OnComponentRemove);
             SubscribeLocalEvent<SharedGlimmerReactiveComponent, PowerChangedEvent>(OnPowerChanged);
+            SubscribeLocalEvent<SharedGlimmerReactiveComponent, GlimmerTierChangedEvent>(OnTierChanged);
         }
 
         /// <summary>
@@ -89,6 +90,24 @@ namespace Content.Server.Psionics.Glimmer
         {
             if (component.RequiresApcPower)
                 UpdateEntityState(uid, component, LastGlimmerTier, 0);
+        }
+
+        /// <summary>
+        ///     Enable / disable special effects from higher tiers.
+        /// </summary>
+        private void OnTierChanged(EntityUid uid, SharedGlimmerReactiveComponent component, GlimmerTierChangedEvent args)
+        {
+            if (!TryComp<ApcPowerReceiverComponent>(uid, out var receiver))
+                return;
+
+            if (args.CurrentTier >= GlimmerTier.Dangerous)
+            {
+                receiver.PowerDisabled = false;
+                receiver.NeedsPower = false;
+            } else
+            {
+                receiver.NeedsPower = true;
+            }
         }
 
         private void Reset(RoundRestartCleanupEvent args)

--- a/Content.Shared/Nyanotrasen/Psionics/Glimmer/SharedGlimmerSystem.cs
+++ b/Content.Shared/Nyanotrasen/Psionics/Glimmer/SharedGlimmerSystem.cs
@@ -48,8 +48,8 @@ namespace Content.Shared.Psionics.Glimmer
                 <= 49 => GlimmerTier.Minimal,
                 >= 50 and <= 99 => GlimmerTier.Low,
                 >= 100 and <= 299 => GlimmerTier.Moderate,
-                >= 300 and <= 599 => GlimmerTier.High,
-                >= 600 and <= 899 => GlimmerTier.Dangerous,
+                >= 300 and <= 499 => GlimmerTier.High,
+                >= 500 and <= 899 => GlimmerTier.Dangerous,
                 _ => GlimmerTier.Critical,
             };
         }

--- a/Resources/Maps/Salvage/stationstation.yml
+++ b/Resources/Maps/Salvage/stationstation.yml
@@ -438,7 +438,7 @@ entities:
     parent: 179
     type: Transform
 - uid: 58
-  type: BaseResearchAndDevelopmentPointSource
+  type: UnfinishedMachineFrame
   components:
   - pos: 13.5,16.5
     parent: 179

--- a/Resources/Prototypes/Nyanotrasen/Catalog/Research/technologies.yml
+++ b/Resources/Prototypes/Nyanotrasen/Catalog/Research/technologies.yml
@@ -18,6 +18,7 @@
     - SatchelOfHolding
     - DuffelbagOfHolding
     - TrashBagOfHolding
+    - NormalityCrystal
 
 - type: technology
   name: "direct energy technology"

--- a/Resources/Prototypes/Nyanotrasen/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Clothing/Head/hats.yml
@@ -19,9 +19,6 @@
     sprite: Nyanotrasen/Clothing/Head/Hats/mystic.rsi
   - type: Clothing
     sprite: Nyanotrasen/Clothing/Head/Hats/mystic.rsi
-  - type: Tag
-    tags:
-    - HidesHair
 
 - type: entity
   parent: ClothingHeadBase
@@ -33,9 +30,6 @@
     sprite: Nyanotrasen/Clothing/Head/Hats/brownhood.rsi
   - type: Clothing
     sprite: Nyanotrasen/Clothing/Head/Hats/brownhood.rsi
-  - type: Tag
-    tags:
-    - HidesHair
 
 - type: entity
   parent: ClothingHeadBase
@@ -58,9 +52,6 @@
     sprite: Nyanotrasen/Clothing/Head/Hats/techpriest.rsi
   - type: Clothing
     sprite: Nyanotrasen/Clothing/Head/Hats/techpriest.rsi
-  - type: Tag
-    tags:
-    - HidesHair
 
 - type: entity
   parent: ClothingHeadBase

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Research/crystals.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Research/crystals.yml
@@ -1,0 +1,14 @@
+- type: entity
+  parent: BaseItem
+  id: CrystalNormality
+  name: normality crystal
+  description: It looks... normal. Placeholder sprite.
+  components:
+  - type: Sprite
+    netsync: false
+    sprite: Nyanotrasen/Objects/Materials/materials.rsi
+    state: bluespace
+    color: gray
+  - type: Tag
+    tags:
+      - NormalityCrystal

--- a/Resources/Prototypes/Nyanotrasen/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Structures/Machines/lathe.yml
@@ -34,6 +34,7 @@
       - ProximitySensor
       - LeftArmBorg
       - RightArmBorg
+      - NormalityCrystal
       - ChemicalPayload #Below = shared
       - FlashlightLantern
       - Bucket

--- a/Resources/Prototypes/Nyanotrasen/Entities/Structures/Research/glimmer_prober.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Structures/Research/glimmer_prober.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: BaseResearchAndDevelopmentPointSource
+  parent: BaseMachinePowered
   id: GlimmerProber
   name: glimmer prober
   description: Probes the noösphere to generate research points. Might be worth turning off if glimmer is a problem.
@@ -67,6 +67,9 @@
   - type: Psionic
   - type: GlimmerSource
     addToGlimmer: false
+  - type: Construction
+    graph: GlimmerDevices
+    node: glimmerDrain
   - type: Sprite
     sprite: Nyanotrasen/Structures/Machines/glimmer_machines.rsi
     netsync: false

--- a/Resources/Prototypes/Nyanotrasen/Recipes/Construction/Graphs/structures/glimmerdevices.yml
+++ b/Resources/Prototypes/Nyanotrasen/Recipes/Construction/Graphs/structures/glimmerdevices.yml
@@ -56,3 +56,48 @@
 
     - node: glimmerProber
       entity: GlimmerProber
+
+    - node: frame
+      entity: GlimmerDeviceFrame
+      edges:
+        - to: glimmerDrain
+          conditions:
+            - !type:EntityAnchored {}
+          steps:
+            - material: Cable
+              amount: 5
+            - tag: NormalityCrystal
+              icon:
+                sprite: Nyanotrasen/Objects/Materials/materials.rsi
+                state: bluespace
+              name: a normality crystal
+              doAfter: 1
+            - tag: NormalityCrystal
+              icon:
+                sprite: Nyanotrasen/Objects/Materials/materials.rsi
+                state: bluespace
+              name: a normality crystal
+              doAfter: 1
+            - tag: NormalityCrystal
+              icon:
+                sprite: Nyanotrasen/Objects/Materials/materials.rsi
+                state: bluespace
+              name: a normality crystal
+              doAfter: 1
+            - tag: NormalityCrystal
+              icon:
+                sprite: Nyanotrasen/Objects/Materials/materials.rsi
+                state: bluespace
+              name: a normality crystal
+              doAfter: 1
+            - tag: NormalityCrystal
+              icon:
+                sprite: Nyanotrasen/Objects/Materials/materials.rsi
+                state: bluespace
+              name: a normality crystal
+              doAfter: 1
+            - tool: Welding
+              doAfter: 5
+
+    - node: glimmerDrain
+      entity: GlimmerDrain

--- a/Resources/Prototypes/Nyanotrasen/Recipes/Construction/Graphs/structures/glimmerdevices.yml
+++ b/Resources/Prototypes/Nyanotrasen/Recipes/Construction/Graphs/structures/glimmerdevices.yml
@@ -11,6 +11,8 @@
           steps:
             - material: Plasteel
               amount: 5
+            - material: Cable
+              amount: 5
 
     - node: frame
       entity: GlimmerDeviceFrame
@@ -19,8 +21,6 @@
           conditions:
             - !type:EntityAnchored {}
           steps:
-            - material: Cable
-              amount: 5
             - tag: BluespaceCrystal
               icon:
                 sprite: Nyanotrasen/Objects/Materials/materials.rsi
@@ -50,54 +50,48 @@
                 sprite: Nyanotrasen/Objects/Materials/materials.rsi
                 state: bluespace
               name: a bluespace crystal
+              doAfter: 1
+            - tool: Welding
+              doAfter: 5
+        - to: glimmerDrain
+          conditions:
+            - !type:EntityAnchored {}
+          steps:
+            - tag: NormalityCrystal
+              icon:
+                sprite: Nyanotrasen/Objects/Materials/materials.rsi
+                state: bluespace
+              name: a normality crystal
+              doAfter: 1
+            - tag: NormalityCrystal
+              icon:
+                sprite: Nyanotrasen/Objects/Materials/materials.rsi
+                state: bluespace
+              name: a normality crystal
+              doAfter: 1
+            - tag: NormalityCrystal
+              icon:
+                sprite: Nyanotrasen/Objects/Materials/materials.rsi
+                state: bluespace
+              name: a normality crystal
+              doAfter: 1
+            - tag: NormalityCrystal
+              icon:
+                sprite: Nyanotrasen/Objects/Materials/materials.rsi
+                state: bluespace
+              name: a normality crystal
+              doAfter: 1
+            - tag: NormalityCrystal
+              icon:
+                sprite: Nyanotrasen/Objects/Materials/materials.rsi
+                state: bluespace
+              name: a normality crystal
               doAfter: 1
             - tool: Welding
               doAfter: 5
 
     - node: glimmerProber
       entity: GlimmerProber
-
-    - node: frame
-      entity: GlimmerDeviceFrame
-      edges:
-        - to: glimmerDrain
-          conditions:
-            - !type:EntityAnchored {}
-          steps:
-            - material: Cable
-              amount: 5
-            - tag: NormalityCrystal
-              icon:
-                sprite: Nyanotrasen/Objects/Materials/materials.rsi
-                state: bluespace
-              name: a normality crystal
-              doAfter: 1
-            - tag: NormalityCrystal
-              icon:
-                sprite: Nyanotrasen/Objects/Materials/materials.rsi
-                state: bluespace
-              name: a normality crystal
-              doAfter: 1
-            - tag: NormalityCrystal
-              icon:
-                sprite: Nyanotrasen/Objects/Materials/materials.rsi
-                state: bluespace
-              name: a normality crystal
-              doAfter: 1
-            - tag: NormalityCrystal
-              icon:
-                sprite: Nyanotrasen/Objects/Materials/materials.rsi
-                state: bluespace
-              name: a normality crystal
-              doAfter: 1
-            - tag: NormalityCrystal
-              icon:
-                sprite: Nyanotrasen/Objects/Materials/materials.rsi
-                state: bluespace
-              name: a normality crystal
-              doAfter: 1
-            - tool: Welding
-              doAfter: 5
 
     - node: glimmerDrain
       entity: GlimmerDrain

--- a/Resources/Prototypes/Nyanotrasen/Recipes/Construction/machines.yml
+++ b/Resources/Prototypes/Nyanotrasen/Recipes/Construction/machines.yml
@@ -14,3 +14,20 @@
   canBuildInImpassable: false
   conditions:
     - !type:TileNotBlocked
+
+- type: construction
+  id: GlimmerDrain
+  name: glimmer drain
+  description: Decreases glimmer.
+  graph: GlimmerDevices
+  startNode: start
+  targetNode: glimmerDrain
+  category: construction-category-machines
+  icon:
+    sprite: Nyanotrasen/Structures/Machines/glimmer_machines.rsi
+    state: base
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+  conditions:
+    - !type:TileNotBlocked

--- a/Resources/Prototypes/Nyanotrasen/Recipes/Lathes/bluespace.yml
+++ b/Resources/Prototypes/Nyanotrasen/Recipes/Lathes/bluespace.yml
@@ -79,3 +79,15 @@
   completetime: 4
   materials:
     Bluespace: 100
+
+- type: latheRecipe
+  id: NormalityCrystal
+  icon:
+    sprite: Nyanotrasen/Objects/Materials/materials.rsi
+    state: bluespace
+  result: CrystalNormality
+  completetime: 4
+  materials:
+    Bluespace: 100
+    Plasma: 100
+    Gold: 25

--- a/Resources/Prototypes/Roles/Jobs/Civilian/chaplain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/chaplain.yml
@@ -2,6 +2,10 @@
   id: Chaplain
   name: "cleric"
   startingGear: ChaplainGear
+  requirements:
+    - !type:DepartmentTimeRequirement
+      department: Epistemics
+      time: 3600
   playTimeTracker: JobChaplain
   icon: "Chaplain"
   supervisors: "the mystagogue"

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -396,6 +396,9 @@
   id: NoAction
 
 - type: Tag
+  id: NormalityCrystal
+
+- type: Tag
   id: NoSpinOnThrow
 
 - type: Tag


### PR DESCRIPTION
:cl: Rane
- fix: Removed the old point source available from salvage.
- fix: Hoods should not hide face (or hair) anymore. Hiding hair broke upstream.
- tweak: As it makes up a disproportionate amount of problematic unwhitelisted players, cleric is now time gated.
- add: Glimmer drains are constructable, although they require something unlocked with spacetime technology.
- add: Glimmer probers have some more special behavior at dangerous glimmer levels. (>500)

