### PR TITLE
identity displays failed disguise attempts

### DIFF
--- a/Content.Server/IdentityManagement/IdentitySystem.cs
+++ b/Content.Server/IdentityManagement/IdentitySystem.cs
@@ -110,6 +110,15 @@ public class IdentitySystem : SharedIdentitySystem
         var ev = new SeeIdentityAttemptEvent();
 
         RaiseLocalEvent(target, ev);
+
+        // If you are failing to disguise as another person, this is visible to others.
+        if (!ev.Cancelled && representation.PresumedName != null
+            && representation.PresumedName != representation.TrueName)
+        {
+            representation.PresumedName = Loc.GetString("identity-presumed-name-outed", ("trueName", representation.TrueName), ("presumedName", representation.PresumedName));
+            return representation.PresumedName;
+        }
+
         return representation.ToStringKnown(!ev.Cancelled);
     }
 

--- a/Resources/Locale/en-US/identity/identity-system.ftl
+++ b/Resources/Locale/en-US/identity/identity-system.ftl
@@ -7,3 +7,5 @@ identity-age-old = old
 identity-gender-feminine = woman
 identity-gender-masculine = man
 identity-gender-person = person
+
+identity-presumed-name-outed = {$trueName} (as {$presumedName})


### PR DESCRIPTION
:cl: Rane
- add: Your identity will now display if you are trying to use someone else's identity and failing. Simple PDA theft is now much easier to catch.
