### PR TITLE
oneirophage uses arachne damage set

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/NPCs/mutants.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/NPCs/mutants.yml
@@ -162,6 +162,9 @@
     modifiers:
       coefficients:
         Piercing: 2.25
+  - type: Damageable
+    damageContainer: Biological
+    damageModifierSet: Arachne
   - type: StatusEffects
     allowed:
       - Stun


### PR DESCRIPTION
:cl: Rane
- tweak: Oneirophages have the same damage modifier sets as arachne.
