### PR TITLE
Minor edits

### DIFF
--- a/Resources/Maps/arena.yml
+++ b/Resources/Maps/arena.yml
@@ -102,7 +102,7 @@ grids:
   - ind: -1,-1
     tiles: PwAAAD8AAAA/AAAAPwAAAT8AAAE/AAACBAAAABsAAAAEAAABPwAAAT8AAAE/AAAAPwAAAT8AAAM/AAACWAAAAD8AAAI/AAABPwAAAj8AAAA/AAADPwAAAj8AAAA/AAACPwAAAj8AAAI/AAAAPwAAAT8AAAI/AAABPwAAAFgAAABYAAAAWAAAAD4AAAE+AAABPgAAAT4AAAI+AAABPgAAAD4AAAI+AAADPgAAAz4AAAE+AAADWAAAAFgAAABYAAAAPgAAAj4AAAM+AAAAPgAAAz4AAAM+AAAAPgAAAD4AAAA+AAAAPgAAAz4AAAA+AAABPgAAAD4AAAE+AAACPgAAAj4AAAI+AAABIwAAAD4AAAM+AAACIwAAAD4AAAI+AAACIwAAAD4AAAA+AAACIwAAAD4AAAI+AAAAIwAAAD4AAAM+AAACWAAAAFgAAABYAAAAPgAAAD4AAAE+AAAAPgAAAz4AAAA+AAAAPgAAA1gAAABYAAAAWAAAAD4AAAA+AAADPgAAAT4AAAIjAAAAPgAAAz4AAAEjAAAAPgAAAz4AAAAjAAAAPgAAAj4AAAIjAAAAPgAAAD4AAAAjAAAAPgAAAz4AAAE+AAADPgAAAz4AAAM+AAADPgAAAz4AAAM+AAABPgAAAz4AAAE+AAACPgAAAD4AAAI+AAAAPgAAAj4AAAEMAAABDAAAAFgAAAA+AAACPgAAAD4AAAM+AAACWAAAACwAAAAsAAAALAAAAFgAAAAfAAAAHwAAAB8AAAEfAAADDAAAAQwAAAJYAAAALAAAACwAAAAsAAAALAAAACwAAAAsAAAALAAAACwAAAAfAAABHwAAAh8AAAAfAAADHwAAAQwAAAIMAAACWAAAACwAAAAsAAAALAAAACwAAAAsAAAALAAAACwAAAAsAAAAHwAAAR8AAAAfAAABHwAAAh8AAAEMAAABDAAAAVgAAAAsAAAALAAAACwAAAAsAAAALAAAACwAAAAsAAAALAAAAB8AAAMfAAACHwAAAB8AAAMfAAADDAAAAAwAAANYAAAALAAAACwAAAAsAAAALAAAACwAAAAsAAAALAAAACwAAAAfAAACHwAAAR8AAAAfAAACHwAAAQwAAAAMAAABWAAAACwAAAAsAAAALAAAAFgAAABYAAAALAAAAFgAAABYAAAAWAAAAB8AAAIfAAACHwAAAC8AAAAMAAAADAAAAVgAAAAsAAAALAAAACwAAAAsAAAALAAAACwAAAAsAAAALAAAAB8AAAAfAAABHwAAAh8AAAEvAAAADAAAAAwAAAFYAAAALAAAACwAAAAsAAAALAAAACwAAAAsAAAALAAAACwAAAAfAAABHwAAAx8AAAEfAAAAHwAAAQ==
   - ind: -1,0
-    tiles: VQAAAVgAAABYAAAAWAAAAFgAAABYAAAAIgAAACIAAAAiAAAAIgAAACIAAABYAAAAWAAAAFgAAABYAAAAWAAAAFUAAAJYAAAAPgAAAD4AAAI+AAABWAAAACIAAAAiAAAAIgAAACIAAAAiAAAAWAAAAAQAAAAEAAABBAAAAQQAAABVAAADWAAAAD4AAAI+AAAAPgAAA1gAAAAiAAAAIgAAACIAAAAiAAAAIgAAAFgAAAAEAAABBAAAAAQAAAAEAAACWAAAAFgAAAA+AAACPgAAAT4AAAFYAAAAIgAAACIAAAAiAAAAIgAAACIAAABYAAAAWAAAAFgAAABYAAAAWAAAAFgAAABYAAAAWAAAAFgAAABYAAAAWAAAAFgAAABYAAAAWAAAAFgAAABYAAAAWAAAAEgAAABIAAAASAAAAEgAAABYAAAAWAAAAFgAAABYAAAAWAAAAFgAAABYAAAAWAAAAFgAAABYAAAAWAAAAFgAAABYAAAAWAAAAFgAAABYAAAABAAAAlgAAABIAAAASAAAAEgAAABIAAAASAAAAEgAAABIAAAASAAAAEgAAABYAAAAWAAAAFgAAABYAAAAWAAAAAQAAAFYAAAAWAAAAFgAAABYAAAAWAAAAFgAAABYAAAAWAAAAFgAAABYAAAAWAAAAAQAAAIEAAAABAAAAQQAAAIEAAABBAAAAgQAAAAEAAACBAAAAAQAAAEEAAACBAAAAQQAAAIEAAACBAAAAAQAAAAEAAABBAAAAAQAAAAEAAABBAAAAgQAAAIEAAABBAAAAgQAAAIEAAABBAAAAAQAAAEEAAACBAAAAgQAAAEEAAAABAAAAgQAAAIEAAABLwAAAAQAAAIEAAAABAAAAQQAAAAEAAACBAAAAAQAAAAEAAACBAAAAQQAAAIEAAABBAAAAAQAAAEEAAACBAAAAi8AAAAEAAABBAAAAQQAAAEEAAACBAAAAgQAAAIEAAAABAAAAgQAAAIEAAABBAAAAAQAAAIEAAABBAAAAgQAAAAvAAAABAAAAgQAAAIEAAABBAAAAAQAAAEEAAACBAAAAgQAAAIEAAABBAAAAQQAAAIEAAAABAAAAgQAAAEEAAACBAAAAQQAAAIEAAAABAAAAgQAAAEEAAAABAAAAAQAAAEEAAAABAAAAAQAAAIEAAACBAAAAAQAAAAEAAAABAAAAQQAAAAEAAACBAAAAgQAAAAEAAACBAAAAQQAAAIEAAABBAAAAgQAAAIEAAAABAAAAgQAAAIEAAACBAAAAQQAAAIEAAAABAAAAQQAAAIEAAAABAAAAAQAAAAEAAABBAAAAgQAAAAEAAABBAAAAQQAAAEEAAAABAAAAQQAAAEEAAABBAAAAQ==
+    tiles: VQAAAVgAAABYAAAAWAAAAEEAAABYAAAAIgAAACIAAAAiAAAAIgAAACIAAABYAAAAWAAAAFgAAABYAAAAWAAAAFUAAAJYAAAAPgAAAD4AAAI+AAABWAAAACIAAAAiAAAAIgAAACIAAAAiAAAAWAAAAAQAAAAEAAABBAAAAQQAAABVAAADWAAAAD4AAAI+AAAAPgAAA1gAAAAiAAAAIgAAACIAAAAiAAAAIgAAAFgAAAAEAAABBAAAAAQAAAAEAAACWAAAAFgAAAA+AAACPgAAAT4AAAFYAAAAIgAAACIAAAAiAAAAIgAAACIAAABYAAAAWAAAAFgAAABYAAAAWAAAAFgAAABYAAAAWAAAAFgAAABYAAAAWAAAAFgAAABYAAAAWAAAAFgAAABYAAAAWAAAAEgAAABIAAAASAAAAEgAAABYAAAAWAAAAFgAAABYAAAAWAAAAFgAAABYAAAAWAAAAFgAAABYAAAAWAAAAFgAAABYAAAAWAAAAFgAAABYAAAABAAAAlgAAABIAAAASAAAAEgAAABIAAAASAAAAEgAAABIAAAASAAAAEgAAABYAAAAWAAAAFgAAABYAAAAWAAAAAQAAAFYAAAAWAAAAFgAAABYAAAAWAAAAFgAAABYAAAAWAAAAFgAAABYAAAAWAAAAAQAAAIEAAAABAAAAQQAAAIEAAABBAAAAgQAAAAEAAACBAAAAAQAAAEEAAACBAAAAQQAAAIEAAACBAAAAAQAAAAEAAABBAAAAAQAAAAEAAABBAAAAgQAAAIEAAABBAAAAgQAAAIEAAABBAAAAAQAAAEEAAACBAAAAgQAAAEEAAAABAAAAgQAAAIEAAABLwAAAAQAAAIEAAAABAAAAQQAAAAEAAACBAAAAAQAAAAEAAACBAAAAQQAAAIEAAABBAAAAAQAAAEEAAACBAAAAi8AAAAEAAABBAAAAQQAAAEEAAACBAAAAgQAAAIEAAAABAAAAgQAAAIEAAABBAAAAAQAAAIEAAABBAAAAgQAAAAvAAAABAAAAgQAAAIEAAABBAAAAAQAAAEEAAACBAAAAgQAAAIEAAABBAAAAQQAAAIEAAAABAAAAgQAAAEEAAACBAAAAQQAAAIEAAAABAAAAgQAAAEEAAAABAAAAAQAAAEEAAAABAAAAAQAAAIEAAACBAAAAAQAAAAEAAAABAAAAQQAAAAEAAACBAAAAgQAAAAEAAACBAAAAQQAAAIEAAABBAAAAgQAAAIEAAAABAAAAgQAAAIEAAACBAAAAQQAAAIEAAAABAAAAQQAAAIEAAAABAAAAAQAAAAEAAABBAAAAgQAAAAEAAABBAAAAQQAAAEEAAAABAAAAQQAAAEEAAABBAAAAQ==
   - ind: 0,-1
     tiles: WAAAAEgAAABIAAAASAAAAFgAAABYAAAAWAAAAFgAAABYAAAABAAAAQQAAAAEAAAAAAAAAAAAAAA+AAACSwAAAVgAAABYAAAASAAAAEgAAABYAAAASAAAAEgAAABYAAAAWAAAAAQAAAAEAAABAAAAAAAAAAAAAAAAPgAAAFgAAABYAAAAWAAAAEgAAABYAAAAWAAAAFgAAABIAAAASAAAAFgAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAD4AAAFLAAADPgAAAlgAAABIAAAAWAAAAFgAAABYAAAAWAAAAFgAAABYAAAABAAAAAAAAAAAAAAAAAAAAAAAAABYAAAASwAAAj4AAANYAAAAWAAAAFgAAABYAAAAWAAAAFgAAABYAAAAWAAAAFgAAABYAAAAWAAAAFgAAABYAAAAWAAAAFgAAAA+AAABPgAAAz4AAAA+AAABPgAAAj4AAAM+AAAAPgAAAD4AAAI+AAACPgAAAT4AAAA+AAACPgAAAT4AAAI+AAAAPgAAAz4AAAA+AAABPgAAAz4AAAM+AAADPgAAAT4AAAM+AAABPgAAAD4AAAA+AAABPgAAAz4AAAI+AAABPgAAAT4AAAA+AAAAPgAAAj4AAAA+AAABPgAAAz4AAAM+AAADPgAAAj4AAAI+AAAAPgAAAz4AAAI+AAADPgAAAT4AAAEfAAACWAAAAD4AAAArAAAAPgAAAVgAAABYAAAAKwAAACsAAABYAAAAPgAAAz4AAAM+AAADWAAAAFgAAAA+AAACHwAAAR8AAAEfAAAAHwAAAx8AAAAfAAACWAAAACsAAAArAAAAWAAAAAAAAAAAAAAAAAAAAAAAAABYAAAAWAAAAB8AAAEfAAACHwAAAh8AAAIfAAACHwAAAlgAAAArAAAAKwAAACsAAAAAAAAAAAAAAAAAAAAAAAAAPgAAAxEAAAAfAAABWAAAAFgAAABYAAAAWAAAAFgAAABYAAAAKwAAACsAAAArAAAAAAAAAAAAAAAAAAAAAAAAAD4AAAIRAAAAHwAAAB8AAAMrAAAAKwAAACsAAAArAAAAKwAAACsAAAArAAAAWAAAAAAAAAAAAAAAAAAAAAAAAABYAAAAEQAAAC8AAAAvAAAAKwAAACsAAAArAAAAKwAAACsAAAArAAAAKwAAACsAAAAAAAAAAAAAAAAAAAAAAAAAPgAAABEAAAAvAAAALwAAACsAAAArAAAAKwAAACsAAAArAAAAKwAAACsAAAArAAAAAAAAAAAAAAAAAAAAAAAAAD4AAAMRAAAAHwAAAx8AAAArAAAAKwAAACsAAAArAAAAKwAAACsAAAArAAAAWAAAAFgAAABYAAAAWAAAAFgAAABYAAAAEQAAAA==
   - ind: 0,0
@@ -156,9 +156,9 @@ grids:
   - ind: -2,-3
     tiles: NAAAADMAAAA0AAAAWAAAADQAAAAzAAAAMwAAADMAAAAzAAAANAAAAFgAAAA0AAAARAAAAzQAAABYAAAAVgAAATQAAAAzAAAANAAAADQAAAA0AAAANAAAADQAAAA0AAAANAAAADQAAABYAAAANAAAAEQAAAFYAAAAWAAAAFYAAAA0AAAAMwAAADQAAABYAAAAWAAAAFgAAABYAAAAWAAAAFgAAABYAAAAWAAAADQAAABEAAABWAAAAFYAAABWAAACNAAAADQAAAA0AAAAWAAAAD4AAAM+AAAAPgAAAD4AAAE+AAADPgAAAlgAAAA0AAAARAAAA0QAAAFWAAABVgAAAVgAAABYAAAAWAAAAFgAAAA+AAACPgAAAT4AAAA+AAABPgAAAz4AAABYAAAANAAAAEQAAABYAAAAVgAAAVYAAANJAAAASQAAAD4AAAM+AAAAPgAAAD4AAAI+AAAAPgAAAD4AAAM+AAAAWAAAAD4AAANEAAACWAAAAFgAAABWAAABSQAAAEkAAAA+AAAAPgAAAT4AAAM+AAACPgAAAz4AAAA+AAADPgAAA1gAAAA0AAAARAAAATQAAABYAAAAVgAAA0kAAABJAAAAPgAAAz4AAAM+AAAAPgAAAz4AAAE+AAABPgAAAj4AAAJYAAAANAAAAEQAAAM0AAAAWAAAAFgAAABYAAAAWAAAAFgAAAA+AAADPgAAAz4AAAE+AAADPgAAAD4AAAI+AAACPgAAATQAAABEAAABNAAAAD4AAAI0AAAASQAAAEkAAAA+AAAAPgAAAD4AAAM+AAACPgAAAz4AAAA+AAADPgAAAUQAAAFEAAAARAAAA0QAAAFEAAACRAAAAUkAAABJAAAAWAAAAFgAAABYAAAAPgAAAj4AAAI+AAABWAAAAD4AAAJYAAAANAAAAEQAAAA0AAAAWAAAAFgAAABJAAAASQAAAEQAAANEAAABNAAAADQAAAA0AAAANAAAADQAAAA0AAAANAAAAEQAAAJEAAAARAAAA0QAAANEAAACSQAAAEkAAABYAAAARAAAAkQAAAFEAAAARAAAA0QAAANEAAABRAAAA0QAAAFEAAACNAAAADQAAABYAAAANAAAAFgAAABYAAAAWAAAADQAAABEAAADNAAAAFgAAAA+AAACPgAAAD4AAAM+AAABRAAAAD4AAAE+AAABWAAAAFgAAAAbAAAAGwAAAD4AAAI0AAAARAAAATQAAAA+AAADNAAAADQAAAA0AAAANAAAAEQAAAA0AAAANAAAAFgAAAA0AAAAGwAAABsAAAA+AAACNAAAAEQAAAE0AAAAPgAAA0QAAAFEAAABRAAAA0QAAANEAAADRAAAATQAAABYAAAANAAAAA==
   - ind: -1,-3
-    tiles: VgAAAVYAAANWAAABVgAAAFYAAAFWAAADVgAAA1YAAAJWAAAAVgAAA1YAAAJWAAADVgAAAEcAAABHAAAAPgAAAVYAAABWAAABVgAAAVYAAANWAAACVgAAA1YAAANWAAABVgAAAFYAAAFWAAADVgAAAFYAAAFHAAAARwAAAT4AAANWAAADVgAAA1YAAAJWAAADVgAAAlYAAANWAAADVgAAAlYAAANWAAABVgAAAFYAAAFWAAADRwAAAUcAAAM+AAACVgAAAVYAAAFWAAACVgAAA1YAAAFWAAAAVgAAA1YAAAJWAAAAVgAAAVYAAAFWAAAAVgAAAEcAAANHAAADPgAAA1YAAAFWAAADVgAAAFYAAAJWAAACVgAAAFYAAANWAAADVgAAA1YAAANWAAABVgAAAVYAAAFHAAADRwAAAz4AAAFWAAAAVgAAAFYAAAJWAAAAVgAAA1YAAAFWAAAAVgAAAFYAAAJWAAABVgAAA1YAAAFWAAACRwAAAEcAAAE+AAABVgAAAVYAAABWAAACVgAAAVYAAABWAAACVgAAA1YAAAFWAAADVgAAAFYAAABWAAACVgAAAUcAAAJHAAAAPgAAAlgAAABYAAAAWAAAAFgAAAA+AAABWAAAAD4AAAA+AAACWAAAAFgAAABYAAAAWAAAAFgAAABYAAAAWAAAAD4AAAI0AAAANAAAADQAAAA0AAAANAAAAD4AAAJEAAACNAAAADQAAAA0AAAANAAAADQAAAA0AAAANAAAAFgAAABYAAAARAAAAkQAAAJEAAAARAAAA0QAAAJEAAADRAAAAkQAAAJEAAADRAAAAkQAAAJEAAABRAAAAzQAAAA0AAAANAAAAFgAAABYAAAAWAAAAFgAAABYAAAAWAAAADQAAABEAAADRAAAAkQAAAFEAAADRAAAA0QAAAFEAAABRAAAAkQAAAFEAAACRAAAAUQAAABEAAACRAAAA0QAAAFEAAACRAAAAEQAAAJEAAABRAAAA0QAAAJEAAACNAAAADQAAAA0AAAANAAAADQAAAA0AAAANAAAADQAAABYAAAARAAAADQAAAA0AAAANAAAAEQAAAE0AAAANAAAADQAAABYAAAAWAAAAFgAAABYAAAAWAAAAFgAAABYAAAAWAAAABsAAABYAAAAWAAAAFgAAAAbAAAAWAAAAFgAAABYAAAAWAAAAD4AAAM0AAAAWAAAABsAAAAbAAAAGwAAABsAAAAbAAAAGwAAABsAAAAbAAAAGwAAABsAAAAbAAAAGwAAAFgAAAA+AAAAWAAAAFgAAAAbAAAAGwAAABsAAAAbAAAAGwAAABsAAABYAAAAGwAAABsAAAAbAAAAGwAAABsAAAAbAAAAPgAAAA==
+    tiles: VgAAAVYAAANWAAABVgAAAFYAAAFWAAADVgAAA1YAAAJWAAAAVgAAA1YAAAJWAAADVgAAAEcAAABHAAAAPgAAAVYAAABWAAABVgAAAVYAAANWAAACVgAAA1YAAANWAAABVgAAAFYAAAFWAAADVgAAAFYAAAFHAAAARwAAAT4AAANWAAADVgAAA1YAAAJWAAADVgAAAlYAAANWAAADVgAAAlYAAANWAAABVgAAAFYAAAFWAAADRwAAAUcAAAM+AAACVgAAAVYAAAFWAAACVgAAA1YAAAFWAAAAVgAAA1YAAAJWAAAAVgAAAVYAAAFWAAAAVgAAAEcAAANHAAADPgAAA1YAAAFWAAADVgAAAFYAAAJWAAACVgAAAFYAAANWAAADVgAAA1YAAANWAAABVgAAAVYAAAFHAAADRwAAAz4AAAFWAAAAVgAAAFYAAAJWAAAAVgAAA1YAAAFWAAAAVgAAAFYAAAJWAAABVgAAA1YAAAFWAAACRwAAAEcAAAE+AAABVgAAAVYAAABWAAACVgAAAVYAAABWAAACVgAAA1YAAAFWAAADVgAAAFYAAABWAAACVgAAAUcAAAJHAAAAPgAAAlgAAABYAAAAWAAAAFgAAAA+AAABWAAAAD4AAAA+AAACWAAAAFgAAABYAAAAWAAAAFgAAABYAAAAWAAAAD4AAAI0AAAANAAAADQAAAA0AAAANAAAAD4AAAJEAAACNAAAADQAAAA0AAAANAAAADQAAAA0AAAANAAAAFgAAAA0AAAARAAAAkQAAAJEAAAARAAAA0QAAAJEAAADRAAAAkQAAAJEAAADRAAAAkQAAAJEAAABRAAAAzQAAAA0AAAANAAAAFgAAABYAAAAWAAAAFgAAABYAAAAWAAAADQAAABEAAADRAAAAkQAAAFEAAADRAAAA0QAAAFEAAABRAAAAkQAAAFEAAACRAAAAUQAAABEAAACRAAAA0QAAAFEAAACRAAAAEQAAAJEAAABRAAAA0QAAAJEAAACNAAAADQAAAA0AAAANAAAADQAAAA0AAAANAAAADQAAABYAAAARAAAADQAAAA0AAAANAAAAEQAAAE0AAAANAAAADQAAABYAAAAWAAAAFgAAABYAAAAWAAAAFgAAABYAAAAWAAAABsAAABYAAAAWAAAAFgAAAAbAAAAWAAAAFgAAABYAAAAWAAAAD4AAAM0AAAAWAAAABsAAAAbAAAAGwAAABsAAAAbAAAAGwAAABsAAAAbAAAAGwAAABsAAAAbAAAAGwAAAFgAAAA+AAAAWAAAAFgAAAAbAAAAGwAAABsAAAAbAAAAGwAAABsAAABYAAAAGwAAABsAAAAbAAAAGwAAABsAAAAbAAAAPgAAAA==
   - ind: 0,-3
-    tiles: PgAAAj4AAAA+AAABPgAAAj4AAAI+AAAAPgAAAz4AAAA+AAABPgAAAz4AAAA+AAAAPgAAAT4AAAI+AAAAPgAAAT4AAAM+AAAAPgAAAj4AAAE+AAAAPgAAAj4AAAI+AAACPgAAAD4AAAI+AAACPgAAAD4AAAI+AAABPgAAAT4AAAA+AAAAPgAAAz4AAAAmAAABJgAAACYAAAAmAAABJgAAAyYAAAMmAAACJgAAAiYAAAImAAABJgAAAyYAAAMmAAABPgAAAT4AAAM+AAACJgAAACYAAAAmAAABJgAAAyYAAAMmAAADJgAAAyYAAAImAAAAJgAAAyYAAAEmAAAAJgAAAz4AAAM+AAADPgAAACYAAAMmAAADJgAAAyYAAAEmAAAAJgAAAyYAAAAmAAACJgAAAyYAAAMmAAADJgAAACYAAAI+AAAAPgAAAT4AAAA+AAACPgAAAD4AAAA+AAADPgAAAT4AAAI+AAACPgAAAj4AAAM+AAABPgAAAj4AAAA+AAADPgAAAD4AAAI+AAABPgAAAz4AAAI+AAABPgAAAj4AAAM+AAADPgAAAT4AAAM+AAADPgAAAz4AAAA+AAADPgAAAT4AAAA+AAAAPgAAAVgAAABYAAAAWAAAAFgAAABYAAAAWAAAAFgAAABYAAAAWAAAAFgAAAA+AAABWAAAAFgAAAA+AAACRAAAAz4AAANYAAAASwAAAEsAAAJLAAABSwAAA0sAAAE1AAAANQAAADUAAAA1AAAANQAAADUAAAA1AAAANAAAAEQAAAA0AAAAWAAAAEsAAAFLAAABSwAAAksAAANLAAAANQAAADUAAAA1AAAANQAAADUAAAA1AAAANQAAAEQAAANEAAAANAAAAFgAAABLAAADSwAAA0sAAABLAAAASwAAAzUAAAA1AAAANQAAADUAAAA1AAAANQAAADUAAAA0AAAARAAAAjQAAABYAAAASwAAAEsAAAFLAAAASwAAAksAAAA1AAAANQAAADUAAAA1AAAANQAAADUAAAA1AAAAWAAAAEQAAAFYAAAAWAAAAFgAAABYAAAAPgAAAD4AAAA+AAAAWAAAAD4AAAM+AAAAPgAAAj4AAAM+AAACPgAAAj4AAAI+AAACPgAAAD4AAAA+AAAAWAAAAAAAAAAAAAAAAAAAAFgAAABLAAADSwAAAUsAAABLAAADSwAAAUsAAAI+AAAAPgAAAj4AAAI+AAAAPgAAAVgAAAAAAAAAAAAAAAAAAABYAAAADQAAAA0AAAANAAAADQAAAEsAAAFLAAAAPgAAAT4AAAM+AAABPgAAAj4AAABYAAAAAAAAAAAAAAAAAAAAWAAAAA0AAAANAAAADQAAAA0AAABLAAAASwAAAw==
+    tiles: PgAAAj4AAAA+AAABPgAAAj4AAAI+AAAAPgAAAz4AAAA+AAABPgAAAz4AAAA+AAAAPgAAAT4AAAI+AAAAPgAAAT4AAAM+AAAAPgAAAj4AAAE+AAAAPgAAAj4AAAI+AAACPgAAAD4AAAI+AAACPgAAAD4AAAI+AAABPgAAAT4AAAA+AAAAPgAAAz4AAAAmAAABJgAAACYAAAAmAAABJgAAAyYAAAMmAAACJgAAAiYAAAImAAABJgAAAyYAAAMmAAABPgAAAT4AAAM+AAACJgAAACYAAAAmAAABJgAAAyYAAAMmAAADJgAAAyYAAAImAAAAJgAAAyYAAAEmAAAAJgAAAz4AAAM+AAADPgAAACYAAAMmAAADJgAAAyYAAAEmAAAAJgAAAyYAAAAmAAACJgAAAyYAAAMmAAADJgAAACYAAAI+AAAAPgAAAT4AAAA+AAACPgAAAD4AAAA+AAADPgAAAT4AAAI+AAACPgAAAj4AAAM+AAABPgAAAj4AAAA+AAADPgAAAD4AAAI+AAABPgAAAz4AAAI+AAABPgAAAj4AAAM+AAADPgAAAT4AAAM+AAADPgAAAz4AAAA+AAADPgAAAT4AAAA+AAAAPgAAAVgAAABYAAAAWAAAAFgAAABYAAAAWAAAAFgAAABYAAAAWAAAAFgAAAA+AAABWAAAAFgAAAA0AAAARAAAAzQAAABYAAAASwAAAEsAAAJLAAABSwAAA0sAAAE1AAAANQAAADUAAAA1AAAANQAAADUAAAA1AAAANAAAAEQAAAA0AAAAWAAAAEsAAAFLAAABSwAAAksAAANLAAAANQAAADUAAAA1AAAANQAAADUAAAA1AAAANQAAAEQAAANEAAAANAAAAFgAAABLAAADSwAAA0sAAABLAAAASwAAAzUAAAA1AAAANQAAADUAAAA1AAAANQAAADUAAAA0AAAARAAAAjQAAABYAAAASwAAAEsAAAFLAAAASwAAAksAAAA1AAAANQAAADUAAAA1AAAANQAAADUAAAA1AAAAWAAAAEQAAAFYAAAAWAAAAFgAAABYAAAAPgAAAD4AAAA+AAAAWAAAAD4AAAM+AAAAPgAAAj4AAAM+AAACPgAAAj4AAAI+AAACPgAAAD4AAAA+AAAAWAAAAAAAAAAAAAAAAAAAAFgAAABLAAADSwAAAUsAAABLAAADSwAAAUsAAAI+AAAAPgAAAj4AAAI+AAAAPgAAAVgAAAAAAAAAAAAAAAAAAABYAAAADQAAAA0AAAANAAAADQAAAEsAAAFLAAAAPgAAAT4AAAM+AAABPgAAAj4AAABYAAAAAAAAAAAAAAAAAAAAWAAAAA0AAAANAAAADQAAAA0AAABLAAAASwAAAw==
   - ind: 1,-3
     tiles: PgAAAj4AAAA+AAADPgAAAT4AAAI+AAADPgAAAT4AAAM+AAAAPgAAAD4AAAE+AAAAPgAAAD4AAAM+AAACPgAAAD4AAAA+AAADPgAAAD4AAAE+AAABPgAAAj4AAAE+AAABPgAAAD4AAAM+AAACPgAAAj4AAAE+AAABPgAAAz4AAAImAAAAJgAAACYAAAImAAABJgAAASYAAAAmAAACJgAAAj4AAAM+AAAAPgAAAD4AAAE+AAABPgAAAz4AAAE+AAACJgAAAiYAAAMmAAACJgAAAyYAAAMmAAAAJgAAAyYAAAM+AAACPgAAADYAAAA2AAAANgAAAD4AAAE+AAADPgAAAiYAAAEmAAADJgAAAyYAAAAmAAABJgAAASYAAAMmAAABPgAAAj4AAAM2AAAANgAAADYAAAA+AAACPgAAAT4AAAM+AAACPgAAAD4AAAE+AAAAPgAAAz4AAAM+AAABPgAAAD4AAAE+AAABPgAAAj4AAAM+AAADPgAAAz4AAAE+AAADPgAAAj4AAAE+AAAAPgAAAD4AAAE+AAABPgAAAD4AAAM+AAADPgAAAD4AAAA+AAADPgAAAD4AAAI+AAAAPgAAA1gAAABYAAAAWAAAAFgAAABYAAAAWAAAAD4AAAA+AAABPgAAAz4AAAE+AAADPgAAAD4AAAE+AAACPgAAAD4AAAE1AAAANQAAADUAAAA1AAAANQAAAFgAAABYAAAAWAAAAFgAAABYAAAAWAAAAFgAAABHAAACRwAAAkcAAAFHAAAANQAAADUAAAA1AAAANQAAADUAAABYAAAAFQAAAhUAAAMVAAADFQAAAhUAAAM+AAABRwAAA0cAAANHAAAARwAAAzUAAAA1AAAANQAAADUAAAA1AAAAFQAAAhUAAAAVAAABFQAAAhUAAAAVAAABFQAAAUcAAABHAAABRwAAA0cAAAM1AAAANQAAADUAAAA1AAAANQAAAFgAAAAVAAACFQAAARUAAAEVAAABFQAAAj4AAAFHAAACRwAAAEcAAAJHAAABPgAAA1gAAABYAAAAPgAAA1gAAABYAAAAWAAAAFgAAAAVAAACFQAAARUAAAJYAAAARwAAA0cAAAFHAAACRwAAAksAAAFYAAAASwAAAEsAAABLAAABSwAAAUsAAANYAAAAFQAAARUAAAEVAAACPgAAA0cAAABHAAAARwAAA0IAAABLAAABSwAAAEsAAANLAAADSwAAA0sAAABLAAACFQAAAhUAAAIVAAACFQAAAz4AAANHAAADRwAAA0cAAANHAAACSwAAAlgAAABLAAAASwAAA0sAAAJLAAADSwAAA1gAAAAVAAABFQAAAhUAAAI+AAACQgAAAUYAAAJGAAACQgAAAA==
   - ind: 0,2
@@ -25105,12 +25105,12 @@ entities:
       8,-29: 0
       8,-28: 0
       8,-27: 0
-      8,-26: 1
+      8,-26: 8
       8,-25: 0
       8,-24: 0
       8,-23: 0
       8,-22: 0
-      8,-21: 1
+      8,-21: 8
       8,-20: 0
       9,-30: 0
       9,-29: 0
@@ -25433,7 +25433,7 @@ entities:
       17,-40: 0
       17,-39: 0
       17,-38: 0
-      17,-37: 8
+      17,-37: 9
       17,-36: 0
       18,-44: 0
       18,-43: 0
@@ -25442,7 +25442,7 @@ entities:
       18,-40: 0
       18,-39: 0
       18,-38: 0
-      18,-37: 8
+      18,-37: 9
       18,-36: 0
       18,-35: 0
       18,-34: 0
@@ -32923,9 +32923,9 @@ entities:
       36,37: 0
       36,38: 0
       36,39: 0
-      36,40: 9
-      36,41: 9
-      36,42: 9
+      36,40: 10
+      36,41: 10
+      36,42: 10
       36,43: 0
       36,44: 0
       37,35: 0
@@ -32943,9 +32943,9 @@ entities:
       38,37: 0
       38,38: 0
       38,39: 0
-      38,40: 10
-      38,41: 10
-      38,42: 10
+      38,40: 11
+      38,41: 11
+      38,42: 11
       38,43: 0
       38,44: 0
       39,35: 0
@@ -32966,9 +32966,9 @@ entities:
       40,37: 0
       40,38: 0
       40,39: 0
-      40,40: 11
-      40,41: 11
-      40,42: 11
+      40,40: 12
+      40,41: 12
+      40,42: 12
       40,43: 0
       40,44: 0
       41,32: 0
@@ -32992,9 +32992,9 @@ entities:
       42,37: 0
       42,38: 0
       42,39: 0
-      42,40: 12
-      42,41: 12
-      42,42: 12
+      42,40: 13
+      42,41: 13
+      42,42: 13
       42,43: 0
       42,44: 0
       43,32: 0
@@ -33018,9 +33018,9 @@ entities:
       44,37: 0
       44,38: 0
       44,39: 0
-      44,40: 12
-      44,41: 12
-      44,42: 12
+      44,40: 13
+      44,41: 13
+      44,42: 13
       44,43: 0
       44,44: 0
       45,32: 0
@@ -33044,9 +33044,9 @@ entities:
       46,37: 0
       46,38: 0
       46,39: 0
-      46,40: 12
-      46,41: 12
-      46,42: 12
+      46,40: 13
+      46,41: 13
+      46,42: 13
       46,43: 0
       46,44: 0
       47,32: 0
@@ -33371,9 +33371,9 @@ entities:
       48,37: 0
       48,38: 0
       48,39: 0
-      48,40: 12
-      48,41: 12
-      48,42: 12
+      48,40: 13
+      48,41: 13
+      48,42: 13
       48,43: 0
       48,44: 0
       49,32: 0
@@ -33518,11 +33518,11 @@ entities:
       53,48: 0
       53,49: 0
       53,50: 0
-      53,51: 13
+      53,51: 14
       54,48: 0
       54,49: 0
       54,50: 0
-      54,51: 13
+      54,51: 14
       55,48: 0
       55,49: 0
       55,50: 0
@@ -35414,14 +35414,14 @@ entities:
       -21,-85: 0
       -21,-84: 0
       -21,-83: 0
-      -20,-89: 14
+      -20,-89: 15
       -20,-88: 0
       -20,-87: 0
       -20,-86: 0
       -20,-85: 0
       -20,-84: 0
-      -19,-91: 15
-      -19,-90: 15
+      -19,-91: 16
+      -19,-90: 16
       -19,-89: 0
       -19,-88: 0
       -19,-87: 0
@@ -35695,86 +35695,86 @@ entities:
       -97,-24: 0
       -97,-23: 0
       -97,-22: 0
-      14,6: 12
-      14,7: 12
-      15,6: 12
-      15,7: 12
-      16,4: 12
-      16,5: 12
-      16,6: 12
-      16,7: 12
-      17,4: 12
-      17,5: 12
-      17,6: 12
-      17,7: 12
-      13,55: 12
-      13,56: 12
-      13,57: 12
-      14,57: 12
-      15,57: 12
-      -48,18: 12
-      -47,18: 12
-      -46,18: 12
-      -45,18: 12
-      -44,18: 12
-      -43,18: 12
-      -42,17: 12
-      -42,18: 12
-      -42,19: 12
-      -41,17: 12
-      -41,18: 12
-      -41,19: 12
-      -40,17: 12
-      -40,18: 12
-      -40,19: 12
-      -7,-101: 12
-      -7,-100: 12
-      -6,-101: 12
-      -5,-101: 12
-      40,-101: 12
-      41,-101: 12
-      42,-101: 12
-      42,-100: 12
-      -56,18: 12
-      -55,18: 12
-      -54,18: 12
-      -53,18: 12
-      -52,18: 12
-      -51,18: 12
-      -50,18: 12
-      -49,18: 12
-      45,57: 12
-      46,57: 12
-      47,57: 12
-      16,57: 12
-      -77,-44: 12
-      -77,-43: 12
-      -77,-42: 12
-      -76,-44: 12
-      -76,-43: 12
-      -75,-44: 12
-      -75,-43: 12
-      16,-80: 12
-      16,-79: 12
-      17,-80: 12
-      17,-79: 12
-      18,-80: 12
-      18,-79: 12
-      18,-78: 12
-      19,-79: 12
-      19,-78: 12
-      20,-79: 12
-      20,-78: 12
-      11,-79: 12
-      11,-78: 12
-      12,-79: 12
-      12,-78: 12
-      13,-80: 12
-      13,-79: 12
-      14,-80: 12
-      14,-79: 12
-      15,-80: 12
-      15,-79: 12
+      14,6: 13
+      14,7: 13
+      15,6: 13
+      15,7: 13
+      16,4: 13
+      16,5: 13
+      16,6: 13
+      16,7: 13
+      17,4: 13
+      17,5: 13
+      17,6: 13
+      17,7: 13
+      13,55: 13
+      13,56: 13
+      13,57: 13
+      14,57: 13
+      15,57: 13
+      -48,18: 13
+      -47,18: 13
+      -46,18: 13
+      -45,18: 13
+      -44,18: 13
+      -43,18: 13
+      -42,17: 13
+      -42,18: 13
+      -42,19: 13
+      -41,17: 13
+      -41,18: 13
+      -41,19: 13
+      -40,17: 13
+      -40,18: 13
+      -40,19: 13
+      -7,-101: 13
+      -7,-100: 13
+      -6,-101: 13
+      -5,-101: 13
+      40,-101: 13
+      41,-101: 13
+      42,-101: 13
+      42,-100: 13
+      -56,18: 13
+      -55,18: 13
+      -54,18: 13
+      -53,18: 13
+      -52,18: 13
+      -51,18: 13
+      -50,18: 13
+      -49,18: 13
+      45,57: 13
+      46,57: 13
+      47,57: 13
+      16,57: 13
+      -77,-44: 13
+      -77,-43: 13
+      -77,-42: 13
+      -76,-44: 13
+      -76,-43: 13
+      -75,-44: 13
+      -75,-43: 13
+      16,-80: 13
+      16,-79: 13
+      17,-80: 13
+      17,-79: 13
+      18,-80: 13
+      18,-79: 13
+      18,-78: 13
+      19,-79: 13
+      19,-78: 13
+      20,-79: 13
+      20,-78: 13
+      11,-79: 13
+      11,-78: 13
+      12,-79: 13
+      12,-78: 13
+      13,-80: 13
+      13,-79: 13
+      14,-80: 13
+      14,-79: 13
+      15,-80: 13
+      15,-79: 13
     uniqueMixes:
     - volume: 2500
       temperature: 293.15
@@ -35794,8 +35794,8 @@ entities:
     - volume: 2500
       temperature: 293.15
       moles:
-      - 13.467232
-      - 50.662445
+      - 12.723625
+      - 47.865067
       - 0
       - 0
       - 0
@@ -35824,8 +35824,8 @@ entities:
     - volume: 2500
       temperature: 235
       moles:
-      - 13.467232
-      - 50.662445
+      - 12.723625
+      - 47.865067
       - 0
       - 0
       - 0
@@ -35884,8 +35884,23 @@ entities:
     - volume: 2500
       temperature: 293.15
       moles:
-      - 15.969111
-      - 60.07428
+      - 15.087361
+      - 56.757217
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+      - 0
+    - volume: 2500
+      temperature: 293.15
+      moles:
+      - 12.367364
+      - 46.524845
       - 0
       - 0
       - 0
@@ -35989,8 +36004,8 @@ entities:
     - volume: 2500
       temperature: 293.15
       moles:
-      - 16.902393
-      - 63.585197
+      - 15.969111
+      - 60.07428
       - 0
       - 0
       - 0
@@ -36758,7 +36773,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 122
-  type: WallReinforced
+  type: Grille
   components:
   - pos: 4.5,-29.5
     parent: 0
@@ -37860,7 +37875,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 302
-  type: AirlockMedicalGlass
+  type: AirlockMedicalGlassLocked
   components:
   - pos: 14.5,-23.5
     parent: 0
@@ -37907,7 +37922,7 @@ entities:
   - pos: 12.5,-24.5
     parent: 0
     type: Transform
-  - SecondsUntilStateChange: -193421.77
+  - SecondsUntilStateChange: -197859.64
     state: Opening
     type: Door
 - uid: 310
@@ -37917,7 +37932,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 311
-  type: AirlockMedicalGlass
+  type: AirlockMedicalGlassLocked
   components:
   - pos: 14.5,-25.5
     parent: 0
@@ -39551,16 +39566,12 @@ entities:
     parent: 0
     type: Transform
 - uid: 578
-  type: SurveillanceWirelessCameraAnchoredEntertainment
+  type: ComputerSurveillanceWirelessCameraMonitor
   components:
-  - pos: -8.5,-17.5
+  - rot: 3.141592653589793 rad
+    pos: -8.5,-17.5
     parent: 0
     type: Transform
-  - setupAvailableNetworks:
-    - SurveillanceCameraEntertainment
-    nameSet: True
-    id: Fan Side Arena
-    type: SurveillanceCamera
 - uid: 579
   type: WallReinforced
   components:
@@ -40091,9 +40102,9 @@ entities:
     parent: 0
     type: Transform
 - uid: 663
-  type: ReinforcedWindow
+  type: ClosetBase
   components:
-  - pos: 0.5,-39.5
+  - pos: 8.5,-20.5
     parent: 0
     type: Transform
 - uid: 664
@@ -40216,9 +40227,10 @@ entities:
     parent: 0
     type: Transform
 - uid: 683
-  type: WardrobePrisonFilled
+  type: EmergencyLight
   components:
-  - pos: 8.5,-25.5
+  - rot: -1.5707963267948966 rad
+    pos: 2.5,-36.5
     parent: 0
     type: Transform
 - uid: 684
@@ -40357,15 +40369,15 @@ entities:
     parent: 0
     type: Transform
 - uid: 706
-  type: ReinforcedWindow
+  type: WallReinforced
   components:
-  - pos: 2.5,-39.5
+  - pos: 2.5,-29.5
     parent: 0
     type: Transform
 - uid: 707
-  type: AirlockBrigGlassLocked
+  type: ClosetBase
   components:
-  - pos: 1.5,-39.5
+  - pos: 8.5,-25.5
     parent: 0
     type: Transform
 - uid: 708
@@ -40682,11 +40694,14 @@ entities:
     parent: 0
     type: Transform
 - uid: 760
-  type: WallReinforced
+  type: Poweredlight
   components:
-  - pos: 2.5,-29.5
+  - rot: -1.5707963267948966 rad
+    pos: 2.5,-36.5
     parent: 0
     type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
 - uid: 761
   type: WallReinforced
   components:
@@ -41769,7 +41784,7 @@ entities:
     type: Transform
   - canCollide: False
     type: Physics
-  - SecondsUntilStateChange: -71835.734
+  - SecondsUntilStateChange: -76273.6
     state: Closing
     type: Door
   - airBlocked: False
@@ -42892,7 +42907,7 @@ entities:
     type: Transform
   - canCollide: False
     type: Physics
-  - SecondsUntilStateChange: -71835.734
+  - SecondsUntilStateChange: -76273.6
     state: Closing
     type: Door
   - airBlocked: False
@@ -42932,7 +42947,7 @@ entities:
     type: Transform
   - canCollide: False
     type: Physics
-  - SecondsUntilStateChange: -71833.23
+  - SecondsUntilStateChange: -76271.09
     state: Closing
     type: Door
   - airBlocked: False
@@ -42954,7 +42969,7 @@ entities:
     type: Transform
   - canCollide: False
     type: Physics
-  - SecondsUntilStateChange: -71833.23
+  - SecondsUntilStateChange: -76271.09
     state: Closing
     type: Door
   - airBlocked: False
@@ -45824,9 +45839,9 @@ entities:
     parent: 0
     type: Transform
 - uid: 1567
-  type: WardrobePrisonFilled
+  type: Grille
   components:
-  - pos: 8.5,-20.5
+  - pos: -4.5,-40.5
     parent: 0
     type: Transform
 - uid: 1568
@@ -47047,13 +47062,13 @@ entities:
 - uid: 1753
   type: Grille
   components:
-  - pos: 0.5,-39.5
+  - pos: -5.5,-40.5
     parent: 0
     type: Transform
 - uid: 1754
   type: Grille
   components:
-  - pos: 2.5,-39.5
+  - pos: -6.5,-40.5
     parent: 0
     type: Transform
 - uid: 1755
@@ -47065,9 +47080,10 @@ entities:
     parent: 0
     type: Transform
 - uid: 1756
-  type: WallReinforced
+  type: WindowReinforcedDirectional
   components:
-  - pos: -0.5,-39.5
+  - rot: 3.141592653589793 rad
+    pos: -3.5,-38.5
     parent: 0
     type: Transform
 - uid: 1757
@@ -47138,15 +47154,17 @@ entities:
     parent: 0
     type: Transform
 - uid: 1768
-  type: WallReinforced
+  type: WindoorSecurityLocked
   components:
-  - pos: -6.5,-40.5
+  - rot: 3.141592653589793 rad
+    pos: -4.5,-38.5
     parent: 0
     type: Transform
 - uid: 1769
-  type: WallReinforced
+  type: WindoorSecurityLocked
   components:
-  - pos: -5.5,-40.5
+  - rot: 3.141592653589793 rad
+    pos: -5.5,-38.5
     parent: 0
     type: Transform
 - uid: 1770
@@ -47156,9 +47174,10 @@ entities:
     parent: 0
     type: Transform
 - uid: 1771
-  type: WallReinforced
+  type: WindowReinforcedDirectional
   components:
-  - pos: -4.5,-40.5
+  - rot: 1.5707963267948966 rad
+    pos: -7.5,-38.5
     parent: 0
     type: Transform
 - uid: 1772
@@ -51436,7 +51455,7 @@ entities:
   - pos: 27.5,-32.5
     parent: 0
     type: Transform
-  - SecondsUntilStateChange: -193557.69
+  - SecondsUntilStateChange: -197995.56
     state: Opening
     type: Door
   - inputs:
@@ -51454,7 +51473,7 @@ entities:
   - pos: 27.5,-33.5
     parent: 0
     type: Transform
-  - SecondsUntilStateChange: -193557.69
+  - SecondsUntilStateChange: -197995.56
     state: Opening
     type: Door
   - inputs:
@@ -51472,7 +51491,7 @@ entities:
   - pos: 27.5,-34.5
     parent: 0
     type: Transform
-  - SecondsUntilStateChange: -193557.69
+  - SecondsUntilStateChange: -197995.56
     state: Opening
     type: Door
   - inputs:
@@ -51490,7 +51509,7 @@ entities:
   - pos: 27.5,-36.5
     parent: 0
     type: Transform
-  - SecondsUntilStateChange: -193557.69
+  - SecondsUntilStateChange: -197995.56
     state: Opening
     type: Door
   - inputs:
@@ -51508,7 +51527,7 @@ entities:
   - pos: 27.5,-38.5
     parent: 0
     type: Transform
-  - SecondsUntilStateChange: -193557.69
+  - SecondsUntilStateChange: -197995.56
     state: Opening
     type: Door
   - inputs:
@@ -57139,9 +57158,10 @@ entities:
     parent: 0
     type: Transform
 - uid: 3369
-  type: WindoorSecurityLocked
+  type: WindowReinforcedDirectional
   components:
-  - pos: -5.5,-37.5
+  - rot: 3.141592653589793 rad
+    pos: -2.5,-38.5
     parent: 0
     type: Transform
 - uid: 3370
@@ -57736,10 +57756,9 @@ entities:
     parent: 0
     type: Transform
 - uid: 3465
-  type: WindowReinforcedDirectional
+  type: DisposalUnit
   components:
-  - rot: -1.5707963267948966 rad
-    pos: -6.5,-39.5
+  - pos: -0.5,-39.5
     parent: 0
     type: Transform
 - uid: 3466
@@ -57763,20 +57782,21 @@ entities:
 - uid: 3469
   type: WindowReinforcedDirectional
   components:
-  - pos: -3.5,-37.5
+  - rot: 3.141592653589793 rad
+    pos: -6.5,-38.5
     parent: 0
     type: Transform
 - uid: 3470
   type: WindowReinforcedDirectional
   components:
-  - rot: -1.5707963267948966 rad
-    pos: -6.5,-38.5
+  - rot: 1.5707963267948966 rad
+    pos: -7.5,-39.5
     parent: 0
     type: Transform
 - uid: 3471
-  type: WindowReinforcedDirectional
+  type: RandomArtifactSpawner20
   components:
-  - pos: -6.5,-37.5
+  - pos: -20.5,-79.5
     parent: 0
     type: Transform
 - uid: 3472
@@ -57786,10 +57806,9 @@ entities:
     parent: 0
     type: Transform
 - uid: 3473
-  type: WindoorSecure
+  type: DisposalBend
   components:
-  - rot: -1.5707963267948966 rad
-    pos: -1.5,-38.5
+  - pos: 1.5,-39.5
     parent: 0
     type: Transform
 - uid: 3474
@@ -57800,9 +57819,13 @@ entities:
     parent: 0
     type: Transform
 - uid: 3475
-  type: WindoorSecurityLocked
+  type: ClothingHandsGlovesColorYellowBudget
   components:
-  - pos: -4.5,-37.5
+  - desc: These gloves plain yellow gloves. That's it. Nothing more. Nothing less. Plain yellow gloves.
+    name: plain yellow gloves
+    type: MetaData
+  - rot: 1.5707963267948966 rad
+    pos: 72.52504,-21.561703
     parent: 0
     type: Transform
 - uid: 3476
@@ -57812,9 +57835,9 @@ entities:
     parent: 0
     type: Transform
 - uid: 3477
-  type: WindowReinforcedDirectional
+  type: PottedPlantRandom
   components:
-  - pos: -2.5,-37.5
+  - pos: -0.5,-36.5
     parent: 0
     type: Transform
 - uid: 3478
@@ -65034,7 +65057,7 @@ entities:
     type: Occluder
   - canCollide: False
     type: Physics
-  - SecondsUntilStateChange: -90765.07
+  - SecondsUntilStateChange: -95202.94
     state: Closing
     type: Door
   - airBlocked: False
@@ -67049,9 +67072,10 @@ entities:
     parent: 0
     type: Transform
 - uid: 4934
-  type: AsteroidRock
+  type: DisposalTagger
   components:
-  - pos: -20.5,-79.5
+  - rot: 1.5707963267948966 rad
+    pos: 0.5,-39.5
     parent: 0
     type: Transform
 - uid: 4935
@@ -87896,7 +87920,7 @@ entities:
   - pos: 53.5,47.5
     parent: 0
     type: Transform
-  - SecondsUntilStateChange: -209942.44
+  - SecondsUntilStateChange: -214380.31
     state: Closing
     type: Door
   - enabled: False
@@ -87920,7 +87944,7 @@ entities:
   - pos: 54.5,47.5
     parent: 0
     type: Transform
-  - SecondsUntilStateChange: -209942.44
+  - SecondsUntilStateChange: -214380.31
     state: Closing
     type: Door
   - enabled: False
@@ -88028,7 +88052,7 @@ entities:
   - pos: 53.5,51.5
     parent: 0
     type: Transform
-  - SecondsUntilStateChange: -209946.08
+  - SecondsUntilStateChange: -214383.95
     state: Closing
     type: Door
   - enabled: False
@@ -88052,7 +88076,7 @@ entities:
   - pos: 54.5,51.5
     parent: 0
     type: Transform
-  - SecondsUntilStateChange: -209946.08
+  - SecondsUntilStateChange: -214383.95
     state: Closing
     type: Door
   - enabled: False
@@ -89870,9 +89894,10 @@ entities:
     parent: 0
     type: Transform
 - uid: 8353
-  type: PottedPlantRandom
+  type: DisposalTrunk
   components:
-  - pos: 2.5,-36.5
+  - rot: 1.5707963267948966 rad
+    pos: -0.5,-39.5
     parent: 0
     type: Transform
 - uid: 8354
@@ -89908,9 +89933,9 @@ entities:
     parent: 0
     type: Transform
 - uid: 8359
-  type: DisposalUnit
+  type: VehicleKeyATV
   components:
-  - pos: -0.5,-38.5
+  - pos: 46.65247,10.510805
     parent: 0
     type: Transform
 - uid: 8360
@@ -104298,6 +104323,8 @@ entities:
   - pos: 58.5,-13.5
     parent: 0
     type: Transform
+  - edge: 1
+    type: Construction
 - uid: 10579
   type: WallReinforced
   components:
@@ -109899,6 +109926,12 @@ entities:
   - pos: -34.516926,-8.454305
     parent: 0
     type: Transform
+- uid: 11451
+  type: VehicleKeyATV
+  components:
+  - pos: 46.57955,10.521229
+    parent: 0
+    type: Transform
 - uid: 11452
   type: ClothingHandsGlovesColorYellowBudget
   components:
@@ -112249,7 +112282,7 @@ entities:
     type: Occluder
   - canCollide: False
     type: Physics
-  - SecondsUntilStateChange: -71840.51
+  - SecondsUntilStateChange: -76278.375
     state: Closing
     type: Door
   - airBlocked: False
@@ -112273,7 +112306,7 @@ entities:
     type: Occluder
   - canCollide: False
     type: Physics
-  - SecondsUntilStateChange: -71840.51
+  - SecondsUntilStateChange: -76278.375
     state: Closing
     type: Door
   - airBlocked: False
@@ -116660,23 +116693,22 @@ entities:
     parent: 0
     type: Transform
 - uid: 12451
-  type: DisposalTrunk
+  type: AirlockSecurityGlassLocked
   components:
-  - rot: 1.5707963267948966 rad
-    pos: -0.5,-38.5
+  - rot: 3.141592653589793 rad
+    pos: -1.5,-37.5
     parent: 0
     type: Transform
 - uid: 12452
-  type: DisposalTagger
+  type: Grille
   components:
-  - rot: 1.5707963267948966 rad
-    pos: 0.5,-38.5
+  - pos: -1.5,-38.5
     parent: 0
     type: Transform
 - uid: 12453
-  type: DisposalBend
+  type: Grille
   components:
-  - pos: 1.5,-38.5
+  - pos: -1.5,-36.5
     parent: 0
     type: Transform
 - uid: 12454
@@ -116938,10 +116970,9 @@ entities:
     parent: 0
     type: Transform
 - uid: 12491
-  type: DisposalPipe
+  type: ReinforcedWindow
   components:
-  - rot: 3.141592653589793 rad
-    pos: 1.5,-39.5
+  - pos: -1.5,-38.5
     parent: 0
     type: Transform
 - uid: 12492
@@ -158389,14 +158420,11 @@ entities:
   - powerLoad: 0
     type: ApcPowerReceiver
 - uid: 17344
-  type: Poweredlight
+  type: ReinforcedWindow
   components:
-  - rot: -1.5707963267948966 rad
-    pos: 2.5,-37.5
+  - pos: -1.5,-36.5
     parent: 0
     type: Transform
-  - powerLoad: 0
-    type: ApcPowerReceiver
 - uid: 17345
   type: Poweredlight
   components:
@@ -160001,10 +160029,10 @@ entities:
     parent: 0
     type: Transform
 - uid: 17580
-  type: EmergencyLight
+  type: WindowReinforcedDirectional
   components:
-  - rot: -1.5707963267948966 rad
-    pos: 2.5,-37.5
+  - rot: 3.141592653589793 rad
+    pos: 46.5,-31.5
     parent: 0
     type: Transform
 - uid: 17581
@@ -185390,9 +185418,10 @@ entities:
     parent: 0
     type: Transform
 - uid: 21790
-  type: FirelockGlass
+  type: WindowReinforcedDirectional
   components:
-  - pos: 1.5,-39.5
+  - rot: 3.141592653589793 rad
+    pos: 48.5,-31.5
     parent: 0
     type: Transform
 - uid: 21791
@@ -187395,6 +187424,8 @@ entities:
     - 21930
     - 13486
     - 13332
+    - 22496
+    - 22497
     type: DeviceList
 - uid: 22062
   type: FireAlarm
@@ -187404,11 +187435,13 @@ entities:
     parent: 0
     type: Transform
   - devices:
-    - 21759
-    - 21760
+    - 21930
     - 22352
     - 22353
-    - 21930
+    - 22497
+    - 22496
+    - 21760
+    - 21759
     type: DeviceList
 - uid: 22063
   type: AirAlarm
@@ -187808,14 +187841,13 @@ entities:
     - 22168
     - 22169
     - 22170
-    - 21790
+    - null
     - 16088
     - 16124
     - 16091
     - 16123
     - 16439
     - 16440
-    - null
     - 16428
     - 16424
     - 16427
@@ -187823,6 +187855,8 @@ entities:
     - 21806
     - 16024
     - 16067
+    - 22495
+    - 16491
     type: DeviceList
 - uid: 22084
   type: FireAlarm
@@ -187837,7 +187871,8 @@ entities:
     - 22168
     - 22169
     - 22170
-    - 21790
+    - null
+    - 22495
     type: DeviceList
 - uid: 22085
   type: AirAlarm
@@ -187975,7 +188010,7 @@ entities:
     - 8963
     - 8972
     - 8971
-    - 21790
+    - null
     - 21789
     - 21892
     - 15279
@@ -187984,6 +188019,7 @@ entities:
     - 15210
     - 14759
     - 14474
+    - 22495
     type: DeviceList
 - uid: 22092
   type: FireAlarm
@@ -188001,9 +188037,10 @@ entities:
     - 8963
     - 8972
     - 8971
-    - 21790
+    - null
     - 21789
     - 21892
+    - 22495
     type: DeviceList
 - uid: 22093
   type: AirAlarm
@@ -191236,7 +191273,7 @@ entities:
 - uid: 22451
   type: Pen
   components:
-  - pos: 3.5576925,-25.990265
+  - pos: 3.188898,-20.292788
     parent: 0
     type: Transform
 - uid: 22452
@@ -191336,6 +191373,216 @@ entities:
   type: AirlockExternalGlassLocked
   components:
   - pos: -2.5,31.5
+    parent: 0
+    type: Transform
+- uid: 22467
+  type: MedkitBruteFilled
+  components:
+  - pos: 13.194896,-27.483688
+    parent: 0
+    type: Transform
+- uid: 22468
+  type: ReinforcedWindow
+  components:
+  - pos: 4.5,-29.5
+    parent: 0
+    type: Transform
+- uid: 22469
+  type: ReinforcedWindow
+  components:
+  - pos: -6.5,-40.5
+    parent: 0
+    type: Transform
+- uid: 22470
+  type: ReinforcedWindow
+  components:
+  - pos: -5.5,-40.5
+    parent: 0
+    type: Transform
+- uid: 22471
+  type: ReinforcedWindow
+  components:
+  - pos: -4.5,-40.5
+    parent: 0
+    type: Transform
+- uid: 22472
+  type: Poweredlight
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 4.5,-24.5
+    parent: 0
+    type: Transform
+  - powerLoad: 0
+    type: ApcPowerReceiver
+- uid: 22473
+  type: EmergencyLight
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 4.5,-24.5
+    parent: 0
+    type: Transform
+- uid: 22474
+  type: DrinkGlass
+  components:
+  - pos: 58.02694,0.58948016
+    parent: 0
+    type: Transform
+- uid: 22475
+  type: DrinkGlass
+  components:
+  - pos: 58.02694,0.8083823
+    parent: 0
+    type: Transform
+- uid: 22476
+  type: DrinkGlass
+  components:
+  - pos: 57.568604,0.7458384
+    parent: 0
+    type: Transform
+- uid: 22477
+  type: DrinkShotGlass
+  components:
+  - pos: 54.256104,3.7270758
+    parent: 0
+    type: Transform
+- uid: 22478
+  type: DrinkShotGlass
+  components:
+  - pos: 53.693604,3.570717
+    parent: 0
+    type: Transform
+- uid: 22479
+  type: CableApcStack1
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 59.28278,-13.162068
+    parent: 0
+    type: Transform
+- uid: 22480
+  type: CableApcStack1
+  components:
+  - pos: 59.084538,-13.600968
+    parent: 0
+    type: Transform
+- uid: 22481
+  type: CableApcStack1
+  components:
+  - pos: 59.05171,-13.170659
+    parent: 0
+    type: Transform
+  - count: 2
+    type: Stack
+- uid: 22482
+  type: CableApcStack1
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 59.2932,-13.724959
+    parent: 0
+    type: Transform
+- uid: 22483
+  type: SheetSteel1
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: 59.169697,-11.868398
+    parent: 0
+    type: Transform
+- uid: 22484
+  type: SheetSteel1
+  components:
+  - rot: 3.141592653589793 rad
+    pos: 59.169697,-11.868398
+    parent: 0
+    type: Transform
+- uid: 22485
+  type: SignRedOne
+  components:
+  - pos: -19.497566,-30.210093
+    parent: 0
+    type: Transform
+- uid: 22486
+  type: SignRedTwo
+  components:
+  - pos: -21.50798,-30.220516
+    parent: 0
+    type: Transform
+- uid: 22487
+  type: SignRedThree
+  components:
+  - pos: -23.50798,-30.210093
+    parent: 0
+    type: Transform
+- uid: 22488
+  type: SignRedFour
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: -17.22673,-31.48181
+    parent: 0
+    type: Transform
+- uid: 22489
+  type: SignRedFive
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: -17.216316,-33.472775
+    parent: 0
+    type: Transform
+- uid: 22490
+  type: SignElectricalMed
+  components:
+  - pos: 0.5,-22.5
+    parent: 0
+    type: Transform
+- uid: 22491
+  type: SignElectricalMed
+  components:
+  - pos: 0.5,-25.5
+    parent: 0
+    type: Transform
+- uid: 22492
+  type: SignElectricalMed
+  components:
+  - pos: -17.5,-22.5
+    parent: 0
+    type: Transform
+- uid: 22493
+  type: SignElectricalMed
+  components:
+  - pos: -17.5,-25.5
+    parent: 0
+    type: Transform
+- uid: 22494
+  type: SignElectricalMed
+  components:
+  - pos: -14.5,-29.5
+    parent: 0
+    type: Transform
+- uid: 22495
+  type: FirelockGlass
+  components:
+  - pos: -1.5,-37.5
+    parent: 0
+    type: Transform
+- uid: 22496
+  type: FirelockGlass
+  components:
+  - pos: -2.5,31.5
+    parent: 0
+    type: Transform
+- uid: 22497
+  type: FirelockGlass
+  components:
+  - pos: -3.5,31.5
+    parent: 0
+    type: Transform
+- uid: 22498
+  type: RandomSoap
+  components:
+  - pos: 36.5,20.5
+    parent: 0
+    type: Transform
+- uid: 22499
+  type: RandomSoap
+  components:
+  - pos: -22.5,-69.5
     parent: 0
     type: Transform
 ...


### PR DESCRIPTION
Arena Update:

I noticed in the last round I observed the edits I pushed through earlier in the day were not there. Perhaps they were accidentally displaced by the other map edits later in the day.  This edit retains all previous edits,  (Salvage hotfix, removal of uncels, and vendor stock entity replacement.) It also replaces some televisions that were accidentally just the frames before and makes some slight adjustments to the arena making it a little more accessible to enter/exit as well as a few other qol adjustments based on my observations over the day.  

