### PR TITLE
reject new accounts when no admins are active

### DIFF
--- a/Content.Server/Connection/ConnectionManager.cs
+++ b/Content.Server/Connection/ConnectionManager.cs
@@ -8,7 +8,7 @@ using Content.Shared.GameTicking;
 using Robust.Server.Player;
 using Robust.Shared.Configuration;
 using Robust.Shared.Network;
-
+using Content.Server.Administration.Managers;
 
 namespace Content.Server.Connection
 {
@@ -27,6 +27,7 @@ namespace Content.Server.Connection
         [Dependency] private readonly IServerNetManager _netMgr = default!;
         [Dependency] private readonly IServerDbManager _db = default!;
         [Dependency] private readonly IConfigurationManager _cfg = default!;
+        [Dependency] private readonly IAdminManager _admin = default!;
 
         public void Initialize()
         {
@@ -109,6 +110,22 @@ namespace Content.Server.Connection
                     (record.FirstSeenTime.CompareTo(DateTimeOffset.Now - TimeSpan.FromMinutes(_cfg.GetCVar(CCVars.PanicBunkerMinAccountAge))) > 0)))
                 {
                     return (ConnectionDenyReason.Panic, Loc.GetString("panic-bunker-account-denied"), null);
+                }
+            }
+
+            int i = 0;
+            foreach (var admin in _admin.ActiveAdmins)
+            {
+                i++;
+            }
+            if (i == 0)
+            {
+                var record = await _dbManager.GetPlayerRecordByUserId(userId);
+
+                if ((record is null ||
+                    (record.FirstSeenTime.CompareTo(DateTimeOffset.Now - TimeSpan.FromMinutes(_cfg.GetCVar(CCVars.PanicBunkerMinAccountAge))) > 0)))
+                {
+                    return (ConnectionDenyReason.Panic, Loc.GetString("panic-bunker-no-admins"), null);
                 }
             }
 

--- a/Resources/Locale/en-US/connection-messages.ftl
+++ b/Resources/Locale/en-US/connection-messages.ftl
@@ -22,4 +22,8 @@ ban-banned-1 = You, or another user of this computer or connection, are banned f
 ban-banned-2 = The ban reason is: "{$reason}"
 
 soft-player-cap-full = The server is full!
-panic-bunker-account-denied = Due to Russian raiders recently, we are not accepting connections from new accounts right now. If you speak good English and are really interested, join the Discord at www.nyanotrasen.moe
+panic-bunker-account-denied = Due to Russian raiders recently, we are not accepting connections from new accounts right now.
+                              If you speak good English and are really interested, join the Discord at www.nyanotrasen.moe
+panic-bunker-no-admins = No admins are on, and your account is new to us.
+                         To ensure game quality, we unfortunately have to reject this connection.
+                         If you're interested in Nyanotrasen, please check out the website and Discord at www.nyanotrasen.moe


### PR DESCRIPTION
:cl: Rane
- add: Connections from new accounts are rejected when no one is adminning.


