### PR TITLE
remove AME overloading

### DIFF
--- a/Content.Server/AME/Components/AMEControllerComponent.cs
+++ b/Content.Server/AME/Components/AMEControllerComponent.cs
@@ -165,7 +165,7 @@ namespace Content.Server.AME.Components
                     ToggleInjection();
                     break;
                 case UiButton.IncreaseFuel:
-                    InjectionAmount += 2;
+                    InjectionAmount = Math.Min(InjectionAmount + 2, GetCoreCount() * 2);
                     break;
                 case UiButton.DecreaseFuel:
                     InjectionAmount = InjectionAmount > 0 ? InjectionAmount -= 2 : 0;


### PR DESCRIPTION
:cl: Rane
- remove: Removed the ability to overload the AME. Braindead griefers have to find another strategy to speedrun permaban.

