### PR TITLE
Bugfixes121222

### DIFF
--- a/Content.Server/Nyanotrasen/Arachne/ArachneSystem.cs
+++ b/Content.Server/Nyanotrasen/Arachne/ArachneSystem.cs
@@ -14,6 +14,8 @@ using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Damage;
 using Content.Shared.Inventory;
 using Content.Shared.Administration.Logs;
+using Content.Shared.Database;
+using Content.Shared.Examine;
 using Content.Server.Buckle.Systems;
 using Content.Server.Coordinates.Helpers;
 using Content.Server.Nutrition.EntitySystems;
@@ -33,32 +35,7 @@ using Robust.Shared.Containers;
 using Robust.Shared.Map;
 using Robust.Server.GameObjects;
 using Robust.Server.Console;
-using Content.Shared.Examine;
 using static Content.Shared.Examine.ExamineSystemShared;
-using System.Threading;
-using Content.Shared.Verbs;
-using Content.Shared.Abilities.Psionics;
-using Content.Shared.Body.Components;
-using Content.Shared.Psionics.Glimmer;
-using Content.Shared.Random;
-using Content.Shared.Random.Helpers;
-using Content.Shared.Buckle.Components;
-using Content.Shared.Administration.Logs;
-using Content.Shared.Database;
-using Content.Server.Buckle.Components;
-using Content.Server.Bible.Components;
-using Content.Server.Stunnable;
-using Content.Server.DoAfter;
-using Content.Server.Humanoid;
-using Content.Server.Players;
-using Content.Server.Popups;
-using Content.Server.Soul;
-using Content.Server.Body.Systems;
-using Robust.Shared.Prototypes;
-using Robust.Shared.Random;
-using Robust.Shared.Player;
-using Robust.Server.GameObjects;
-using Robust.Shared.Timing;
 
 namespace Content.Server.Arachne
 {
@@ -171,7 +148,7 @@ namespace Content.Server.Arachne
 
         private void OnCocEntRemoved(EntityUid uid, CocoonComponent component, EntRemovedFromContainerMessage args)
         {
-            if (component.WasReplacementAccent && TryComp<ReplacementAccentComponent>(uid, out var replacement))
+            if (component.WasReplacementAccent && TryComp<ReplacementAccentComponent>(args.Entity, out var replacement))
             {
                 replacement.Accent = component.OldAccent;
             } else

--- a/Content.Server/Nyanotrasen/Arachne/ArachneSystem.cs
+++ b/Content.Server/Nyanotrasen/Arachne/ArachneSystem.cs
@@ -13,6 +13,7 @@ using Content.Shared.Doors.Components;
 using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Damage;
 using Content.Shared.Inventory;
+using Content.Shared.Administration.Logs;
 using Content.Server.Buckle.Systems;
 using Content.Server.Coordinates.Helpers;
 using Content.Server.Nutrition.EntitySystems;
@@ -34,6 +35,30 @@ using Robust.Server.GameObjects;
 using Robust.Server.Console;
 using Content.Shared.Examine;
 using static Content.Shared.Examine.ExamineSystemShared;
+using System.Threading;
+using Content.Shared.Verbs;
+using Content.Shared.Abilities.Psionics;
+using Content.Shared.Body.Components;
+using Content.Shared.Psionics.Glimmer;
+using Content.Shared.Random;
+using Content.Shared.Random.Helpers;
+using Content.Shared.Buckle.Components;
+using Content.Shared.Administration.Logs;
+using Content.Shared.Database;
+using Content.Server.Buckle.Components;
+using Content.Server.Bible.Components;
+using Content.Server.Stunnable;
+using Content.Server.DoAfter;
+using Content.Server.Humanoid;
+using Content.Server.Players;
+using Content.Server.Popups;
+using Content.Server.Soul;
+using Content.Server.Body.Systems;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+using Robust.Shared.Player;
+using Robust.Server.GameObjects;
+using Robust.Shared.Timing;
 
 namespace Content.Server.Arachne
 {
@@ -53,6 +78,7 @@ namespace Content.Server.Arachne
         [Dependency] private readonly IServerConsoleHost _host = default!;
         [Dependency] private readonly BloodSuckerSystem _bloodSuckerSystem = default!;
         [Dependency] private readonly InventorySystem _inventorySystem = default!;
+        [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
 
         private const string BodySlot = "body_slot";
 
@@ -357,6 +383,11 @@ namespace Content.Server.Arachne
             _itemSlots.SetLock(cocoon, BodySlot, false, slots);
             _itemSlots.TryInsert(cocoon, BodySlot, args.Target, args.Webber);
             _itemSlots.SetLock(cocoon, BodySlot, true, slots);
+
+            var impact = (spawnProto == "CocoonedHumanoid") ? LogImpact.High : LogImpact.Medium;
+
+            _adminLogger.Add(LogType.Action, impact, $"{ToPrettyString(args.Webber):player} cocooned {ToPrettyString(args.Target):target}");
+
         }
 
         private void OnWebCancelled(WebCancelledEvent ev)

--- a/Content.Server/Nyanotrasen/Arachne/ArachneSystem.cs
+++ b/Content.Server/Nyanotrasen/Arachne/ArachneSystem.cs
@@ -32,6 +32,8 @@ using Robust.Shared.Containers;
 using Robust.Shared.Map;
 using Robust.Server.GameObjects;
 using Robust.Server.Console;
+using Content.Shared.Examine;
+using static Content.Shared.Examine.ExamineSystemShared;
 
 namespace Content.Server.Arachne
 {
@@ -283,7 +285,9 @@ namespace Content.Server.Arachne
                 }
             }
 
-            _popupSystem.PopupEntity(Loc.GetString("spin-web-start-third-person", ("spider", Identity.Entity(args.Performer, EntityManager))), args.Performer, Filter.PvsExcept(args.Performer), Shared.Popups.PopupType.MediumCaution);
+            _popupSystem.PopupEntity(Loc.GetString("spin-web-start-third-person", ("spider", Identity.Entity(args.Performer, EntityManager))), args.Performer,
+            Filter.PvsExcept(args.Performer).RemoveWhereAttachedEntity(entity => !ExamineSystemShared.InRangeUnOccluded(args.Performer, entity, ExamineRange, null)),
+            Shared.Popups.PopupType.MediumCaution);
             _popupSystem.PopupEntity(Loc.GetString("spin-web-start-second-person"), args.Performer, Filter.Entities(args.Performer), Shared.Popups.PopupType.Medium);
             arachne.CancelToken = new CancellationTokenSource();
             _doAfter.DoAfter(new DoAfterEventArgs(args.Performer, arachne.WebDelay, arachne.CancelToken.Token)
@@ -300,7 +304,11 @@ namespace Content.Server.Arachne
             if (component.CancelToken != null)
                 return;
 
-            _popupSystem.PopupEntity(Loc.GetString("cocoon-start-third-person", ("target", Identity.Entity(target, EntityManager)), ("spider", Identity.Entity(uid, EntityManager))), uid, Filter.PvsExcept(uid), Shared.Popups.PopupType.MediumCaution);
+            _popupSystem.PopupEntity(Loc.GetString("cocoon-start-third-person", ("target", Identity.Entity(target, EntityManager)), ("spider", Identity.Entity(uid, EntityManager))), uid,
+                // TODO: We need popup occlusion lmao
+                Filter.PvsExcept(uid).RemoveWhereAttachedEntity(entity => !ExamineSystemShared.InRangeUnOccluded(uid, entity, ExamineRange, null)),
+                Shared.Popups.PopupType.MediumCaution);
+
             _popupSystem.PopupEntity(Loc.GetString("cocoon-start-second-person", ("target", Identity.Entity(target, EntityManager))), uid, Filter.Entities(uid), Shared.Popups.PopupType.Medium);
 
             var delay = component.CocoonDelay;
@@ -380,7 +388,9 @@ namespace Content.Server.Arachne
                 _thirstSystem.UpdateThirst(thirst, -20);
 
             Spawn("ArachneWeb", ev.Coords.SnapToGrid());
-            _popupSystem.PopupEntity(Loc.GetString("spun-web-third-person", ("spider", Identity.Entity(ev.Webber, EntityManager))), ev.Webber, Filter.PvsExcept(ev.Webber), Shared.Popups.PopupType.MediumCaution);
+            _popupSystem.PopupEntity(Loc.GetString("spun-web-third-person", ("spider", Identity.Entity(ev.Webber, EntityManager))), ev.Webber,
+            Filter.PvsExcept(ev.Webber).RemoveWhereAttachedEntity(entity => !ExamineSystemShared.InRangeUnOccluded(ev.Webber, entity, ExamineRange, null)),
+            Shared.Popups.PopupType.MediumCaution);
             _popupSystem.PopupEntity(Loc.GetString("spun-web-second-person"), ev.Webber, Filter.Entities(ev.Webber), Shared.Popups.PopupType.Medium);
         }
 

--- a/Content.Server/Nyanotrasen/Chapel/SacrificialAltarSystem.cs
+++ b/Content.Server/Nyanotrasen/Chapel/SacrificialAltarSystem.cs
@@ -88,6 +88,10 @@ namespace Content.Server.Chapel
             if (!TryComp<SacrificialAltarComponent>(args.Altar, out var altarComp))
                 return;
 
+            // note: we checked this twice in case they could have gone SSD in the doafter time.
+            if (!TryComp<ActorComponent>(args.Target, out var actor))
+                return;
+
             altarComp.CancelToken = null;
 
             _adminLogger.Add(LogType.Action, LogImpact.Extreme, $"{ToPrettyString(args.User):player} sacrified {ToPrettyString(args.Target):target} on {ToPrettyString(args.Altar):altar}");
@@ -110,9 +114,6 @@ namespace Content.Server.Chapel
 
             int reduction = _robustRandom.Next(altarComp.GlimmerReductionMin, altarComp.GlimmerReductionMax);
             _glimmerSystem.Glimmer -= reduction;
-
-            if (!TryComp<ActorComponent>(args.Target, out var actor))
-                return;
 
             if (actor.PlayerSession.ContentData()?.Mind != null)
             {
@@ -182,6 +183,12 @@ namespace Content.Server.Chapel
             if (!HasComp<HumanoidComponent>(patient))
             {
                 _popups.PopupEntity(Loc.GetString("altar-failure-reason-target-humanoid", ("target", patient)), altar, Filter.Entities(agent), Shared.Popups.PopupType.SmallCaution);
+                return;
+            }
+
+            if (!HasComp<ActorComponent>(patient))
+            {
+                _popups.PopupEntity(Loc.GetString("altar-failure-reason-target-ssd", ("target", patient)), altar, Filter.Entities(agent), Shared.Popups.PopupType.SmallCaution);
                 return;
             }
 

--- a/Content.Server/Nyanotrasen/Chapel/SacrificialAltarSystem.cs
+++ b/Content.Server/Nyanotrasen/Chapel/SacrificialAltarSystem.cs
@@ -94,7 +94,7 @@ namespace Content.Server.Chapel
 
             altarComp.CancelToken = null;
 
-            _adminLogger.Add(LogType.Action, LogImpact.Extreme, $"{ToPrettyString(args.User):player} sacrified {ToPrettyString(args.Target):target} on {ToPrettyString(args.Altar):altar}");
+            _adminLogger.Add(LogType.Action, LogImpact.Extreme, $"{ToPrettyString(args.User):player} sacrificed {ToPrettyString(args.Target):target} on {ToPrettyString(args.Altar):altar}");
 
             if (!_prototypeManager.TryIndex<WeightedRandomPrototype>(altarComp.RewardPool, out var pool))
                 return;

--- a/Resources/Locale/en-US/chapel/altar.ftl
+++ b/Resources/Locale/en-US/chapel/altar.ftl
@@ -9,3 +9,4 @@ altar-failure-reason-user = You are not psionic or clerically trained!
 altar-failure-reason-user-humanoid = You are not a humanoid!
 altar-failure-reason-target = {CAPITALIZE(THE($target))} {CONJUGATE-BE($target)} not psionic!
 altar-failure-reason-target-humanoid = {CAPITALIZE(THE($target))} {CONJUGATE-BE($target)} not humanoid!
+altar-failure-reason-target-ssd = {CAPITALIZE(THE($target))} {CONJUGATE-BE($target)} SSD!

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Engineering/salvage_technician.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Engineering/salvage_technician.yml
@@ -21,9 +21,9 @@
   id: SalvageTechnicianGear
   equipment:
     jumpsuit: ClothingUniformJumpsuitSalvageSpecialist
-    back: ClothingBackpackFilled
+    back: ClothingBackpackSalvageFilled
     shoes: ClothingShoesBootsSalvage
     id: SalvageTechPDA
     ears: ClothingHeadsetEngineering
-  satchel: ClothingBackpackSatchelFilled
-  duffelbag: ClothingBackpackDuffelFilled
+  satchel: ClothingBackpackSatchelSalvageFilled
+  duffelbag: ClothingBackpackDuffelSalvageFilled


### PR DESCRIPTION
:cl: Rane
- add: Added some additional admin logs.
- fix: You can no longer see spiders spinning webs through walls.
- fix: Mice will no longer gain the ability to speak after being freed from a cocoon.
- fix: Fixed sacrificial altar's handling of SSD people.
- fix: Salvage technicians spawn with the proper backpack.

