### PR TITLE
Update 11/02

### DIFF
--- a/Content.Server/Nyanotrasen/Psionics/Glimmer/Events/NoosphericZap.cs
+++ b/Content.Server/Nyanotrasen/Psionics/Glimmer/Events/NoosphericZap.cs
@@ -44,7 +44,7 @@ public sealed class NoosphericZap : GlimmerEventSystem
                     _popupSystem.PopupEntity(Loc.GetString("noospheric-zap-seize-potential-regained"), psion.Owner, Filter.Entities(psion.Owner), Shared.Popups.PopupType.LargeCaution);
                 } else
                 {
-                    _psionicsSystem.RollPsionics(psion.Owner, psion);
+                    _psionicsSystem.RollPsionics(psion.Owner, psion, multiplier: 0.5f);
                     _popupSystem.PopupEntity(Loc.GetString("noospheric-zap-seize"), psion.Owner, Filter.Entities(psion.Owner), Shared.Popups.PopupType.LargeCaution);
                 }
             }

--- a/Content.Server/Nyanotrasen/Psionics/Glimmer/Structures/GlimmerSourceComponent.cs
+++ b/Content.Server/Nyanotrasen/Psionics/Glimmer/Structures/GlimmerSourceComponent.cs
@@ -8,11 +8,12 @@ namespace Content.Server.Psionics.Glimmer
     {
         [DataField("accumulator")]
         public float Accumulator = 0f;
+
         /// <summary>
         ///     Since glimmer is an int, we'll do it like this.
         /// </summary>
         [DataField("secondsPerGlimmer")]
-        public float SecondsPerGlimmer = 20f;
+        public float SecondsPerGlimmer = 10f;
 
         /// <summary>
         ///     True if it produces glimmer, false if it subtracts it.

--- a/Content.Server/Nyanotrasen/Psionics/PsionicsSystem.cs
+++ b/Content.Server/Nyanotrasen/Psionics/PsionicsSystem.cs
@@ -88,7 +88,7 @@ namespace Content.Server.Psionics
             args.FlatModifier += component.PsychicStaminaDamage;
         }
 
-        public void RollPsionics(EntityUid uid, PotentialPsionicComponent component, bool applyGlimmer = true)
+        public void RollPsionics(EntityUid uid, PotentialPsionicComponent component, bool applyGlimmer = true, float multiplier = 1f)
         {
             if (HasComp<PsionicComponent>(uid))
                 return;
@@ -104,6 +104,8 @@ namespace Content.Server.Psionics
 
             if (applyGlimmer)
                 chance += ((float) _glimmerSystem.Glimmer / 1000);
+
+            chance *= multiplier;
 
             chance = Math.Clamp(chance, 0, 1);
             if (_random.Prob(chance))

--- a/Resources/Prototypes/Maps/angle.yml
+++ b/Resources/Prototypes/Maps/angle.yml
@@ -3,7 +3,7 @@
   mapName: 'Angle'
   mapPath: /Maps/angle.yml
   minPlayers: 20
-  maxPlayers: 45
+  maxPlayers: 60
   stations:
     Angle:
       mapNameTemplate: '{0} Angle Rig {1}'

--- a/Resources/Prototypes/Maps/pebble.yml
+++ b/Resources/Prototypes/Maps/pebble.yml
@@ -3,7 +3,7 @@
   mapName: 'Pebble Station'
   mapPath: /Maps/pebble.yml
   minPlayers: 0
-  maxPlayers: 30
+  maxPlayers: 25
   votable: true
   stations:
     PebbleStation:

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Devices/Circuitboards/production.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Devices/Circuitboards/production.yml
@@ -1,0 +1,57 @@
+- type: entity
+  id: EngineeringTechFabCircuitboard
+  parent: BaseMachineCircuitboard
+  name: engineering techfab machine board
+  description: A machine printed circuit board for a engineering techfab
+  components:
+    - type: Sprite
+      state: engineering
+    - type: MachineBoard
+      prototype: EngineeringTechFab
+      requirements:
+        MatterBin: 2
+        Manipulator: 2
+      tagRequirements:
+        GlassBeaker:
+          Amount: 2
+          DefaultPrototype: Beaker
+          ExamineName: Glass Beaker
+
+- type: entity
+  id: ServiceTechFabCircuitboard
+  parent: BaseMachineCircuitboard
+  name: service techfab machine board
+  description: A machine printed circuit board for a service techfab
+  components:
+    - type: Sprite
+      state: service
+    - type: MachineBoard
+      prototype: ServiceTechFab
+      requirements:
+        MatterBin: 2
+        Manipulator: 2
+      tagRequirements:
+        GlassBeaker:
+          Amount: 2
+          DefaultPrototype: Beaker
+          ExamineName: Glass Beaker
+
+- type: entity
+  id: ScienceTechFabCircuitboard
+  parent: BaseMachineCircuitboard
+  name: epistemics techfab machine board
+  description: A machine printed circuit board for an epistemics techfab
+  components:
+    - type: Sprite
+      state: science
+    - type: MachineBoard
+      prototype: ScienceTechFab
+      requirements:
+        MatterBin: 2
+        Manipulator: 2
+      tagRequirements:
+        GlassBeaker:
+          Amount: 2
+          DefaultPrototype: Beaker
+          ExamineName: Glass Beaker
+

--- a/Resources/Prototypes/Nyanotrasen/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Structures/Machines/lathe.yml
@@ -18,6 +18,8 @@
       map: ["enum.LatheVisualLayers.IsInserting"]
     - state: panel
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
+  - type: Machine
+    board: ScienceTechFabCircuitboard
   - type: Lathe
     idleState: icon
     runningState: icon
@@ -86,6 +88,8 @@
       map: ["enum.LatheVisualLayers.IsInserting"]
     - state: panel
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
+  - type: Machine
+    board: ServiceTechFabCircuitboard
   - type: Lathe
     idleState: icon
     runningState: icon
@@ -153,6 +157,8 @@
       map: ["enum.LatheVisualLayers.IsInserting"]
     - state: panel
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
+  - type: Machine
+    board: EngineeringTechFabCircuitboard
   - type: Lathe
     idleState: icon
     runningState: icon


### PR DESCRIPTION
:cl: Rane
- tweak: Doubled glimmer production from probers and drains (per advice of one Sidney K. Meier).
- tweak: Noospheric zap event's glimmer bonus halved.
- tweak: Min/Max players on each of the maps in our pool has been made more consistent.
- fix: Fixed techfab deconstruction.

