### PR TITLE
Fix MeleeStaminaCost swing detection and add Wield coefficient.

### DIFF
--- a/Content.Server/Flash/FlashSystem.cs
+++ b/Content.Server/Flash/FlashSystem.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Content.Server.Flash.Components;
 using Content.Server.Light.EntitySystems;
 using Content.Server.Stunnable;
@@ -43,11 +44,12 @@ namespace Content.Server.Flash
 
         private void OnFlashMeleeHit(EntityUid uid, FlashComponent comp, MeleeHitEvent args)
         {
-            if (!args.IsHit)
+            if (!args.IsHit ||
+                !args.HitEntities.Any() ||
+                !UseFlash(comp, args.User))
+            {
                 return;
-
-            if (!UseFlash(comp, args.User))
-                return;
+            }
 
             args.Handled = true;
             foreach (var e in args.HitEntities)

--- a/Content.Server/Nyanotrasen/Abilities/Gachi/GachiSystem.cs
+++ b/Content.Server/Nyanotrasen/Abilities/Gachi/GachiSystem.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Content.Shared.Damage;
 using Content.Shared.FixedPoint;
 using Content.Shared.Inventory.Events;
@@ -59,6 +60,12 @@ namespace Content.Server.Abilities.Gachi
 
         private void OnMeleeHit(EntityUid uid, GachiComponent component, MeleeHitEvent args)
         {
+            if (!args.IsHit ||
+                !args.HitEntities.Any())
+            {
+                return;
+            }
+
             if (_random.Prob(0.2f * component.Multiplier))
             {
                 FixedPoint2 newMultiplier = component.Multiplier - 0.25;

--- a/Content.Server/Nyanotrasen/Weapons/Melee/DamageWeaponOnHitSystem.cs
+++ b/Content.Server/Nyanotrasen/Weapons/Melee/DamageWeaponOnHitSystem.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Content.Shared.Damage;
 using Content.Shared.Weapons.Melee.Events;
 
@@ -16,7 +17,8 @@ namespace Content.Server.Weapons.Melee
 
         private void OnMeleeHit(EntityUid uid, DamageWeaponOnHitComponent component, MeleeHitEvent args)
         {
-            if (!args.IsHit)
+            if (!args.IsHit ||
+                !args.HitEntities.Any())
                 return;
 
             _damageableSystem.TryChangeDamage(uid, component.Damage);

--- a/Content.Server/Nyanotrasen/Weapons/Melee/MeleeStaminaCostComponent.cs
+++ b/Content.Server/Nyanotrasen/Weapons/Melee/MeleeStaminaCostComponent.cs
@@ -22,5 +22,12 @@ namespace Content.Server.Weapons.Melee
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("hit")]
         public float HitCost { get; set; }
+
+        /// <summary>
+        /// How much is the stamina cost muliplied by when the weapon is Wielded?
+        /// </summary>
+        [ViewVariables(VVAccess.ReadWrite)]
+        [DataField("wieldCoefficient")]
+        public float WieldCoefficient { get; set; } = 1.5f;
     }
 }

--- a/Content.Server/Nyanotrasen/Weapons/Melee/MeleeStaminaCostSystem.cs
+++ b/Content.Server/Nyanotrasen/Weapons/Melee/MeleeStaminaCostSystem.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+using Content.Server.Wieldable.Components;
 using Content.Shared.Damage.Components;
 using Content.Shared.Damage.Systems;
 using Content.Shared.Weapons.Melee.Events;
@@ -17,12 +19,23 @@ namespace Content.Server.Weapons.Melee
 
         private void OnMeleeHit(EntityUid uid, MeleeStaminaCostComponent component, MeleeHitEvent args)
         {
+            // MeleeHitEvent is raised when examining a weapon with IsHit set to false.
+            // Not the best naming scheme.
+            if (!args.IsHit)
+                return;
+
             if (!TryComp(args.User, out StaminaComponent? staminaComponent))
                 return;
 
+            float coefficient = 1.0f;
+
+            if (TryComp(uid, out WieldableComponent? wieldableComponent) && wieldableComponent.Wielded)
+                coefficient = component.WieldCoefficient;
+
             _staminaSystem.TakeStaminaDamage(
                 args.User,
-                component.SwingCost + (args.IsHit ? component.HitCost : 0),
+                // We can see if it's a swing or a hit by checking if there are any HitEntities.
+                coefficient * (component.SwingCost + (args.HitEntities.Any() ? component.HitCost : 0)),
                 staminaComponent);
         }
     }

--- a/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
@@ -225,11 +225,12 @@ public sealed class MeleeWeaponSystem : SharedMeleeWeaponSystem
 
     private void OnChemicalInjectorHit(EntityUid owner, MeleeChemicalInjectorComponent comp, MeleeHitEvent args)
     {
-        if (!args.IsHit)
+        if (!args.IsHit ||
+            !args.HitEntities.Any() ||
+            !_solutions.TryGetSolution(owner, comp.Solution, out var solutionContainer))
+        {
             return;
-
-        if (!_solutions.TryGetSolution(owner, comp.Solution, out var solutionContainer))
-            return;
+        }
 
         var hitBloodstreams = new List<BloodstreamComponent>();
         var bloodQuery = GetEntityQuery<BloodstreamComponent>();

--- a/Content.Shared/Damage/Systems/StaminaSystem.cs
+++ b/Content.Shared/Damage/Systems/StaminaSystem.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Alert;
 using Content.Shared.CombatMode;
@@ -138,10 +139,12 @@ public sealed class StaminaSystem : EntitySystem
 
     private void OnHit(EntityUid uid, StaminaDamageOnHitComponent component, MeleeHitEvent args)
     {
-        if (!args.IsHit)
+        if (!args.IsHit ||
+            !args.HitEntities.Any() ||
+            component.Damage <= 0f)
+        {
             return;
-
-        if (component.Damage <= 0f) return;
+        }
 
         var ev = new StaminaDamageOnHitAttemptEvent();
         RaiseLocalEvent(uid, ref ev);


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

There was a bug in the original `MeleeStaminaCost`, in that there was really no way to detect misses/swings in melee combat. I have fixed that upstream and pulled said fix into this branch. MeleeHitEvent is fired even if there are no HitEntities, which it had support for, and some code checked, but it's a confusing event to begin with, since it's fired when someone examines a weapon.

I thoroughly examined upstream for any usage of MeleeHitEvent to make sure there were no side-effects to this change of firing it on misses, and I fixed what I found (stun batons and flashes), but we'll need to be mindful of this in our own codebase.

Additionally, per request of @OldDanceJacket and @Leander-0 , I have added the ability to specify a Wield coefficient for stamina costs.

**Screenshots**
<!-- If applicable, add screenshots to showcase your PR. If your PR is a visual change, add
screenshots or it's liable to be closed by maintainers. -->

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->