### PR TITLE
Updates ChefVend inventory w/ Monkey Cubes

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
@@ -23,7 +23,7 @@
     sprite: Objects/Specific/Service/vending_machine_restock.rsi
     state: base
   product: CrateVendingMachineRestockChefvendFilled
-  cost: 680
+  cost: 720
   category: Service
   group: market
 

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chefvend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chefvend.yml
@@ -11,10 +11,10 @@
     FoodCondimentBottleBBQ: 1
     FoodCondimentBottleSmallVinegar: 2
     ReagentContainerOliveoil: 2
-    #cold??
     FoodContainerEgg: 1
     ReagentContainerMilk: 2
     ReagentContainerMilkSoy: 1
+    MonkeyCubeBox: 1
     FoodButter: 4
     FoodCheese: 1
     FoodMeat: 6


### PR DESCRIPTION
Changelog:

-Adds monkey cube box to ChefVend
-Adjusts restock price accordingly

(sorry, I meant to update with the chefvend texture at the same time.)