### PR TITLE
Stamina exhaustion threshold

### DIFF
--- a/Content.Shared/Damage/Systems/StaminaSystem.cs
+++ b/Content.Shared/Damage/Systems/StaminaSystem.cs
@@ -230,6 +230,14 @@ public sealed class StaminaSystem : EntitySystem
             _stunSystem.TrySlowdown(uid, TimeSpan.FromSeconds(3), true, 0.8f, 0.8f);
         }
 
+        var exhaustedTreshold = component.CritThreshold * 0.9f;
+
+        if (oldDamage <= exhaustedTreshold &&
+            component.StaminaDamage >= exhaustedTreshold)
+        {
+            _stunSystem.TrySlowdown(uid, TimeSpan.FromSeconds(6), true, 0.6f, 0.6f);
+        }
+
         SetStaminaAlert(uid, component);
 
         if (!component.Critical)


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

When the stamina damage reaches the 90% threshold you will suffer a slowdown with a duration of 6 seconds, this threshold will vary between Oni, human and felinid since they have different levels of stamina.

**Media**

https://user-images.githubusercontent.com/80334192/206916464-50e6f074-1326-4a90-a109-cbe37fb1f7e3.mp4

- [x] I have added screenshots/videos to this PR showcasing its changes ingame

**Changelog**

:cl: Leander
- tweak: Added a slowdown from exhaustion at 90% stamina damage.
