### PR TITLE
Nyanoupdatesoct31

### DIFF
--- a/Content.Server/Nyanotrasen/Abilities/Psionics/PsionicAbilitiesSystem.cs
+++ b/Content.Server/Nyanotrasen/Abilities/Psionics/PsionicAbilitiesSystem.cs
@@ -96,6 +96,9 @@ namespace Content.Server.Abilities.Psionics
             if (!TryComp<PsionicComponent>(uid, out var psionic))
                 return;
 
+            if (!psionic.Removable)
+                return;
+
             if (!_prototypeManager.TryIndex<WeightedRandomPrototype>("RandomPsionicPowerPool", out var pool))
             {
                 Logger.Error("Can't index the random psionic power pool!");

--- a/Content.Server/Nyanotrasen/Objectives/Conditions/RaiseGlimmerCondition.cs
+++ b/Content.Server/Nyanotrasen/Objectives/Conditions/RaiseGlimmerCondition.cs
@@ -1,5 +1,4 @@
 using Content.Server.Objectives.Interfaces;
-using Content.Shared.Abilities.Psionics;
 using Content.Shared.Psionics.Glimmer;
 using JetBrains.Annotations;
 using Robust.Shared.Utility;
@@ -8,17 +7,19 @@ namespace Content.Server.Objectives.Conditions
 {
     [UsedImplicitly]
     [DataDefinition]
-    public sealed class Glimmer400Condition : IObjectiveCondition
+    public sealed class RaiseGlimmerCondition : IObjectiveCondition
     {
         private Mind.Mind? _mind;
+        [DataField("target")] private int _target = 500;
+
         public IObjectiveCondition GetAssigned(Mind.Mind mind)
         {
-            return new Glimmer400Condition {_mind = mind};
+            return new RaiseGlimmerCondition {_mind = mind};
         }
 
-        public string Title => Loc.GetString("objective-condition-glimmer-400-title");
+        public string Title => Loc.GetString("objective-condition-raise-glimmer-title", ("target", _target));
 
-        public string Description => Loc.GetString("objective-condition-glimmer-400-description");
+        public string Description => Loc.GetString("objective-condition-raise-glimmer-description", ("target", _target));
 
         public SpriteSpecifier Icon => new SpriteSpecifier.Rsi(new ResourcePath("Nyanotrasen/Icons/psi.rsi"), "psi");
 
@@ -27,16 +28,16 @@ namespace Content.Server.Objectives.Conditions
             get {
                 var glimmer = IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<SharedGlimmerSystem>();
 
-                var progress = Math.Min((float) glimmer.Glimmer / 400f, 1f);
+                var progress = Math.Min((float) glimmer.Glimmer / (float) _target, 1f);
                 return progress;
             }
         }
 
-        public float Difficulty => 2f;
+        public float Difficulty => 2.5f;
 
         public bool Equals(IObjectiveCondition? other)
         {
-            return other is Glimmer400Condition condition && Equals(_mind, condition._mind);
+            return other is RaiseGlimmerCondition condition && Equals(_mind, condition._mind);
         }
 
         public override bool Equals(object? obj)
@@ -44,7 +45,7 @@ namespace Content.Server.Objectives.Conditions
             if (ReferenceEquals(null, obj)) return false;
             if (ReferenceEquals(this, obj)) return true;
             if (obj.GetType() != GetType()) return false;
-            return Equals((Glimmer400Condition) obj);
+            return Equals((RaiseGlimmerCondition) obj);
         }
 
         public override int GetHashCode()

--- a/Content.Server/Nyanotrasen/Psionics/PsionicsCommands.cs
+++ b/Content.Server/Nyanotrasen/Psionics/PsionicsCommands.cs
@@ -1,0 +1,26 @@
+using Content.Server.Administration;
+using Content.Shared.Administration;
+using Content.Shared.Abilities.Psionics;
+using Content.Shared.MobState.Components;
+using Robust.Shared.Console;
+using Robust.Server.GameObjects;
+
+namespace Content.Server.Psionics;
+
+[AdminCommand(AdminFlags.Logs)]
+public sealed class ListPsionicsCommand : IConsoleCommand
+{
+    public string Command => "lspsionics";
+    public string Description => Loc.GetString("command-lspsionic-description");
+    public string Help => Loc.GetString("command-lspsionic-help");
+    public async void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        var entMan = IoCManager.Resolve<IEntityManager>();
+        foreach (var (actor, mob, psionic, meta) in entMan.EntityQuery<ActorComponent, MobStateComponent, PsionicComponent, MetaDataComponent>())
+        {
+            // filter out xenos, etc, with innate telepathy
+            if (psionic.PsionicAbility?.DisplayName != null)
+                shell.WriteLine(meta.EntityName + " (" + meta.Owner + ") - " + actor.PlayerSession.Name + " - " + Loc.GetString(psionic.PsionicAbility.DisplayName));
+        }
+    }
+}

--- a/Content.Shared/Nyanotrasen/Abilities/Psionics/PsionicComponent.cs
+++ b/Content.Shared/Nyanotrasen/Abilities/Psionics/PsionicComponent.cs
@@ -7,5 +7,11 @@ namespace Content.Shared.Abilities.Psionics
     public sealed class PsionicComponent : Component
     {
         public ActionType? PsionicAbility = null;
+
+        /// <summary>
+        ///     Ifrits, revenants, etc are explicitly magical beings that shouldn't get mindbreakered.
+        /// </summary>
+        [DataField("removable")]
+        public bool Removable = true;
     }
 }

--- a/Resources/Locale/en-US/objectives/conditions/glimmer-400-condition.ftl
+++ b/Resources/Locale/en-US/objectives/conditions/glimmer-400-condition.ftl
@@ -1,2 +1,2 @@
-objective-condition-glimmer-400-title = Ensure glimmer reaches 400Ψ.
-objective-condition-glimmer-400-description = We need you to pump the noösphere surrounding the station to at least 400Ψ and keep it that way.
+objective-condition-raise-glimmer-title = Ensure glimmer reaches {$target}Ψ.
+objective-condition-raise-glimmer-description = We need you to pump the noösphere surrounding the station to at least {$target}Ψ and keep it that way.

--- a/Resources/Locale/en-US/psionics/psionic-commands.ftl
+++ b/Resources/Locale/en-US/psionics/psionic-commands.ftl
@@ -3,3 +3,6 @@ command-glimmershow-help = No arguments.
 
 command-glimmerset-description = Set glimmer to a number.
 command-glimmerset-help = glimmerset (integer)
+
+command-lspsionic-description = List psionics.
+command-lspsionic-help = No arguments.

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -496,6 +496,10 @@
     Telecrystal: 2
   categories:
   - UplinkArmor
+  conditions:
+  - !type:BuyerSpeciesCondition
+    blacklist:
+    - Arachne
 
 - type: listing
   id: UplinkgClothingThievingGloves
@@ -523,6 +527,10 @@
     Telecrystal: 8
   categories:
   - UplinkArmor
+  conditions:
+  - !type:BuyerSpeciesCondition
+    blacklist:
+    - Arachne
 
 - type: listing
   id: UplinkClothingShoesBootsMagSyndie
@@ -532,6 +540,10 @@
     Telecrystal: 2
   categories:
   - UplinkArmor
+  conditions:
+  - !type:BuyerSpeciesCondition
+    blacklist:
+    - Arachne
 
 - type: listing
   id: UplinkEVASyndie
@@ -550,6 +562,10 @@
     Telecrystal: 12
   categories:
   - UplinkArmor
+  conditions:
+  - !type:BuyerSpeciesCondition
+    blacklist:
+    - Arachne
 
 # Misc
 

--- a/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
@@ -201,4 +201,5 @@
     equippedPrefix: holding
   - type: Storage
     capacity: 5000
+    popup: false
   - type: OfHolding

--- a/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
@@ -200,4 +200,5 @@
       shader: unshaded
   - type: Storage
     capacity: 5000
+    popup: false
   - type: OfHolding

--- a/Resources/Prototypes/Entities/Clothing/Back/satchel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/satchel.yml
@@ -111,4 +111,5 @@
       shader: unshaded
   - type: Storage
     capacity: 5000
+    popup: false
   - type: OfHolding

--- a/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
@@ -75,4 +75,5 @@
     - of
     - RevenantAdjective
     - RevenantTheme
-  - type: Psionic #they can't get mindbreakered and I do not want to give them powers, so...
+  - type: Psionic
+    removable: false

--- a/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
@@ -115,6 +115,8 @@
     molsPerSecondPerUnitMass: 0.0005
   - type: PotentialPsionic
     chance: -2
+  - type: Psionic
+    removable: false
 
 - type: entity
   name: Praetorian
@@ -145,7 +147,6 @@
       - MobMask
       layer:
       - MobLayer
-  - type: Psionic
 
 - type: entity
   name: Drone
@@ -179,7 +180,6 @@
       - MobMask
       layer:
       - MobLayer
-  - type: Psionic
 
 - type: entity
   name: Queen
@@ -218,11 +218,6 @@
       - MobMask
       layer:
       - MobLayer
-  - type: PotentialPsionic
-    chance: 0
-  - type: PsionicBonusChance
-    flatBonus: 1
-    warn: false
 
 - type: entity
   name: Ravager
@@ -261,7 +256,6 @@
       - MobMask
       layer:
       - MobLayer
-  - type: Psionic
 
 - type: entity
   name: Runner
@@ -300,7 +294,6 @@
       - MobMask
       layer:
       - MobLayer
-  - type: Psionic
 
 - type: entity
   name: Rouny
@@ -311,7 +304,6 @@
     drawdepth: Mobs
     sprite: Mobs/Aliens/Xenos/rouny.rsi
     offset: 0,0.6
-  - type: Psionic
 
 - type: entity
   name: Spitter
@@ -342,7 +334,6 @@
       - MobMask
       layer:
       - MobLayer
-  - type: Psionic
 
 - type: entity
   name: space adder

--- a/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
@@ -17,6 +17,8 @@
 - type: randomHumanoidSettings
   id: ERTLeader
   randomizeName: false
+  speciesBlacklist:
+    - Arachne
   components:
     - type: GhostTakeoverAvailable
       name: ERT Leader
@@ -224,6 +226,8 @@
 
 - type: randomHumanoidSettings
   id: CBURNAgent
+  speciesBlacklist:
+    - Arachne
   components:
     - type: Loadout
       prototypes: [CBURNGear]
@@ -268,6 +272,8 @@
 
 - type: randomHumanoidSettings
   id: SyndicateAgent
+  speciesBlacklist:
+    - Arachne
   components:
     - type: Loadout
       prototypes: [SyndicateOperativeGearExtremelyBasic]
@@ -284,6 +290,8 @@
 
 - type: randomHumanoidSettings
   id: NukeOp
+  speciesBlacklist:
+    - Arachne
   components:
     - type: NukeOperative
     - type: PsionicBonusChance

--- a/Resources/Prototypes/Maps/angle.yml
+++ b/Resources/Prototypes/Maps/angle.yml
@@ -1,5 +1,5 @@
 ﻿- type: gameMap
-  id: angle
+  id: Angle
   mapName: 'Angle'
   mapPath: /Maps/angle.yml
   minPlayers: 20

--- a/Resources/Prototypes/Maps/box.yml
+++ b/Resources/Prototypes/Maps/box.yml
@@ -1,5 +1,5 @@
 - type: gameMap
-  id: boxstation
+  id: Boxstation
   mapName: 'Box Station'
   mapPath: /Maps/box.yml
   minPlayers: 30

--- a/Resources/Prototypes/Maps/lighthouse.yml
+++ b/Resources/Prototypes/Maps/lighthouse.yml
@@ -1,5 +1,5 @@
 ﻿- type: gameMap
-  id: lighthouse
+  id: Lighthouse
   mapName: 'lighthouse'
   mapPath: /Maps/lighthouse.yml
   minPlayers: 20

--- a/Resources/Prototypes/Maps/saucer.yml
+++ b/Resources/Prototypes/Maps/saucer.yml
@@ -1,5 +1,5 @@
 - type: gameMap
-  id: saucer
+  id: Saucer
   mapName: 'Saucer'
   mapPath: /Maps/saucer.yml
   minPlayers: 0

--- a/Resources/Prototypes/Maps/tortuga.yml
+++ b/Resources/Prototypes/Maps/tortuga.yml
@@ -1,5 +1,5 @@
 - type: gameMap
-  id: tortuga
+  id: Tortuga
   mapName: 'Tortuga'
   mapPath: /Maps/tortuga.yml
   minPlayers: 30

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/NPCs/familiars.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/NPCs/familiars.yml
@@ -77,6 +77,7 @@
     nameSegments: [names_golem]
   - type: PotentialPsionic
   - type: Psionic
+    removable: false
   - type: PyrokinesisPower
   - type: Grammar
     attributes:

--- a/Resources/Prototypes/Nyanotrasen/InventoryTemplates/anytaur_inventory_template.yml
+++ b/Resources/Prototypes/Nyanotrasen/InventoryTemplates/anytaur_inventory_template.yml
@@ -88,7 +88,8 @@
     - name: id
       slotTexture: id
       slotFlags: IDCARD
-      stripTime: 5
+      slotGroup: SecondHotbar
+      stripTime: 6
       uiWindowPos: 2,1
       strippingWindowPos: 2,4
       dependsOn: jumpsuit

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -2,9 +2,9 @@
 - type: weightedRandom
   id: TraitorObjectiveGroups
   weights:
-    TraitorObjectiveGroupSteal: 1
-    TraitorObjectiveGroupKill: 1
-    TraitorObjectiveGroupState: 1 #As in, something about your character. Alive, dead, arrested, gained an ability...
+    # TraitorObjectiveGroupSteal: 1
+    # TraitorObjectiveGroupKill: 1
+    # TraitorObjectiveGroupState: 1 #As in, something about your character. Alive, dead, arrested, gained an ability...
     TraitorObjectiveGroupSocial: 1 #Involves helping/harming others without killing them or stealing their stuff
 
 - type: weightedRandom
@@ -38,6 +38,6 @@
   weights:
     RandomTraitorAliveObjective: 1
     RandomTraitorProgressObjective: 1
-    Glimmer400Objective: 1
+    RaiseGlimmerObjective: 1
 
 #Changeling, crew, wizard, when you code it...

--- a/Resources/Prototypes/Objectives/traitorObjectives.yml
+++ b/Resources/Prototypes/Objectives/traitorObjectives.yml
@@ -246,9 +246,9 @@
   canBeDuplicate: true
 
 - type: objective
-  id: Glimmer400Objective
+  id: RaiseGlimmerObjective
   issuer: syndicate
   requirements:
     - !type:TraitorRequirement {}
   conditions:
-    - !type:Glimmer400Condition {}
+    - !type:RaiseGlimmerCondition {}


### PR DESCRIPTION
:cl: Rane
- fix: Arachne whitelists and blacklists updated for uplink items and random humanoid spawns.
- fix: Arachne PDA slot is in the correct location.
- fix: Revenants, familiars, etc cannot get mindbreakered.
- fix: Fixed multiple popups on bags of holding.
- tweak: Glimmer objective rasied to 500 and difficulty adjusted accordingly.
- add: New 'lspsionics' command for developers and admins.
