### PR TITLE
improve moth layering slightly

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/moth.yml
@@ -84,6 +84,7 @@
         sprite: Objects/Misc/handcuffs.rsi
         state: body-overlay-2
         visible: false
+      - map: [ "enum.HumanoidVisualLayers.Tail" ] #in the utopian future we should probably have a wings enum inserted here so everything doesn't break
       - map: [ "id" ]
       - map: [ "gloves" ]
       - map: [ "shoes" ]
@@ -91,7 +92,6 @@
       - map: [ "outerClothing" ]
       - map: [ "eyes" ]
       - map: [ "belt" ]
-      - map: [ "enum.HumanoidVisualLayers.Tail" ] #in the utopian future we should probably have a wings enum inserted here so everyhting doesn't break
       - map: [ "neck" ]
       - map: [ "back" ]
       - map: [ "enum.HumanoidVisualLayers.FacialHair" ]


### PR DESCRIPTION
:cl: Rane
- tweak: Moved moth wings sprite layer down. This leads to more correct rendering, but introduces a smaller amount of other rendering errors, particularly when facing north. A special solution will need to be coded to fully resolve this issue.

