### PR TITLE
Update121622

### DIFF
--- a/Content.Server/Nyanotrasen/Abilities/Psionics/Abilities/MindSwapPowerSystem.cs
+++ b/Content.Server/Nyanotrasen/Abilities/Psionics/Abilities/MindSwapPowerSystem.cs
@@ -169,6 +169,7 @@ namespace Content.Server.Abilities.Psionics
                 RemComp<PsionicallyInvisibleComponent>(uid);
                 RemComp<StealthComponent>(uid);
                 EnsureComp<SharedSpeechComponent>(uid);
+                EnsureComp<DispellableComponent>(uid);
                 MetaData(uid).EntityName = Loc.GetString("telegnostic-trapped-entity-name");
                 MetaData(uid).EntityDescription = Loc.GetString("telegnostic-trapped-entity-desc");
             }

--- a/Content.Server/Nyanotrasen/Fugitive/FugitiveSystem.cs
+++ b/Content.Server/Nyanotrasen/Fugitive/FugitiveSystem.cs
@@ -17,12 +17,15 @@ using Content.Shared.Movement.Systems;
 using Content.Shared.Humanoid.Prototypes;
 using Content.Shared.Humanoid;
 using Content.Shared.Random.Helpers;
+using Content.Shared.Examine;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
+using Robust.Shared.Audio;
 using Robust.Shared.Utility;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Player;
 using Robust.Server.GameObjects;
+using static Content.Shared.Examine.ExamineSystemShared;
 
 namespace Content.Server.Fugitive
 {
@@ -84,10 +87,11 @@ namespace Content.Server.Fugitive
             if (TryComp<FugitiveCountdownComponent>(uid, out var cd))
                 cd.AnnounceTime = _timing.CurTime + cd.AnnounceCD;
 
-            _popupSystem.PopupEntity(Loc.GetString("fugitive-spawn", ("name", uid)), uid, Filter.Pvs(uid), Shared.Popups.PopupType.LargeCaution);
+            _popupSystem.PopupEntity(Loc.GetString("fugitive-spawn", ("name", uid)), uid,
+            Filter.Pvs(uid).RemoveWhereAttachedEntity(entity => !ExamineSystemShared.InRangeUnOccluded(uid, entity, ExamineRange, null)), Shared.Popups.PopupType.LargeCaution);
 
             _stun.TryParalyze(uid, TimeSpan.FromSeconds(2), false);
-            _audioSystem.PlayPvs(component.SpawnSoundPath, uid);
+            _audioSystem.PlayPvs(component.SpawnSoundPath, uid, AudioParams.Default.WithVolume(-6f));
 
             var tile = Spawn("FloorTileItemSteel", Transform(uid).Coordinates);
             tile.RandomOffset(0.3f);

--- a/Content.Server/Nyanotrasen/Psionics/PsionicsSystem.cs
+++ b/Content.Server/Nyanotrasen/Psionics/PsionicsSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.MobState;
 using Content.Shared.Psionics.Glimmer;
 using Content.Shared.Weapons.Melee.Events;
 using Content.Shared.Damage.Events;
+using Content.Shared.IdentityManagement;
 using Content.Server.Abilities.Psionics;
 using Content.Server.Electrocution;
 using Content.Server.Chat.Systems;
@@ -89,13 +90,13 @@ namespace Content.Server.Psionics
             switch (_glimmerSystem.GetGlimmerTier())
             {
                 case GlimmerTier.Critical:
-                    message = Loc.GetString("death-gasp-high", ("ent", uid));
+                    message = Loc.GetString("death-gasp-high", ("ent", Identity.Entity(uid, EntityManager)));
                     break;
                 case GlimmerTier.Dangerous:
-                    message = Loc.GetString("death-gasp-medium", ("ent", uid));
+                    message = Loc.GetString("death-gasp-medium", ("ent",Identity.Entity(uid, EntityManager)));
                     break;
                 default:
-                    message = Loc.GetString("death-gasp-normal", ("ent", uid));
+                    message = Loc.GetString("death-gasp-normal", ("ent", Identity.Entity(uid, EntityManager)));
                     break;
             }
 


### PR DESCRIPTION
:cl: Rane
- fix: Death gasps conceal identity.
- fix: Severed telegnostic projections can be dispelled.
- fix: The popup for fugitive spawn no longer appears through walls.
- tweak: Reduced volume of fugitives spawning.

