### PR TITLE
huh, skub

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/skub.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/skub.yml
@@ -13,5 +13,11 @@
   - type: EmitSoundOnUse
     sound:
       path: /Audio/Items/skub.ogg
+  - type: EmitSoundOnTrigger
+    sound:
+      path: /Audio/Items/skub.ogg
+  - type: Tag
+    tags:
+    - Payload # skub grenade /!\
   - type: UseDelay
     delay: 2.0


### PR DESCRIPTION
## About the PR
Same as last pr but for skubnades.

Probably outlawed by the Space Geneva convention.

**Changelog**
:cl:
- tweak: Skub can now be used in modular grenades and mines

