### PR TITLE
Save BC20_emergencyShuttleG as grid.

### DIFF
--- a/Resources/Maps/Shuttles/BC20_emergencyShuttleG.yml
+++ b/Resources/Maps/Shuttles/BC20_emergencyShuttleG.yml
@@ -104,7 +104,7 @@ entities:
   components:
   - type: MetaData
   - pos: 0.5104167,0.43224397
-    parent: 2
+    parent: invalid
     type: Transform
   - chunks:
       0,-1:
@@ -142,7 +142,6 @@ entities:
     type: Fixtures
   - gravityShakeSound: !type:SoundPathSpecifier
       path: /Audio/Effects/alert.ogg
-    enabled: True
     type: Gravity
   - chunkCollection:
       -1,-1:
@@ -1730,8 +1729,8 @@ entities:
     - volume: 2500
       temperature: 293.15
       moles:
-      - 21.213781
-      - 79.80423
+      - 20.619795
+      - 77.56971
       - 0
       - 0
       - 0
@@ -1777,15 +1776,10 @@ entities:
   - type: Shuttle
   - type: GridPathfinding
   - type: RadiationGridResistance
-- uid: 2
-  components:
-  - type: MetaData
-  - type: Transform
-  - index: 2
-    type: Map
-  - type: PhysicsMap
-  - type: Broadphase
-  - type: OccluderTree
+  - nextShake: 0
+    shakeTimes: 10
+    type: GravityShake
+  - type: GasTileOverlay
 - uid: 3
   type: LockerSecurityFilled
   components:


### PR DESCRIPTION
The shuttle in #803 was not saved as a grid. I re-saved it as a grid, forcemapped Lighthouse, called the shuttle, and confirmed that it can dock without issue.