### PR TITLE
Prevent self-stun from melee stamina cost.

### DIFF
--- a/Content.Server/Nyanotrasen/Weapons/Melee/MeleeStaminaCostSystem.cs
+++ b/Content.Server/Nyanotrasen/Weapons/Melee/MeleeStaminaCostSystem.cs
@@ -32,10 +32,21 @@ namespace Content.Server.Weapons.Melee
             if (TryComp(uid, out WieldableComponent? wieldableComponent) && wieldableComponent.Wielded)
                 coefficient = component.WieldCoefficient;
 
+            // We can see if it's a swing or a hit by checking if there are any HitEntities.
+            float staminaDamage = coefficient * (component.SwingCost + (args.HitEntities.Any() ? component.HitCost : 0f));
+            float meleeCostLimit = staminaComponent.CritThreshold * staminaComponent.MeleeCostLimitFactor;
+
+            // Avoid GetStaminaDamage: it uses some time-based prediction calculation.
+            if (staminaComponent.StaminaDamage + staminaDamage > meleeCostLimit)
+                staminaDamage = meleeCostLimit - staminaComponent.StaminaDamage;
+
+            const float ImpermissibleLimit = 0.01f;
+            if (staminaDamage <= ImpermissibleLimit)
+                return;
+
             _staminaSystem.TakeStaminaDamage(
                 args.User,
-                // We can see if it's a swing or a hit by checking if there are any HitEntities.
-                coefficient * (component.SwingCost + (args.HitEntities.Any() ? component.HitCost : 0)),
+                staminaDamage,
                 staminaComponent);
         }
     }

--- a/Content.Shared/Damage/Components/StaminaComponent.cs
+++ b/Content.Shared/Damage/Components/StaminaComponent.cs
@@ -45,7 +45,7 @@ public sealed class StaminaComponent : Component
     /// attacks?
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField("meleeCostLimitFactor")]
-    public float MeleeCostLimitFactor = 0.95f;
+    public float MeleeCostLimitFactor = 0.90f;
 
     /// <summary>
     /// To avoid continuously updating our data we track the last time we updated so we can extrapolate our current stamina.

--- a/Content.Shared/Damage/Components/StaminaComponent.cs
+++ b/Content.Shared/Damage/Components/StaminaComponent.cs
@@ -40,6 +40,14 @@ public sealed class StaminaComponent : Component
     public float CritThreshold = 100f;
 
     /// <summary>
+    /// What percentage of the CritThreshold is the maximum amount of stamina
+    /// damage that can be reached by exhausting yourself with melee weapon
+    /// attacks?
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite), DataField("meleeCostLimitFactor")]
+    public float MeleeCostLimitFactor = 0.95f;
+
+    /// <summary>
     /// To avoid continuously updating our data we track the last time we updated so we can extrapolate our current stamina.
     /// </summary>
     [DataField("lastUpdate", customTypeSerializer:typeof(TimeOffsetSerializer))]


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR prevents self-stun from swinging a melee weapon and adds a new DataField to StaminaComponent to determine what percentage of the CritThreshold that it should be limited to. It's by default set to a factor sufficient that will get most normal mobs close to the limit of exhaustion with a small buffer.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: You will no longer stun yourself with melee attacks.