### PR TITLE
undo whitelisting nukies

### DIFF
--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -18,7 +18,6 @@ using Content.Server.Spawners.Components;
 using Content.Server.Station.Components;
 using Content.Server.Station.Systems;
 using Content.Server.Traitor;
-using Content.Server.Database;
 using Content.Shared.Dataset;
 using Content.Shared.MobState;
 using Content.Shared.MobState.Components;
@@ -53,7 +52,6 @@ public sealed class NukeopsRuleSystem : GameRuleSystem
     [Dependency] private readonly GameTicker _ticker = default!;
     [Dependency] private readonly MapLoaderSystem _map = default!;
     [Dependency] private readonly RandomHumanoidSystem _randomHumanoid = default!;
-    [Dependency] private readonly IServerDbManager _db = default!;
 
 
     private enum WinType
@@ -452,7 +450,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem
             CheckRoundShouldEnd();
     }
 
-    private async void OnPlayersSpawning(RulePlayerSpawningEvent ev)
+    private void OnPlayersSpawning(RulePlayerSpawningEvent ev)
     {
         if (!RuleAdded)
             return;
@@ -474,11 +472,6 @@ public sealed class NukeopsRuleSystem : GameRuleSystem
             {
                 continue;
             }
-            if (!await _db.GetWhitelistStatusAsync(player.UserId))
-            {
-                continue;
-            }
-
             var profile = ev.Profiles[player.UserId];
             if (profile.AntagPreferences.Contains(_nukeopsRuleConfig.OperativeRoleProto))
             {


### PR DESCRIPTION
:cl: Rane
- remove: For balance concerns and a serious bug found, nuke ops no longer require whitelist.

