### PR TITLE
Add Fish and Chips, remove carpotoxin from meals

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/meals.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/meals.yml
@@ -230,9 +230,32 @@
         reagents:
         - ReagentId: Nutriment
           Quantity: 6
-        - ReagentId: CarpoToxin
+        - ReagentId: Protein
           Quantity: 3
 # Tastes like fish, batter, hot peppers.
+
+- type: entity
+  name: fish and chips
+  parent: FoodMealBase
+  id: FoodMealFishChips
+  description: A dish that consists of fried fish and potatoes.
+  components:
+  - type: FlavorProfile
+    flavors:
+      - fishy
+      - batter
+  - type: Sprite
+    state: fishandchips
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 15
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 4
+        - ReagentId: Protein
+          Quantity: 3
+# Tastes like fish and batter.
 
 - type: entity
   name: corned beef and cabbage
@@ -472,7 +495,7 @@
   name: Sashimi
   parent: FoodMealBase
   id: FoodMealSashimi
-  description: Its taste can only be described as "Exotic". The poisoning though? That's pretty common.
+  description: Its taste can only be described as "Exotic".
   components:
   - type: FlavorProfile
     flavors:
@@ -485,9 +508,9 @@
         maxVol: 18
         reagents:
         - ReagentId: Nutriment
+          Quantity: 2
+        - ReagentId: Protein
           Quantity: 6
-        - ReagentId: CarpoToxin
-          Quantity: 15
 # tastes exotic
 
 - type: entity

--- a/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
@@ -617,6 +617,16 @@
     FoodMeatFish: 2
 
 - type: microwaveMealRecipe
+  id: RecipeFishChips
+  name: fish and chips recipe
+  result: FoodMealFishChips
+  time: 15
+  solids:
+    FoodDough: 1
+    FoodPotato: 1
+    FoodMeatFish: 1
+
+- type: microwaveMealRecipe
   id: RecipeSashimi
   name: sashimi recipe
   result: FoodMealSashimi


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

The Pescetarian PR!

Adds a recipe for fish and chips, a dish that requires dough, potato, and carp.
Adjusts meals' contents by removing carpotoxin from carp-related meals, namely Cuban Carp and Sashimi.

The sprite for fish and chips is already in the Textures folder.

**Media**

![image](https://user-images.githubusercontent.com/113523727/209475611-529da093-d69f-4110-b239-5e6e425af226.png)

**Changelog**
:cl:
- add: Added a new recipe for fish and chips, and made dishes with fish not kill you.