### PR TITLE
Update1024

### DIFF
--- a/Content.Server/Nyanotrasen/Abilities/Psionics/Abilities/MindSwapPowerSystem.cs
+++ b/Content.Server/Nyanotrasen/Abilities/Psionics/Abilities/MindSwapPowerSystem.cs
@@ -2,6 +2,7 @@ using Content.Shared.Actions;
 using Content.Shared.Actions.ActionTypes;
 using Content.Shared.Abilities.Psionics;
 using Content.Shared.Speech;
+using Content.Shared.Stealth.Components;
 using Content.Shared.Damage;
 using Content.Server.Players;
 using Content.Server.MobState;
@@ -166,6 +167,7 @@ namespace Content.Server.Abilities.Psionics
             if (HasComp<TelegnosticProjectionComponent>(uid))
             {
                 RemComp<PsionicallyInvisibleComponent>(uid);
+                RemComp<StealthComponent>(uid);
                 EnsureComp<SharedSpeechComponent>(uid);
                 MetaData(uid).EntityName = Loc.GetString("telegnostic-trapped-entity-name");
                 MetaData(uid).EntityDescription = Loc.GetString("telegnostic-trapped-entity-desc");

--- a/Content.Server/Nyanotrasen/Psionics/Glimmer/Events/GlimmerRandomSentience.cs
+++ b/Content.Server/Nyanotrasen/Psionics/Glimmer/Events/GlimmerRandomSentience.cs
@@ -25,10 +25,12 @@ public sealed class GlimmerRandomSentience : GlimmerEventSystem
                 break;
 
             EntityManager.RemoveComponent<SentienceTargetComponent>(target.Owner);
+            MetaData(target.Owner).EntityName = Loc.GetString("glimmer-event-awakened-prefix", ("entity", target.Owner));
             var comp = EntityManager.AddComponent<GhostTakeoverAvailableComponent>(target.Owner);
             comp.RoleName = EntityManager.GetComponent<MetaDataComponent>(target.Owner).EntityName;
             comp.RoleDescription = Loc.GetString("station-event-random-sentience-role-description", ("name", comp.RoleName));
             RemComp<ReplacementAccentComponent>(target.Owner);
+            RemComp<MonkeyAccentComponent>(target.Owner);
             EnsureComp<PotentialPsionicComponent>(target.Owner);
         }
     }

--- a/Content.Server/Nyanotrasen/Psionics/Glimmer/GlimmerReactiveSystem.cs
+++ b/Content.Server/Nyanotrasen/Psionics/Glimmer/GlimmerReactiveSystem.cs
@@ -185,7 +185,6 @@ namespace Content.Server.Psionics.Glimmer
             _sharedGlimmerSystem.AddToGlimmer(0 - (int) removed);
             BeamRandomNearProber(uid, _sharedGlimmerSystem.Glimmer / 350, _sharedGlimmerSystem.Glimmer / 100);
             _explosionSystem.QueueExplosion(uid, "Default", totalIntensity, slope, maxIntensity);
-
         }
 
         private void BeamRandomNearProber(EntityUid prober, int targets, float range = 10f)

--- a/Content.Server/Nyanotrasen/Psionics/Glimmer/GlimmerReactiveSystem.cs
+++ b/Content.Server/Nyanotrasen/Psionics/Glimmer/GlimmerReactiveSystem.cs
@@ -180,8 +180,12 @@ namespace Content.Server.Psionics.Glimmer
             var slope = (float) (11 - _sharedGlimmerSystem.Glimmer / 100);
             var maxIntensity = 20;
 
+            var removed = (float) _sharedGlimmerSystem.Glimmer * _random.NextFloat(0.05f, 0.15f);
+            Logger.Error("Removed: " + removed);
+            _sharedGlimmerSystem.AddToGlimmer(0 - (int) removed);
             BeamRandomNearProber(uid, _sharedGlimmerSystem.Glimmer / 350, _sharedGlimmerSystem.Glimmer / 100);
             _explosionSystem.QueueExplosion(uid, "Default", totalIntensity, slope, maxIntensity);
+
         }
 
         private void BeamRandomNearProber(EntityUid prober, int targets, float range = 10f)

--- a/Content.Server/Nyanotrasen/Psionics/Glimmer/GlimmerReactiveSystem.cs
+++ b/Content.Server/Nyanotrasen/Psionics/Glimmer/GlimmerReactiveSystem.cs
@@ -150,7 +150,6 @@ namespace Content.Server.Psionics.Glimmer
         private void OnDamageChanged(EntityUid uid, SharedGlimmerReactiveComponent component, DamageChangedEvent args)
         {
             Logger.Error("Received event");
-            Logger.Error("origin: " + args.Origin);
             if (args.Origin == null)
                 return;
 

--- a/Content.Server/Nyanotrasen/Psionics/Glimmer/GlimmerReactiveSystem.cs
+++ b/Content.Server/Nyanotrasen/Psionics/Glimmer/GlimmerReactiveSystem.cs
@@ -149,19 +149,16 @@ namespace Content.Server.Psionics.Glimmer
 
         private void OnDamageChanged(EntityUid uid, SharedGlimmerReactiveComponent component, DamageChangedEvent args)
         {
-            Logger.Error("Received event");
             if (args.Origin == null)
                 return;
 
-            // if (!_random.Prob((float) _sharedGlimmerSystem.Glimmer / 1000))
-            //     return;
+            if (!_random.Prob((float) _sharedGlimmerSystem.Glimmer / 1000))
+                return;
 
             var tier = _sharedGlimmerSystem.GetGlimmerTier();
-            Logger.Error("Tier: " + tier);
             if (tier < GlimmerTier.High)
                 return;
 
-            Logger.Error("Tier is good.");
             string beamproto;
 
             switch (tier)
@@ -176,7 +173,6 @@ namespace Content.Server.Psionics.Glimmer
                     beamproto = "ChargedLightning";
                     break;
             }
-            Logger.Error("Beamproto: " + beamproto);
 
             var lxform = Transform(uid);
             var txform = Transform(args.Origin.Value);
@@ -186,7 +182,6 @@ namespace Content.Server.Psionics.Glimmer
             if (distance > (float) (_sharedGlimmerSystem.Glimmer / 100))
                 return;
 
-            Logger.Error("Creating beam...");
             _beam.TryCreateBeam(uid, args.Origin.Value, beamproto);
         }
 

--- a/Content.Server/Nyanotrasen/Research/Oracle/OracleSystem.cs
+++ b/Content.Server/Nyanotrasen/Research/Oracle/OracleSystem.cs
@@ -58,6 +58,7 @@ namespace Content.Server.Research.Oracle
             "TrashBagOfHolding",
             "BluespaceCrystal",
             "InsulativeHeadcage",
+            "CrystalNormality",
             "BodyBag_Folded",
             "BodyBag",
             "LockboxDecloner",
@@ -158,16 +159,16 @@ namespace Content.Server.Research.Oracle
 
             EntityManager.QueueDeleteEntity(args.Used);
 
-            EntityManager.SpawnEntity("ResearchDisk5000", Transform(uid).Coordinates);
+            EntityManager.SpawnEntity("ResearchDisk5000", Transform(args.User).Coordinates);
 
             if (TryComp<PotentialPsionicComponent>(args.User, out var potential))
                 _psionicsSystem.RollPsionics(args.User, potential);
 
-            int i = ((_random.Next() % 4) + 1);
+            int i = _random.Next(1, 4);
 
             while (i != 0)
             {
-                EntityManager.SpawnEntity("MaterialBluespace", Transform(uid).Coordinates);
+                EntityManager.SpawnEntity("MaterialBluespace", Transform(args.User).Coordinates);
                 i--;
             }
 

--- a/Content.Server/Nyanotrasen/Research/Oracle/OracleSystem.cs
+++ b/Content.Server/Nyanotrasen/Research/Oracle/OracleSystem.cs
@@ -61,6 +61,9 @@ namespace Content.Server.Research.Oracle
             "BodyBag_Folded",
             "BodyBag",
             "LockboxDecloner",
+            "MopBucket",
+            "FoodOnionRed",
+            "FoodGatfruit",
         };
 
 

--- a/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
@@ -154,7 +154,7 @@ public sealed class MeleeWeaponSystem : SharedMeleeWeaponSystem
         RaiseLocalEvent(ev.Target.Value, new AttackedEvent(component.Owner, user, targetXform.Coordinates));
 
         var modifiedDamage = DamageSpecifier.ApplyModifierSets(damage + hitEvent.BonusDamage + itemDamage.BonusDamage, hitEvent.ModifiersList);
-        var damageResult = _damageable.TryChangeDamage(ev.Target, modifiedDamage);
+        var damageResult = _damageable.TryChangeDamage(ev.Target, modifiedDamage, origin:user);
 
         if (damageResult != null && damageResult.Total > FixedPoint2.Zero)
         {
@@ -262,7 +262,7 @@ public sealed class MeleeWeaponSystem : SharedMeleeWeaponSystem
         {
             RaiseLocalEvent(entity, new AttackedEvent(component.Owner, user, ev.Coordinates));
 
-            var damageResult = _damageable.TryChangeDamage(entity, modifiedDamage);
+            var damageResult = _damageable.TryChangeDamage(entity, modifiedDamage, origin:user);
 
             if (damageResult != null && damageResult.Total > FixedPoint2.Zero)
             {

--- a/Content.Shared/Damage/Systems/DamageableSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageableSystem.cs
@@ -189,7 +189,7 @@ namespace Content.Shared.Damage
 
             if (!delta.Empty)
             {
-                DamageChanged(damageable, delta, interruptsDoAfters);
+                DamageChanged(damageable, delta, interruptsDoAfters, origin);
             }
 
             return delta;

--- a/Content.Shared/Nyanotrasen/Psionics/Glimmer/SharedGlimmerReactiveComponent.cs
+++ b/Content.Shared/Nyanotrasen/Psionics/Glimmer/SharedGlimmerReactiveComponent.cs
@@ -1,3 +1,5 @@
+using Robust.Shared.Audio;
+
 namespace Content.Shared.Psionics.Glimmer
 {
     [RegisterComponent]
@@ -29,5 +31,11 @@ namespace Content.Shared.Psionics.Glimmer
         /// </summary>
         [DataField("glimmerToLightRadiusFactor")]
         public float GlimmerToLightRadiusFactor = 1.0f;
+
+        /// <summary>
+        /// Noises to play on failed turn off.
+        /// </summary>
+        [DataField("shockNoises")]
+        public SoundSpecifier ShockNoises { get; } = new SoundCollectionSpecifier("sparks");
     }
 }

--- a/Resources/Locale/en-US/abilities/psionic.ftl
+++ b/Resources/Locale/en-US/abilities/psionic.ftl
@@ -46,6 +46,7 @@ action-description-psionic-regeneration = Push your natural metabolism to the li
 glimmer-report = Current Glimmer Level: {$level}Ψ.
 glimmer-event-report-generic = Noöspheric discharge detected. Glimmer level has decreased by {$decrease} to {$level}μΨ.
 glimmer-event-report-signatures = New psionic signatures manifested. Glimmer level has decreased by {$decrease} to {$level}μΨ.
+glimmer-event-awakened-prefix = awakened {$entity}
 
 noospheric-zap-seize = You seize up!
 noospheric-zap-seize-potential-regained = You seize up! Some mental block seems to have cleared, too.

--- a/Resources/Locale/en-US/station-events/events/random-sentience.ftl
+++ b/Resources/Locale/en-US/station-events/events/random-sentience.ftl
@@ -27,4 +27,4 @@ station-event-random-sentience-announcement = Based on { $data }, we believe tha
 
 ## Ghost role description
 
-station-event-random-sentience-role-description = You are a sentient { $name }, brought to life through space magic.
+station-event-random-sentience-role-description = You are an { $name }, having gained new insight from the high amount of glimmer.

--- a/Resources/Prototypes/Body/Presets/primate.yml
+++ b/Resources/Prototypes/Body/Presets/primate.yml
@@ -2,7 +2,8 @@
   name: "primate preset"
   id: PrimatePreset
   partIDs:
-    hands: HandsAnimal
+    left hand: LeftHandHuman
+    right hand: RightHandHuman
     legs: LegsAnimal
     feet: FeetAnimal
     torso: TorsoAnimal

--- a/Resources/Prototypes/Body/Templates/primate.yml
+++ b/Resources/Prototypes/Body/Templates/primate.yml
@@ -5,12 +5,13 @@
   centerSlot: "torso"
   slots:
     torso: Torso
-    hands: Hand
+    left hand: Hand
+    right hand: Hand
     legs: Leg
     feet: Foot
   connections:
     torso:
-    - hands
-    - legs
-    legs: 
+    - left hand
+    - right hand
+    legs:
     - feet

--- a/Resources/Prototypes/Catalog/Research/technologies.yml
+++ b/Resources/Prototypes/Catalog/Research/technologies.yml
@@ -312,6 +312,8 @@
   unlockedRecipes:
     - SheetSteel
     - SheetPlastic
+    - SheetPlasteel
+    - SheetPlasma
     - SheetRGlass
     - SheetGlass1
     - BluespaceCrystal

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -758,6 +758,10 @@
   - type: MonkeyAccent
   - type: Puller
   - type: CanHostGuardian
+  - type: DiseaseCarrier
+  - type: Tag
+    tags:
+    - GunsDisabled
 
 - type: entity
   name: mouse

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -707,8 +707,6 @@
   components:
   - type: CombatMode
     disarm: null
-  - type: NameIdentifier
-    group: Monkey
   - type: SentienceTarget
     flavorKind: primate
   - type: Inventory

--- a/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
@@ -46,8 +46,6 @@
     drawFov: false
   - type: DoAfter
   - type: Alerts
-  - type: NameIdentifier
-    group: GenericNumber
   - type: GhostTakeoverAvailable
     makeSentient: true
     name: Revenant

--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -62,8 +62,6 @@
     - SlowedDown
     - Stutter
     - Electrocution
-  - type: NameIdentifier
-    group: GenericNumber
   - type: Repairable
     fuelcost: 15
     doAfterDelay: 8

--- a/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
@@ -137,13 +137,10 @@
   - type: Polymorphable
   - type: Pullable
   - type: Buckle
-  - type: DiseaseCarrier
   - type: Recyclable
     safe: false
   - type: StandingState
   - type: Alerts
-  - type: NameIdentifier
-    group: GenericNumber
   - type: SlowOnDamage
     speedModifierThresholds:
       60: 0.7

--- a/Resources/Prototypes/Entities/Mobs/Player/guardian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/guardian.yml
@@ -110,8 +110,6 @@
       makeSentient: true
       name: Holoparasite
       description: Listen to your owner. Don't tank damage. Punch people hard.
-    - type: NameIdentifier
-      group: Holoparasite
     - type: TypingIndicator
       proto: holo
     - type: Sprite

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -74,8 +74,6 @@
       - id: trayScanner
       - id: Omnitool
       - id: WelderExperimental
-  - type: NameIdentifier
-    group: Drone
   - type: Eye
   - type: Inventory
     templateId: drone

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -161,6 +161,8 @@
       - LightTube
       - LightBulb
       - SheetSteel
+      - SheetPlasteel
+      - SheetPlasma
       - SheetGlass1
       - SheetRGlass
       - SheetPlastic
@@ -344,6 +346,8 @@
       - LightTube
       - LightBulb
       - SheetSteel
+      - SheetPlasteel
+      - SheetPlasma
       - SheetGlass1
       - SheetRGlass
       - SheetPlastic
@@ -409,6 +413,8 @@
       - LightTube
       - LightBulb
       - SheetSteel
+      - SheetPlasteel
+      - SheetPlasma
       - SheetGlass1
       - SheetRGlass
       - SheetPlastic
@@ -546,5 +552,4 @@
         - SheetPGlass30
         - SheetRPGlass30
         - SheetUranium1
-        - IngotGold1
         - IngotSilver1

--- a/Resources/Prototypes/Nyanotrasen/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Nyanotrasen/Damage/modifier_sets.yml
@@ -18,3 +18,14 @@
     Blunt: 0.85
     Slash: 0.85
     Piercing: 0.85
+
+- type: damageModifierSet
+  id: ShockAbsorber
+  coefficients:
+    Blunt: 0.7
+    Slash: 0.5
+    Piercing: 0.7
+    Shock: -1
+  flatReductions:
+    Blunt: 5
+    Heat: 5

--- a/Resources/Prototypes/Nyanotrasen/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Structures/Machines/lathe.yml
@@ -44,6 +44,8 @@
       - LightTube
       - LightBulb
       - SheetSteel
+      - SheetPlasteel
+      - SheetPlasma
       - SheetGlass1
       - SheetRGlass
       - SheetPlastic
@@ -108,9 +110,12 @@
       - LightTube
       - LightBulb
       - SheetSteel
+      - SheetPlasteel
+      - SheetPlasma
       - SheetGlass1
       - SheetRGlass
       - SheetPlastic
+      - BluespaceCrystal
       - CableStack
       - CableMVStack
       - CableHVStack
@@ -174,9 +179,12 @@
       - LightTube
       - LightBulb
       - SheetSteel
+      - SheetPlasteel
+      - SheetPlasma
       - SheetGlass1
       - SheetRGlass
       - SheetPlastic
+      - BluespaceCrystal
       - CableStack
       - CableMVStack
       - CableHVStack

--- a/Resources/Prototypes/Nyanotrasen/Entities/Structures/Research/glimmer_prober.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Structures/Research/glimmer_prober.yml
@@ -57,6 +57,9 @@
     glimmerToLightEnergyFactor: 2.0
     glimmerToLightRadiusFactor: 1.3
   - type: PowerSwitch
+  - type: Damageable
+    damageContainer: Inorganic
+    damageModifierSet: ShockAbsorber
 
 - type: entity
   parent: BaseMachinePowered

--- a/Resources/Prototypes/Nyanotrasen/GameRules/events.yml
+++ b/Resources/Prototypes/Nyanotrasen/GameRules/events.yml
@@ -66,6 +66,6 @@
   config:
     !type:GlimmerEventRuleConfiguration
     id: GlimmerRevenantSpawn
-    minimumGlimmer: 450
+    minimumGlimmer: 600
     maximumGlimmer: 900
     report: glimmer-event-report-signatures

--- a/Resources/Prototypes/Nyanotrasen/Recipes/Lathes/materials.yml
+++ b/Resources/Prototypes/Nyanotrasen/Recipes/Lathes/materials.yml
@@ -1,0 +1,20 @@
+- type: latheRecipe
+  id: SheetPlasma
+  icon:
+    sprite: Objects/Materials/Sheets/other.rsi
+    state: plasma
+  result: SheetPlasma1
+  completetime: 2
+  materials:
+    Plasma: 100
+
+- type: latheRecipe
+  id: SheetPlasteel
+  icon:
+    sprite: Objects/Materials/Sheets/metal.rsi
+    state: plasteel
+  result: SheetPlasteel1
+  completetime: 2
+  materials:
+    Steel: 100
+    Plasma: 100

--- a/Resources/Prototypes/SoundCollections/lobby.yml
+++ b/Resources/Prototypes/SoundCollections/lobby.yml
@@ -2,7 +2,6 @@
   id: LobbyMusic
   files:
     - /Audio/Lobby/thunderdome.ogg
-    - /Audio/Lobby/thesnow.ogg
     - /Audio/Lobby/space_asshole.ogg
     - /Audio/Lobby/endless_space.ogg
     - /Audio/Lobby/atomicamnesiammx.ogg
@@ -10,9 +9,10 @@
     - /Audio/Lobby/comet_haley.ogg
     - /Audio/Lobby/marhaba.ogg
     - /Audio/Lobby/title3.ogg
-    - /Audio/Lobby/sneedsfeedandseed.ogg
     - /Audio/Lobby/mod.flip-flap.ogg
     - /Audio/Lobby/Monument.ogg
-    - /Audio/Lobby/Spac_Stac.ogg
+    - /Audio/Lobby/sneedsfeedandseed.ogg
     - /Audio/Lobby/myunmyun.ogg
     - /Audio/Lobby/squids.ogg
+    - /Audio/Lobby/thesnow.ogg
+    - /Audio/Lobby/teenagelightning2.ogg

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -2,6 +2,5 @@
   id: Secret
   weights:
     Survival: 0.15
-    Nukeops: 0.075
+    Nukeops: 0.1
     Traitor: 0.75
-    Zombie: 0.025


### PR DESCRIPTION
:cl: Rane
- remove: Removed name identifiers for animals (they were ugly and our ghost roles are whitelisted).
- remove: Zombie removed from secret.
- fix: DiseaseCarrier is back to humanoids, mice, and monkeys.
- tweak: Monkeys have 2 hands.
- fix: Removed several more impossible / unreasonably difficult oracle requests.
- tweak: Oracle now drops the rewards at your feet, so people are less likely to forget them.
- tweak: Revenant's minimum eligible glimmer increased by 150.
- add: Polished random sentience event.
- add: Interacting with probers at high glimmer is much more fun.
- add: Destroying glimmer probers will reduce glimmer level if glimmer is above 300.
- add: Plasteel and plasma are printable now with material printing
- add: New soul lobby song
- add: Reenabled early shuttle call cvar. Great way to speedrun a whitelist removal and/or ban if you abuse it.

