### PR TITLE
pyrokinesis/dispel fixes/tweaks

### DIFF
--- a/Content.Server/Nyanotrasen/Abilities/Psionics/Abilities/NoosphericZapPowerSystem.cs
+++ b/Content.Server/Nyanotrasen/Abilities/Psionics/Abilities/NoosphericZapPowerSystem.cs
@@ -60,7 +60,7 @@ namespace Content.Server.Abilities.Psionics
             _beam.TryCreateBeam(args.Performer, args.Target, "LightningNoospheric");
 
             _stunSystem.TryParalyze(args.Target, TimeSpan.FromSeconds(5), false);
-            _statusEffectsSystem.TryAddStatusEffect(args.Target, "Stutter", TimeSpan.FromSeconds(30), false, "StutteringAccent");
+            _statusEffectsSystem.TryAddStatusEffect(args.Target, "Stutter", TimeSpan.FromSeconds(10), false, "StutteringAccent");
 
             _psionics.LogPowerUsed(args.Performer, "noospheric zap");
             args.Handled = true;

--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -881,7 +881,7 @@
 
 - type: entity
   id: WallForce
-  name: Force Wall
+  name: force wall
   components:
     - type: TimedDespawn
       lifetime: 20
@@ -907,3 +907,4 @@
       sprite: Structures/Magic/forcewall.rsi
       state: forcewall
     - type: Dispellable
+    - type: Clickable

--- a/Resources/Prototypes/Nyanotrasen/Actions/types.yml
+++ b/Resources/Prototypes/Nyanotrasen/Actions/types.yml
@@ -18,9 +18,9 @@
   name: action-name-dispel
   description: action-description-dispel
   icon: Nyanotrasen/Interface/VerbIcons/dispel.png
-  useDelay: 45
+  # useDelay: 45
   checkCanAccess: false
-  range: 8
+  range: 6
   canTargetSelf: false
   serverEvent: !type:DispelPowerActionEvent
 
@@ -115,7 +115,8 @@
   description: action-description-pyrokinesis
   icon: Nyanotrasen/Interface/VerbIcons/pyrokinesis.png
   useDelay: 50
-  range: 8
+  checkCanAccess: false
+  range: 6
   serverEvent: !type:PyrokinesisPowerActionEvent
 
 - type: worldTargetAction


### PR DESCRIPTION
:cl: Rane
- tweak: Reduced dispel and pyrokinesis to 6 tile range. Neither check blockers.
- tweak: The stutter from getting zapped by unsulated gloves has been reduced.
- fix: Force walls can be dispelled.