### PR TITLE
display locked roles properly for nonwhitelisted

### DIFF
--- a/Content.Client/Players/PlayTimeTracking/PlayTimeTrackingManager.cs
+++ b/Content.Client/Players/PlayTimeTracking/PlayTimeTrackingManager.cs
@@ -20,10 +20,12 @@ public sealed class PlayTimeTrackingManager
     [Dependency] private readonly IPrototypeManager _prototypes = default!;
 
     private readonly Dictionary<string, TimeSpan> _roles = new();
+    private bool _whitelisted = false;
 
     public void Initialize()
     {
         _net.RegisterNetMessage<MsgPlayTime>(RxPlayTime);
+        _net.RegisterNetMessage<MsgWhitelist>(RxWhitelist);
 
         _client.RunLevelChanged += ClientOnRunLevelChanged;
     }
@@ -54,6 +56,11 @@ public sealed class PlayTimeTrackingManager
         }*/
     }
 
+    private void RxWhitelist(MsgWhitelist message)
+    {
+        _whitelisted = message.Whitelisted;
+    }
+
     public bool IsAllowed(JobPrototype job, [NotNullWhen(false)] out string? reason)
     {
         reason = null;
@@ -80,6 +87,14 @@ public sealed class PlayTimeTrackingManager
             first = false;
 
             reasonBuilder.AppendLine(reason);
+        }
+
+        if (!_whitelisted)
+        {
+            if (reasonBuilder.Length > 0)
+                reasonBuilder.Append('\n');
+
+            reasonBuilder.AppendLine(Loc.GetString("playtime-deny-reason-not-whitelisted"));
         }
 
         reason = reasonBuilder.Length == 0 ? null : reasonBuilder.ToString();

--- a/Content.Server/Players/PlayTimeTracking/PlayTimeTrackingManager.cs
+++ b/Content.Server/Players/PlayTimeTracking/PlayTimeTrackingManager.cs
@@ -84,6 +84,7 @@ public sealed class PlayTimeTrackingManager
         _sawmill = Logger.GetSawmill("play_time");
 
         _net.RegisterNetMessage<MsgPlayTime>();
+        _net.RegisterNetMessage<MsgWhitelist>();
 
         _cfg.OnValueChanged(CCVars.PlayTimeSaveInterval, f => _saveInterval = TimeSpan.FromSeconds(f), true);
     }
@@ -129,6 +130,7 @@ public sealed class PlayTimeTrackingManager
             if (data.NeedSendTimers)
             {
                 SendPlayTimes(player);
+                SendWhitelist(player);
                 data.NeedSendTimers = false;
             }
 
@@ -210,6 +212,18 @@ public sealed class PlayTimeTrackingManager
         };
 
         _net.ServerSendMessage(msg, pSession.ConnectedClient);
+    }
+
+    public async void SendWhitelist(IPlayerSession playerSession)
+    {
+        var whitelist = await _db.GetWhitelistStatusAsync(playerSession.UserId);
+
+        var msg = new MsgWhitelist
+        {
+            Whitelisted = whitelist
+        };
+
+        _net.ServerSendMessage(msg, playerSession.ConnectedClient);
     }
 
     /// <summary>

--- a/Content.Shared/Nyanotrasen/Players/PlayTimeTracking/MsgWhitelist.cs
+++ b/Content.Shared/Nyanotrasen/Players/PlayTimeTracking/MsgWhitelist.cs
@@ -1,0 +1,25 @@
+using Lidgren.Network;
+using Robust.Shared.Network;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Players.PlayTimeTracking;
+
+/// <summary>
+/// Sent server -> client to inform the client of their play times.
+/// </summary>
+public sealed class MsgWhitelist : NetMessage
+{
+    public override MsgGroups MsgGroup => MsgGroups.EntityEvent;
+
+    public bool Whitelisted = false;
+
+    public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
+    {
+        Whitelisted = buffer.ReadBoolean();
+    }
+
+    public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
+    {
+        buffer.Write(Whitelisted);
+    }
+}

--- a/Content.Shared/Nyanotrasen/Players/PlayTimeTracking/MsgWhitelist.cs
+++ b/Content.Shared/Nyanotrasen/Players/PlayTimeTracking/MsgWhitelist.cs
@@ -5,7 +5,7 @@ using Robust.Shared.Serialization;
 namespace Content.Shared.Players.PlayTimeTracking;
 
 /// <summary>
-/// Sent server -> client to inform the client of their play times.
+/// Sent server -> client to inform the client of their whitelist status.
 /// </summary>
 public sealed class MsgWhitelist : NetMessage
 {

--- a/Resources/Locale/en-US/players/play-time/whitelist.ftl
+++ b/Resources/Locale/en-US/players/play-time/whitelist.ftl
@@ -1,0 +1,1 @@
+playtime-deny-reason-not-whitelisted = You need to be whitelisted.


### PR DESCRIPTION
:cl: Rane
- fix: Locked roles are now displayed properly for players who are not whitelisted.
