### PR TITLE
Update1128

### DIFF
--- a/Content.Server/Chemistry/ReagentEffects/MakeSentient.cs
+++ b/Content.Server/Chemistry/ReagentEffects/MakeSentient.cs
@@ -1,8 +1,9 @@
 using Content.Server.Mind.Components;
 using Content.Server.Speech.Components;
-
-using Content.Shared.Chemistry.Reagent;
+using Content.Server.StationEvents.Components;
 using Content.Server.Ghost.Roles.Components;
+using Content.Server.Psionics;
+using Content.Shared.Chemistry.Reagent;
 
 namespace Content.Server.Chemistry.ReagentEffects;
 
@@ -13,30 +14,24 @@ public sealed class MakeSentient : ReagentEffect
         var entityManager = args.EntityManager;
         var uid = args.SolutionEntity;
 
-        // This makes it so it doesn't affect things that are already sentient
         if (entityManager.HasComponent<MindComponent>(uid))
-        {
             return;
-        }
 
-        // This piece of code makes things able to speak "normally". One thing of note is that monkeys have a unique accent and won't be affected by this.
+        entityManager.RemoveComponent<SentienceTargetComponent>(uid);
+
         entityManager.RemoveComponent<ReplacementAccentComponent>(uid);
-
-        // Monke talk
         entityManager.RemoveComponent<MonkeyAccentComponent>(uid);
 
-        // No idea what anything past this point does
-        if (entityManager.TryGetComponent(uid, out GhostTakeoverAvailableComponent? takeOver))
-        {
+        if (entityManager.HasComponent<GhostTakeoverAvailableComponent>(uid))
             return;
-        }
 
-        takeOver = entityManager.AddComponent<GhostTakeoverAvailableComponent>(uid);
+        entityManager.EnsureComponent<PotentialPsionicComponent>(uid);
 
+        var takeOver = entityManager.AddComponent<GhostTakeoverAvailableComponent>(uid);
         var entityData = entityManager.GetComponent<MetaDataComponent>(uid);
+
+        entityData.EntityName = Loc.GetString("glimmer-event-awakened-prefix", ("entity", uid));
         takeOver.RoleName = entityData.EntityName;
         takeOver.RoleDescription = Loc.GetString("ghost-role-information-cognizine-description");
     }
 }
-
-// Original code written by areitpog on GitHub in Issue #7666, then I (Interrobang01) copied it and used my nonexistant C# skills to try to make it work again.

--- a/Content.Server/Nyanotrasen/Abilities/Oni/OniSystem.cs
+++ b/Content.Server/Nyanotrasen/Abilities/Oni/OniSystem.cs
@@ -2,6 +2,7 @@ using Content.Server.Tools;
 using Content.Shared.Tools.Components;
 using Content.Shared.Damage.Events;
 using Content.Shared.Weapons.Melee.Events;
+using Content.Shared.Weapons.Ranged.Components;
 using Robust.Shared.Containers;
 
 namespace Content.Server.Abilities.Oni
@@ -27,12 +28,26 @@ namespace Content.Server.Abilities.Oni
 
             if (TryComp<ToolComponent>(args.Entity, out var tool) && _toolSystem.HasQuality(args.Entity, "Prying", tool))
                 tool.SpeedModifier *= 1.66f;
+
+            if (TryComp<GunComponent>(args.Entity, out var gun))
+            {
+                gun.MinAngle *= 15f;
+                gun.AngleIncrease *= 15f;
+                gun.MaxAngle *= 15f;
+            }
         }
 
         private void OnEntRemoved(EntityUid uid, OniComponent component, EntRemovedFromContainerMessage args)
         {
             if (TryComp<ToolComponent>(args.Entity, out var tool) && _toolSystem.HasQuality(args.Entity, "Prying", tool))
                 tool.SpeedModifier /= 1.66f;
+
+            if (TryComp<GunComponent>(args.Entity, out var gun))
+            {
+                gun.MinAngle /= 15f;
+                gun.AngleIncrease /= 15f;
+                gun.MaxAngle /= 15f;
+            }
 
             RemComp<HeldByOniComponent>(args.Entity);
         }

--- a/Content.Server/Nyanotrasen/Borgs/LawsSystem.cs
+++ b/Content.Server/Nyanotrasen/Borgs/LawsSystem.cs
@@ -1,6 +1,7 @@
 using Content.Shared.Borgs;
 using Content.Server.Chat.Systems;
 using Robust.Shared.Timing;
+using Robust.Server.GameObjects;
 
 namespace Content.Server.Borgs
 {
@@ -8,15 +9,26 @@ namespace Content.Server.Borgs
     {
         [Dependency] private readonly ChatSystem _chat = default!;
         [Dependency] private readonly IGameTiming _timing = default!;
+        [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
+
         public override void Initialize()
         {
             base.Initialize();
             SubscribeLocalEvent<LawsComponent, StateLawsMessage>(OnStateLaws);
+            SubscribeLocalEvent<LawsComponent, PlayerAttachedEvent>(OnPlayerAttached);
         }
 
         private void OnStateLaws(EntityUid uid, LawsComponent component, StateLawsMessage args)
         {
             StateLaws(uid, component);
+        }
+
+        private void OnPlayerAttached(EntityUid uid, LawsComponent component, PlayerAttachedEvent args)
+        {
+            if (!_uiSystem.TryGetUi(uid, LawsUiKey.Key, out var ui))
+                return;
+
+            _uiSystem.TryOpen(uid, LawsUiKey.Key, args.Player);
         }
 
         public void StateLaws(EntityUid uid, LawsComponent? component = null)

--- a/Content.Server/Nyanotrasen/Chapel/SacrificialAltarComponent.cs
+++ b/Content.Server/Nyanotrasen/Chapel/SacrificialAltarComponent.cs
@@ -14,9 +14,6 @@ namespace Content.Server.Chapel
         [DataField("sacrificeSound")]
         public SoundSpecifier SacrificeSoundPath = new SoundPathSpecifier("/Audio/Effects/clang2.ogg");
 
-        [DataField("finishSound")]
-        public SoundSpecifier FinishSound = new SoundPathSpecifier("/Audio/Effects/gib1.ogg");
-
         public IPlayingAudioStream? SacrificeStingStream;
 
         [DataField("rewardPool")]

--- a/Content.Server/Nyanotrasen/Chapel/SacrificialAltarComponent.cs
+++ b/Content.Server/Nyanotrasen/Chapel/SacrificialAltarComponent.cs
@@ -42,5 +42,13 @@ namespace Content.Server.Chapel
 
         [DataField("trapPrototype")]
         public string TrapPrototype = "CrystalSoul";
+
+        /// <summary>
+        ///     Antiexploit.
+        /// </summary>
+        public TimeSpan? StunTime = null;
+
+        [DataField("stateCD")]
+        public TimeSpan StunCD = TimeSpan.FromSeconds(30);
     }
 }

--- a/Content.Server/Nyanotrasen/Chapel/SacrificialAltarSystem.cs
+++ b/Content.Server/Nyanotrasen/Chapel/SacrificialAltarSystem.cs
@@ -19,6 +19,7 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Player;
 using Robust.Server.GameObjects;
+using Robust.Shared.Timing;
 
 namespace Content.Server.Chapel
 {
@@ -32,7 +33,7 @@ namespace Content.Server.Chapel
         [Dependency] private readonly AudioSystem _audioSystem = default!;
         [Dependency] private readonly PopupSystem _popups = default!;
         [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
-
+        [Dependency] private readonly IGameTiming _timing = default!;
 
         public override void Initialize()
         {
@@ -176,7 +177,15 @@ namespace Content.Server.Chapel
                 return;
             }
 
-            _stunSystem.TryParalyze(patient, component.SacrificeTime, true);
+
+            if (HasComp<BibleUserComponent>(agent))
+            {
+                if (component.StunTime == null || _timing.CurTime > component.StunTime)
+                {
+                    _stunSystem.TryParalyze(patient, component.SacrificeTime + TimeSpan.FromSeconds(1), true);
+                    component.StunTime = _timing.CurTime + component.StunCD;
+                }
+            }
 
             _popups.PopupEntity(Loc.GetString("altar-popup", ("user", agent), ("target", patient)), altar, Filter.Pvs(altar), Shared.Popups.PopupType.LargeCaution);
 

--- a/Content.Server/Nyanotrasen/Chapel/SacrificialAltarSystem.cs
+++ b/Content.Server/Nyanotrasen/Chapel/SacrificialAltarSystem.cs
@@ -95,14 +95,6 @@ namespace Content.Server.Chapel
             if (!_prototypeManager.TryIndex<WeightedRandomPrototype>(altarComp.RewardPool, out var pool))
                 return;
 
-            if (TryComp<BodyComponent>(args.Target, out var body))
-            {
-                _bodySystem.GibBody(args.Target, true, body, false);
-            } else
-            {
-                QueueDel(args.Target);
-            }
-
             var chance = HasComp<BibleUserComponent>(args.User) ? altarComp.RewardPoolChanceBibleUser : altarComp.RewardPoolChance;
 
             if (_robustRandom.Prob(chance))
@@ -132,6 +124,14 @@ namespace Content.Server.Chapel
 
                 MetaData(trap).EntityName = Loc.GetString("soul-entity-name", ("trapped", args.Target));
                 MetaData(trap).EntityDescription = Loc.GetString("soul-entity-desc", ("trapped", args.Target));
+            }
+
+            if (TryComp<BodyComponent>(args.Target, out var body))
+            {
+                _bodySystem.GibBody(args.Target, true, body, false);
+            } else
+            {
+                QueueDel(args.Target);
             }
         }
 

--- a/Content.Server/Nyanotrasen/Psionics/Glimmer/Events/NoosphericZap.cs
+++ b/Content.Server/Nyanotrasen/Psionics/Glimmer/Events/NoosphericZap.cs
@@ -32,7 +32,7 @@ public sealed class NoosphericZap : GlimmerEventSystem
         foreach (var psion in psionicList)
         {
             _stunSystem.TryParalyze(psion.Owner, TimeSpan.FromSeconds(5), false);
-            _statusEffectsSystem.TryAddStatusEffect(psion.Owner, "Stutter", TimeSpan.FromSeconds(30), false, "StutteringAccent");
+            _statusEffectsSystem.TryAddStatusEffect(psion.Owner, "Stutter", TimeSpan.FromSeconds(10), false, "StutteringAccent");
 
             if (HasComp<PsionicComponent>(psion.Owner))
                 _popupSystem.PopupEntity(Loc.GetString("noospheric-zap-seize"), psion.Owner, Filter.Entities(psion.Owner), Shared.Popups.PopupType.LargeCaution);

--- a/Content.Server/Nyanotrasen/Soul/GolemSystem.cs
+++ b/Content.Server/Nyanotrasen/Soul/GolemSystem.cs
@@ -10,6 +10,7 @@ using Content.Shared.Administration.Logs;
 using Content.Server.Borgs;
 using Content.Server.Abilities.Psionics;
 using Content.Server.Players;
+using Content.Server.Humanoid;
 using Robust.Shared.Random;
 using Robust.Server.GameObjects;
 using Robust.Shared.Prototypes;
@@ -53,6 +54,9 @@ namespace Content.Server.Soul
                 return;
 
             if (!TryComp<ActorComponent>(args.User, out var userActor))
+                return;
+
+            if (!HasComp<HumanoidComponent>(args.User))
                 return;
 
             if (!_uiSystem.TryGetUi(args.Target.Value, GolemUiKey.Key, out var ui))

--- a/Content.Server/Xenoarchaeology/Equipment/Systems/ArtifactAnalyzerSystem.cs
+++ b/Content.Server/Xenoarchaeology/Equipment/Systems/ArtifactAnalyzerSystem.cs
@@ -333,7 +333,7 @@ public sealed class ArtifactAnalyzerSystem : EntitySystem
         var points = _artifact.GetResearchPointValue(entToDestroy.Value);
 
         client.Server.Points += points;
-        _glimmerSystem.Glimmer += (int) points / 1000;
+        _glimmerSystem.Glimmer += (int) points / 800;
         EntityManager.DeleteEntity(entToDestroy.Value);
 
         _audio.PlayPvs(component.DestroySound, component.AnalyzerEntity.Value, AudioParams.Default.WithVolume(2f));

--- a/Resources/Locale/en-US/abilities/psionic.ftl
+++ b/Resources/Locale/en-US/abilities/psionic.ftl
@@ -44,8 +44,8 @@ action-name-psionic-regeneration = Psionic Regeneration
 action-description-psionic-regeneration = Push your natural metabolism to the limit to power your body's regenerative capability.
 
 glimmer-report = Current Glimmer Level: {$level}Ψ.
-glimmer-event-report-generic = Noöspheric discharge detected. Glimmer level has decreased by {$decrease} to {$level}μΨ.
-glimmer-event-report-signatures = New psionic signatures manifested. Glimmer level has decreased by {$decrease} to {$level}μΨ.
+glimmer-event-report-generic = Noöspheric discharge detected. Glimmer level has decreased by {$decrease} to {$level}Ψ.
+glimmer-event-report-signatures = New psionic signatures manifested. Glimmer level has decreased by {$decrease} to {$level}Ψ.
 glimmer-event-awakened-prefix = awakened {$entity}
 
 noospheric-zap-seize = You seize up!

--- a/Resources/Locale/en-US/chapel/altar.ftl
+++ b/Resources/Locale/en-US/chapel/altar.ftl
@@ -3,3 +3,9 @@ soul-entity-name = {$trapped}'s soul crystal
 soul-entity-desc = A soul crystal with {$trapped}'s soul inside.
 
 altar-popup = {$user} starts to sacrifice {$target}!
+
+altar-failure-reason-self = You can't sacrifice yourself!
+altar-failure-reason-user = You are not psionic or clerically trained!
+altar-failure-reason-user-humanoid = You are not a humanoid!
+altar-failure-reason-target = {CAPITALIZE(THE($target))} {CONJUGATE-BE($target)} not psionic!
+altar-failure-reason-target-humanoid = {CAPITALIZE(THE($target))} {CONJUGATE-BE($target)} not humanoid!

--- a/Resources/Prototypes/Catalog/Research/technologies.yml
+++ b/Resources/Prototypes/Catalog/Research/technologies.yml
@@ -113,7 +113,6 @@
     - ReagentGrinderMachineCircuitboard
     - PillCanister
     - ChemistryEmptyBottle01
-    - TimerTrigger
     - ChemicalPayload
 
 - type: technology
@@ -386,6 +385,7 @@
     - Signaller
     - SignalTrigger
     - VoiceTrigger
+    - TimerTrigger
 
 - type: technology
   name: technologies-compact-power-technology

--- a/Resources/Prototypes/Entities/Clothing/Ears/headsets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Ears/headsets.yml
@@ -172,6 +172,7 @@
     channels:
       - Common
       - Science
+      - Binary
   - type: Sprite
     sprite: Clothing/Ears/Headsets/robotics.rsi
   - type: Clothing

--- a/Resources/Prototypes/Entities/Structures/Decoration/banners.yml
+++ b/Resources/Prototypes/Entities/Structures/Decoration/banners.yml
@@ -80,8 +80,8 @@
 - type: entity
   id: BannerScience
   parent: BannerBase
-  name: science banner
-  description: A banner displaying the colors of the science department. Where stupidity is proven greater than the universe.
+  name: epistemics banner
+  description: A banner displaying the colors of the epistemics department.
   components:
   - type: Sprite
     sprite: Structures/Decoration/banner.rsi

--- a/Resources/Prototypes/Nyanotrasen/Catalog/Fills/Lockers/empty.yml
+++ b/Resources/Prototypes/Nyanotrasen/Catalog/Fills/Lockers/empty.yml
@@ -8,7 +8,7 @@
   id: LockerEpistemics
   parent: LockerScientist
   suffix: Empty
-  name: epistemologist's locker
+  name: acolyte's locker
 
 - type: entity
   id: LockerForensicMantis

--- a/Resources/Prototypes/Nyanotrasen/Catalog/Fills/Lockers/ourjobs.yml
+++ b/Resources/Prototypes/Nyanotrasen/Catalog/Fills/Lockers/ourjobs.yml
@@ -22,7 +22,7 @@
   id: LockerEpistemicsFilled
   suffix: Filled
   parent: LockerScientist
-  name: epistemologist's locker
+  name: acolyte's locker
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/moth.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/moth.yml
@@ -1,6 +1,6 @@
 - type: entity
   save: false
-  name: Urist McFluff
+  name: Player moth
   parent: BaseMobMoth
   id: MobMoth
   components:

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/oni.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/oni.yml
@@ -1,6 +1,6 @@
 - type: entity
   save: false
-  name: Urist-ni-Kanabou
+  name: Player oni
   parent: MobOniBase
   id: MobOni
   components:

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/oni.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/oni.yml
@@ -1,6 +1,6 @@
 - type: entity
   parent: BaseMobHuman
-  name: Urist-ni-Kanabou
+  name: Base oni
   id: MobOniBase
   abstract: true
   components:
@@ -9,7 +9,6 @@
     - CanPilot
     - FootstepSound
     - DoorBumpOpener
-    - GunsDisabled
   - type: Speech
     speechSounds: Baritone
   - type: Humanoid

--- a/Resources/Prototypes/Nyanotrasen/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Structures/Machines/lathe.yml
@@ -181,6 +181,7 @@
       - FireAlarmElectronics
       - HolofanProjector
       - Drone
+      - ConveyorBeltAssembly
       - RPED
       - RCDAmmo # Below is shared with other lathes
       - FlashlightLantern

--- a/Resources/Prototypes/Nyanotrasen/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Structures/Machines/lathe.yml
@@ -33,9 +33,6 @@
       - BackpackOfHolding
       - SatchelOfHolding
       - DuffelbagOfHolding
-      - ProximitySensor
-      - LeftArmBorg
-      - RightArmBorg
       - NormalityCrystal
       - ChemicalPayload #Below = shared
       - FlashlightLantern

--- a/Resources/Prototypes/Nyanotrasen/GameRules/events.yml
+++ b/Resources/Prototypes/Nyanotrasen/GameRules/events.yml
@@ -9,7 +9,6 @@
     weight: 5
     endAfter: 1
     earliestStart: 15
-    maxOccurrences: 3
 
 - type: gameRule
   id: MundaneDischarge


### PR DESCRIPTION
:cl: Rane
- fix: Fixed altar exploit.
- tweak: Altar gibs again.
- add: Added a bunch of messages that should make people understand why altar sacrifice is or is not working.
- tweak: Stutter accent from the noospheric zap event reduced from 30s to 10s.
- add: Oni can use guns again. They are just extremely inaccurate.
- tweak: Artifact glimmer from sacrifice increased slightly.
- tweak: Removed max occurences from noospheric storm.
- tweak: Entities with laws open the UI for you when you attach to them.
- fix: Renamed more stuff.
- tweak: Cognizine behavior has been unified with the other methods of gaining sentience.
- fix: Only humanoids can install golems.
- tweak: Timer trigger moved out of chem technology and is unlocked with the other triggers.

