### PR TITLE
Fix missing parallaxes.

### DIFF
--- a/Resources/Maps/ovni.yml
+++ b/Resources/Maps/ovni.yml
@@ -11299,6 +11299,8 @@ entities:
   - type: Transform
   - index: 4
     type: Map
+  - type: Parallax
+    parallax: PebbleStation
   - type: PhysicsMap
   - type: Broadphase
   - type: OccluderTree

--- a/Resources/Maps/pebble.yml
+++ b/Resources/Maps/pebble.yml
@@ -13001,6 +13001,8 @@ entities:
   - type: Transform
   - index: 4
     type: Map
+  - type: Parallax
+    parallax: PebbleStation
   - type: PhysicsMap
   - type: Broadphase
   - type: OccluderTree


### PR DESCRIPTION
Ovni, Pebble, and Tortuga's Parallax components were overwritten by map updates.
