### PR TITLE
BluntStaminaDamage and StaminaCost changes

### DIFF
--- a/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
+++ b/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
@@ -81,7 +81,7 @@ public sealed class MeleeWeaponComponent : Component
 
     [DataField("bluntStaminaDamageFactor")]
     [ViewVariables(VVAccess.ReadWrite)]
-    public FixedPoint2 BluntStaminaDamageFactor { get; set; } = 0.5f;
+    public FixedPoint2 BluntStaminaDamageFactor { get; set; } = 1.0f;
 
     // TODO: Temporarily 1.5 until interactionoutline is adjusted to use melee, then probably drop to 1.2
     /// <summary>

--- a/Resources/Prototypes/Entities/Objects/base_item.yml
+++ b/Resources/Prototypes/Entities/Objects/base_item.yml
@@ -17,7 +17,7 @@
     soundHit:
       path: /Audio/Effects/hit_kick.ogg
   - type: MeleeStaminaCost
-    swing: 5
+    swing: 3.5
   - type: CollisionWake
   - type: TileFrictionModifier
     modifier: 0.5


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Blunt damage type with deal 1:1 stamina damage and most objects in the game will cost 3.5 stamina instead of 5.

:cl: Leander
- tweak: Blunt damage will do 1:1 stamina damage now
- tweak: Most objects/weapons will cost less stamina to swing 

