### PR TITLE
Updated shuttle airlocks

### DIFF
--- a/Resources/Maps/Shuttles/NTES_Kaeri.yml
+++ b/Resources/Maps/Shuttles/NTES_Kaeri.yml
@@ -4349,7 +4349,7 @@ entities:
   - powerLoad: 0
     type: ApcPowerReceiver
 - uid: 566
-  type: AirlockExternalGlassShuttleEmergencyLocked
+  type: AirlockGlassShuttle
   components:
   - rot: -1.5707963267948966 rad
     pos: -7.5,2.5
@@ -4382,7 +4382,7 @@ entities:
       id: docking
     type: Fixtures
 - uid: 567
-  type: AirlockExternalGlassShuttleEmergencyLocked
+  type: AirlockGlassShuttle
   components:
   - rot: -1.5707963267948966 rad
     pos: -7.5,4.5
@@ -4415,10 +4415,10 @@ entities:
       id: docking
     type: Fixtures
 - uid: 568
-  type: AirlockExternalGlassShuttleEmergencyLocked
+  type: AirlockGlassShuttle
   components:
   - rot: 1.5707963267948966 rad
-    pos: 6.5,4.5
+    pos: 6.5,2.5
     parent: 0
     type: Transform
   - fixtures:
@@ -4448,10 +4448,10 @@ entities:
       id: docking
     type: Fixtures
 - uid: 569
-  type: AirlockExternalGlassShuttleEmergencyLocked
+  type: AirlockGlassShuttle
   components:
   - rot: 1.5707963267948966 rad
-    pos: 6.5,2.5
+    pos: 6.5,4.5
     parent: 0
     type: Transform
   - fixtures:
@@ -4592,40 +4592,7 @@ entities:
   - powerLoad: 0
     type: ApcPowerReceiver
 - uid: 584
-  type: AirlockExternalGlassShuttleEmergencyLocked
-  components:
-  - rot: 1.5707963267948966 rad
-    pos: 6.5,-3.5
-    parent: 0
-    type: Transform
-  - fixtures:
-    - density: 100
-      shape: !type:PolygonShape
-        vertices:
-        - 0.49,-0.49
-        - 0.49,0.49
-        - -0.49,0.49
-        - -0.49,-0.49
-      mask:
-      - Impassable
-      - MidImpassable
-      - HighImpassable
-      - LowImpassable
-      - InteractImpassable
-      layer:
-      - MidImpassable
-      - HighImpassable
-      - BulletImpassable
-      - InteractImpassable
-      - Opaque
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
-- uid: 585
-  type: AirlockExternalGlassShuttleEmergencyLocked
+  type: AirlockGlassShuttle
   components:
   - rot: 1.5707963267948966 rad
     pos: 6.5,-5.5
@@ -4657,8 +4624,41 @@ entities:
       hard: False
       id: docking
     type: Fixtures
+- uid: 585
+  type: AirlockGlassShuttle
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: 6.5,-3.5
+    parent: 0
+    type: Transform
+  - fixtures:
+    - density: 100
+      shape: !type:PolygonShape
+        vertices:
+        - 0.49,-0.49
+        - 0.49,0.49
+        - -0.49,0.49
+        - -0.49,-0.49
+      mask:
+      - Impassable
+      - MidImpassable
+      - HighImpassable
+      - LowImpassable
+      - InteractImpassable
+      layer:
+      - MidImpassable
+      - HighImpassable
+      - BulletImpassable
+      - InteractImpassable
+      - Opaque
+    - shape: !type:PhysShapeCircle
+        position: 0,-0.5
+        radius: 0.2
+      hard: False
+      id: docking
+    type: Fixtures
 - uid: 586
-  type: AirlockExternalGlassShuttleEmergencyLocked
+  type: AirlockGlassShuttle
   components:
   - rot: -1.5707963267948966 rad
     pos: -7.5,-5.5
@@ -4691,7 +4691,7 @@ entities:
       id: docking
     type: Fixtures
 - uid: 587
-  type: AirlockExternalGlassShuttleEmergencyLocked
+  type: AirlockGlassShuttle
   components:
   - rot: -1.5707963267948966 rad
     pos: -7.5,-3.5
@@ -4908,6 +4908,12 @@ entities:
     type: AmbientSound
   - powerLoad: 0
     type: ApcPowerReceiver
+- uid: 617
+  type: ClothingHeadHatSombrero
+  components:
+  - pos: 0.8424497,-9.161962
+    parent: 0
+    type: Transform
 - uid: 618
   type: ShuttleWindow
   components:
@@ -5141,7 +5147,7 @@ entities:
     parent: 0
     type: Transform
 - uid: 652
-  type: RandomDrinkGlass
+  type: RandomItem
   components:
   - pos: 4.5,-0.5
     parent: 0

--- a/Resources/Maps/Shuttles/emergency.yml
+++ b/Resources/Maps/Shuttles/emergency.yml
@@ -1,5 +1,5 @@
 meta:
-  format: 2
+  format: 3
   name: DemoStation
   author: Space-Wizards
   postmapinit: false
@@ -26,60 +26,73 @@ tilemap:
   19: FloorCaveDrought
   20: FloorClown
   21: FloorDark
-  22: FloorDirt
-  23: FloorEighties
-  24: FloorElevatorShaft
-  25: FloorFreezer
-  26: FloorGlass
-  27: FloorGold
-  28: FloorGrass
-  29: FloorGrassDark
-  30: FloorGrassJungle
-  31: FloorGrassLight
-  32: FloorGreenCircuit
-  33: FloorGym
-  34: FloorHydro
-  35: FloorKitchen
-  36: FloorLaundry
-  37: FloorLino
-  38: FloorMetalDiamond
-  39: FloorMime
-  40: FloorMono
-  41: FloorRGlass
-  42: FloorReinforced
-  43: FloorRockVault
-  44: FloorShowroom
-  45: FloorShuttleBlue
-  46: FloorShuttleOrange
-  47: FloorShuttlePurple
-  48: FloorShuttleRed
-  49: FloorShuttleWhite
-  50: FloorSilver
-  51: FloorSnow
-  52: FloorSteel
-  53: FloorSteelDirty
-  54: FloorTechMaint
-  55: FloorWhite
-  56: FloorWood
-  57: Lattice
-  58: Plating
-grids:
-- settings:
-    chunksize: 16
-    tilesize: 1
-  chunks:
-  - ind: -1,-1
-    tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA5AAAAOQAAADkAAAA5AAAAOQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA5AAAAOgAAADoAAAAqAAAAKgAAACoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOgAAADoAAAAgAAAAIAAAACAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOQAAACoAAAA6AAAAOgAAADoAAAA6AAAAOgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADoAAAA6AAAAJgAAACYAAAAmAAAAOgAAAA4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADoAAAA6AAAAJgAAACYAAAAmAAAAJgAAADoAAAA6AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAqAAAADgAAACYAAAAmAAAAJgAAACYAAAAmAAAAJgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOgAAADoAAAAVAAAAFQAAABUAAAAVAAAAJgAAACYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADkAAAA6AAAAOgAAADoAAAA6AAAAOgAAADoAAAAoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA5AAAAKgAAABUAAAApAAAAKQAAABUAAAA6AAAAFQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOQAAACoAAAAVAAAAKQAAACkAAAAVAAAAKgAAABUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADkAAAAqAAAAFQAAACkAAAApAAAAFQAAACoAAAAVAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA5AAAAOgAAABUAAAApAAAAKQAAABUAAAAqAAAAFQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOQAAACoAAAAVAAAAKQAAACkAAAAVAAAAKgAAABUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADkAAAAqAAAAFQAAACkAAAApAAAAFQAAABUAAAAVAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA5AAAAKgAAACoAAAAoAAAAKQAAADoAAAAVAAAAFQAAAA==
-  - ind: 0,-1
-    tiles: OQAAADkAAAA5AAAAOQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACoAAAAqAAAAOgAAADoAAAA5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAIAAAACAAAAA6AAAAOgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOgAAADoAAAA6AAAAOgAAACoAAAA5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADoAAAAmAAAAJgAAACYAAAA6AAAAOgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA6AAAAJgAAACYAAAAmAAAAJgAAADoAAAA6AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJgAAACYAAAAmAAAAJgAAACYAAAAOAAAAKgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACYAAAAVAAAAFQAAABUAAAAVAAAAOgAAADoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAqAAAAOgAAADoAAAA6AAAAOgAAADoAAAA5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFQAAADoAAAA3AAAANwAAADcAAAAqAAAAOQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABUAAAAoAAAANwAAADcAAAA3AAAAKgAAADkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVAAAAOgAAADcAAAA3AAAANwAAACoAAAA5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFQAAADoAAAA6AAAAOgAAADoAAAA6AAAAOQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABUAAAA6AAAAFQAAABUAAAAVAAAAKgAAADkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVAAAAFQAAABUAAAAVAAAAFQAAACoAAAA5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFQAAABUAAAAVAAAAFQAAABUAAAAqAAAAOQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
-  - ind: -1,0
-    tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA5AAAAOgAAABUAAAApAAAAKQAAABUAAAAVAAAAFQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOQAAADoAAAAVAAAAKQAAACkAAAApAAAAFQAAABUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADkAAAAqAAAAFQAAABUAAAAVAAAAFQAAABUAAAApAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADoAAAA6AAAAOgAAABUAAAAVAAAAFQAAABUAAAAVAAAAFQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADoAAAA6AAAAKgAAADoAAAAqAAAAKgAAACoAAAA6AAAAKAAAACgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAqAAAAKgAAACoAAAAqAAAAFQAAABUAAAAVAAAAFQAAABUAAAAVAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOgAAADoAAAA6AAAAOgAAABUAAAApAAAAFQAAABUAAAApAAAAFQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACoAAAAqAAAAKgAAACoAAAAVAAAAFQAAABUAAAAVAAAAFQAAABUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA6AAAAOgAAADoAAAA6AAAAKAAAACgAAAAoAAAAOgAAACoAAAAoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOQAAADkAAAA5AAAAKgAAABUAAAAVAAAAFQAAADoAAAAVAAAAFQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADkAAAAAAAAAOQAAACoAAAAVAAAAKQAAABUAAAAqAAAAFQAAABUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA5AAAAOQAAADkAAAAqAAAAFQAAABUAAAAVAAAAKgAAABUAAAAVAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOgAAADoAAAA6AAAAOgAAABUAAAAVAAAAFQAAADoAAAAVAAAAFQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACoAAAAqAAAAKgAAACoAAAAVAAAAFQAAABUAAAA6AAAAOgAAACgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA6AAAAOgAAADoAAAA6AAAAFQAAACkAAAAVAAAAOgAAACYAAAAmAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKgAAACoAAAAqAAAAKgAAABUAAAAVAAAAFQAAADoAAAAmAAAAJgAAAA==
-  - ind: 0,0
-    tiles: FQAAABUAAAAVAAAAOAAAADgAAAA6AAAAOQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABUAAAAVAAAAFQAAADgAAAA4AAAAOgAAADkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVAAAAFQAAABUAAAA4AAAAOAAAACoAAAA5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFQAAABUAAAAVAAAAOAAAADgAAAA6AAAAOgAAADoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACgAAAA6AAAAOgAAADoAAAA6AAAAOgAAACoAAAA6AAAAOgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVAAAAFQAAABUAAAAVAAAAFQAAACoAAAAqAAAAKgAAACoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKQAAABUAAAAVAAAAKQAAABUAAAA6AAAAOgAAADoAAAA6AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABUAAAAVAAAAFQAAABUAAAAVAAAAKgAAACoAAAAqAAAAKgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAqAAAAOgAAACgAAAAoAAAAKAAAADoAAAA6AAAAOgAAADoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFQAAADoAAAAVAAAAFQAAABUAAAAqAAAAOQAAADkAAAA5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABUAAAAqAAAAFQAAACkAAAAVAAAAKgAAADkAAAAAAAAAOQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVAAAAKgAAABUAAAAVAAAAFQAAACoAAAA5AAAAOQAAADkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFQAAADoAAAAVAAAAFQAAABUAAAA6AAAAOgAAADoAAAA6AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADoAAAA6AAAAFQAAABUAAAAVAAAAKgAAACoAAAAqAAAAKgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAmAAAAOgAAABUAAAApAAAAFQAAADoAAAA6AAAAOgAAADoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJgAAADoAAAAVAAAAFQAAABUAAAAqAAAAKgAAACoAAAAqAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
-  - ind: 0,1
-    tiles: OgAAADoAAAAoAAAAKAAAACgAAAA6AAAAKgAAADoAAAA6AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABUAAAAVAAAAFQAAABUAAAAVAAAAOgAAADoAAAA6AAAAOQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAApAAAAFQAAACkAAAAVAAAAFQAAABUAAAA6AAAAOQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFQAAABUAAAAVAAAAFQAAABUAAAA6AAAAOgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACoAAAA6AAAAKgAAACoAAAA6AAAAOgAAADkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA3AAAANwAAADcAAAA3AAAANwAAACoAAAA5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAANwAAADcAAAA3AAAANwAAADcAAAAqAAAAOQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADcAAAA3AAAANwAAADcAAAA3AAAAKgAAADkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA6AAAAOgAAADoAAAA6AAAAOgAAADoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKQAAACkAAAApAAAAKQAAABUAAAAqAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABUAAAApAAAAFQAAABUAAAAqAAAAKgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVAAAAKQAAABUAAAAqAAAAKgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKgAAACoAAAAqAAAAKgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
-  - ind: -1,1
-    tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOgAAADoAAAAqAAAAOgAAACgAAAAoAAAAKAAAADoAAAA6AAAAOgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADkAAAA6AAAAOgAAADoAAAAVAAAAFQAAABUAAAAVAAAAFQAAACkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOQAAADoAAAAVAAAAFQAAABUAAAApAAAAFQAAACkAAAApAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA6AAAAOgAAABUAAAAVAAAAFQAAABUAAAAVAAAAKQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOQAAADoAAAAVAAAAKQAAABUAAAA6AAAAKgAAACgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADkAAAAqAAAAFQAAABUAAAAVAAAAOgAAADcAAAA3AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA5AAAAKgAAABUAAAAVAAAAFQAAACoAAAA3AAAANwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOQAAACoAAAAVAAAAKQAAABUAAAA6AAAANwAAADcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA6AAAAKgAAACgAAAAqAAAAOgAAADoAAAA6AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKgAAABUAAAApAAAAKQAAACkAAAApAAAAKQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACoAAAAqAAAAFQAAABUAAAApAAAAFQAAACkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKgAAACoAAAAVAAAAKQAAABUAAAApAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAqAAAAKgAAACoAAAAqAAAAKgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+  22: FloorDarkDiagonal
+  23: FloorDarkDiagonalMini
+  24: FloorDarkHerringbone
+  25: FloorDarkMini
+  26: FloorDarkMono
+  27: FloorDarkOffset
+  28: FloorDarkPavement
+  29: FloorDarkPavementVertical
+  30: FloorDarkPlastic
+  31: FloorDirt
+  32: FloorEighties
+  33: FloorElevatorShaft
+  34: FloorFreezer
+  35: FloorGlass
+  36: FloorGold
+  37: FloorGrass
+  38: FloorGrassDark
+  39: FloorGrassJungle
+  40: FloorGrassLight
+  41: FloorGreenCircuit
+  42: FloorGym
+  43: FloorHydro
+  44: FloorKitchen
+  45: FloorLaundry
+  46: FloorLino
+  47: FloorMetalDiamond
+  48: FloorMime
+  49: FloorMono
+  50: FloorPlastic
+  51: FloorRGlass
+  52: FloorReinforced
+  53: FloorRockVault
+  54: FloorShowroom
+  55: FloorShuttleBlue
+  56: FloorShuttleOrange
+  57: FloorShuttlePurple
+  58: FloorShuttleRed
+  59: FloorShuttleWhite
+  60: FloorSilver
+  61: FloorSnow
+  62: FloorSteel
+  63: FloorSteelDiagonal
+  64: FloorSteelDiagonalMini
+  65: FloorSteelDirty
+  66: FloorSteelHerringbone
+  67: FloorSteelMini
+  68: FloorSteelMono
+  69: FloorSteelOffset
+  70: FloorSteelPavement
+  71: FloorSteelPavementVertical
+  72: FloorTechMaint
+  73: FloorTechMaint2
+  74: FloorTechMaint3
+  75: FloorWhite
+  76: FloorWhiteDiagonal
+  77: FloorWhiteDiagonalMini
+  78: FloorWhiteHerringbone
+  79: FloorWhiteMini
+  80: FloorWhiteMono
+  81: FloorWhiteOffset
+  82: FloorWhitePavement
+  83: FloorWhitePavementVertical
+  84: FloorWhitePlastic
+  85: FloorWood
+  86: FloorWoodTile
+  87: Lattice
+  88: Plating
 entities:
 - uid: 0
   type: Grille
@@ -279,6 +292,7 @@ entities:
   - pos: 6.5,13.5
     parent: 408
     type: Transform
+  - type: ActiveEmergencyLight
 - uid: 32
   type: EmergencyLight
   components:
@@ -286,6 +300,7 @@ entities:
     pos: -7.5,15.5
     parent: 408
     type: Transform
+  - type: ActiveEmergencyLight
 - uid: 33
   type: PoweredlightLED
   components:
@@ -418,6 +433,7 @@ entities:
   - pos: 3.5,-8.5
     parent: 408
     type: Transform
+  - type: ActiveEmergencyLight
 - uid: 50
   type: EmergencyLight
   components:
@@ -425,6 +441,7 @@ entities:
     pos: -5.5,-3.5
     parent: 408
     type: Transform
+  - type: ActiveEmergencyLight
 - uid: 51
   type: Poweredlight
   components:
@@ -459,12 +476,14 @@ entities:
     pos: 6.5,15.5
     parent: 408
     type: Transform
+  - type: ActiveEmergencyLight
 - uid: 55
   type: EmergencyLight
   components:
   - pos: -7.5,13.5
     parent: 408
     type: Transform
+  - type: ActiveEmergencyLight
 - uid: 56
   type: ChairPilotSeat
   components:
@@ -499,6 +518,7 @@ entities:
   - pos: -4.5,-8.5
     parent: 408
     type: Transform
+  - type: ActiveEmergencyLight
 - uid: 61
   type: EmergencyLight
   components:
@@ -506,6 +526,7 @@ entities:
     pos: 1.5,-1.5
     parent: 408
     type: Transform
+  - type: ActiveEmergencyLight
 - uid: 62
   type: FirelockGlass
   components:
@@ -623,6 +644,8 @@ entities:
 - uid: 80
   type: VendingMachineBooze
   components:
+  - flags: SessionSpecific
+    type: MetaData
   - pos: 4.5,3.5
     parent: 408
     type: Transform
@@ -799,6 +822,8 @@ entities:
 - uid: 107
   type: VendingMachineGames
   components:
+  - flags: SessionSpecific
+    type: MetaData
   - pos: -6.5,18.5
     parent: 408
     type: Transform
@@ -881,6 +906,8 @@ entities:
 - uid: 120
   type: VendingMachineSnack
   components:
+  - flags: SessionSpecific
+    type: MetaData
   - pos: 5.5,18.5
     parent: 408
     type: Transform
@@ -1018,12 +1045,14 @@ entities:
   - pos: 6.5,5.5
     parent: 408
     type: Transform
+  - type: ActiveEmergencyLight
 - uid: 141
   type: EmergencyLight
   components:
   - pos: -7.5,5.5
     parent: 408
     type: Transform
+  - type: ActiveEmergencyLight
 - uid: 142
   type: EmergencyLight
   components:
@@ -1031,6 +1060,7 @@ entities:
     pos: -7.5,7.5
     parent: 408
     type: Transform
+  - type: ActiveEmergencyLight
 - uid: 143
   type: EmergencyLight
   components:
@@ -1038,6 +1068,7 @@ entities:
     pos: 6.5,7.5
     parent: 408
     type: Transform
+  - type: ActiveEmergencyLight
 - uid: 144
   type: ChairPilotSeat
   components:
@@ -1102,7 +1133,8 @@ entities:
 - uid: 154
   type: VendingMachineCigs
   components:
-  - name: cigarette machine
+  - flags: SessionSpecific
+    name: cigarette machine
     type: MetaData
   - pos: -1.5,0.5
     parent: 408
@@ -1238,6 +1270,270 @@ entities:
   - pos: 3.5,3.5
     parent: 408
     type: Transform
+- uid: 174
+  type: AirlockGlassShuttle
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: -9.5,7.5
+    parent: 408
+    type: Transform
+  - fixtures:
+    - density: 100
+      shape: !type:PolygonShape
+        vertices:
+        - 0.49,-0.49
+        - 0.49,0.49
+        - -0.49,0.49
+        - -0.49,-0.49
+      mask:
+      - Impassable
+      - MidImpassable
+      - HighImpassable
+      - LowImpassable
+      - InteractImpassable
+      layer:
+      - MidImpassable
+      - HighImpassable
+      - BulletImpassable
+      - InteractImpassable
+      - Opaque
+    - shape: !type:PhysShapeCircle
+        position: 0,-0.5
+        radius: 0.2
+      hard: False
+      id: docking
+    type: Fixtures
+- uid: 175
+  type: AirlockGlassShuttle
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: -9.5,5.5
+    parent: 408
+    type: Transform
+  - fixtures:
+    - density: 100
+      shape: !type:PolygonShape
+        vertices:
+        - 0.49,-0.49
+        - 0.49,0.49
+        - -0.49,0.49
+        - -0.49,-0.49
+      mask:
+      - Impassable
+      - MidImpassable
+      - HighImpassable
+      - LowImpassable
+      - InteractImpassable
+      layer:
+      - MidImpassable
+      - HighImpassable
+      - BulletImpassable
+      - InteractImpassable
+      - Opaque
+    - shape: !type:PhysShapeCircle
+        position: 0,-0.5
+        radius: 0.2
+      hard: False
+      id: docking
+    type: Fixtures
+- uid: 176
+  type: AirlockGlassShuttle
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: -9.5,15.5
+    parent: 408
+    type: Transform
+  - fixtures:
+    - density: 100
+      shape: !type:PolygonShape
+        vertices:
+        - 0.49,-0.49
+        - 0.49,0.49
+        - -0.49,0.49
+        - -0.49,-0.49
+      mask:
+      - Impassable
+      - MidImpassable
+      - HighImpassable
+      - LowImpassable
+      - InteractImpassable
+      layer:
+      - MidImpassable
+      - HighImpassable
+      - BulletImpassable
+      - InteractImpassable
+      - Opaque
+    - shape: !type:PhysShapeCircle
+        position: 0,-0.5
+        radius: 0.2
+      hard: False
+      id: docking
+    type: Fixtures
+- uid: 177
+  type: AirlockGlassShuttle
+  components:
+  - rot: -1.5707963267948966 rad
+    pos: -9.5,13.5
+    parent: 408
+    type: Transform
+  - fixtures:
+    - density: 100
+      shape: !type:PolygonShape
+        vertices:
+        - 0.49,-0.49
+        - 0.49,0.49
+        - -0.49,0.49
+        - -0.49,-0.49
+      mask:
+      - Impassable
+      - MidImpassable
+      - HighImpassable
+      - LowImpassable
+      - InteractImpassable
+      layer:
+      - MidImpassable
+      - HighImpassable
+      - BulletImpassable
+      - InteractImpassable
+      - Opaque
+    - shape: !type:PhysShapeCircle
+        position: 0,-0.5
+        radius: 0.2
+      hard: False
+      id: docking
+    type: Fixtures
+- uid: 178
+  type: AirlockGlassShuttle
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: 8.5,5.5
+    parent: 408
+    type: Transform
+  - fixtures:
+    - density: 100
+      shape: !type:PolygonShape
+        vertices:
+        - 0.49,-0.49
+        - 0.49,0.49
+        - -0.49,0.49
+        - -0.49,-0.49
+      mask:
+      - Impassable
+      - MidImpassable
+      - HighImpassable
+      - LowImpassable
+      - InteractImpassable
+      layer:
+      - MidImpassable
+      - HighImpassable
+      - BulletImpassable
+      - InteractImpassable
+      - Opaque
+    - shape: !type:PhysShapeCircle
+        position: 0,-0.5
+        radius: 0.2
+      hard: False
+      id: docking
+    type: Fixtures
+- uid: 179
+  type: AirlockGlassShuttle
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: 8.5,7.5
+    parent: 408
+    type: Transform
+  - fixtures:
+    - density: 100
+      shape: !type:PolygonShape
+        vertices:
+        - 0.49,-0.49
+        - 0.49,0.49
+        - -0.49,0.49
+        - -0.49,-0.49
+      mask:
+      - Impassable
+      - MidImpassable
+      - HighImpassable
+      - LowImpassable
+      - InteractImpassable
+      layer:
+      - MidImpassable
+      - HighImpassable
+      - BulletImpassable
+      - InteractImpassable
+      - Opaque
+    - shape: !type:PhysShapeCircle
+        position: 0,-0.5
+        radius: 0.2
+      hard: False
+      id: docking
+    type: Fixtures
+- uid: 180
+  type: AirlockGlassShuttle
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: 8.5,13.5
+    parent: 408
+    type: Transform
+  - fixtures:
+    - density: 100
+      shape: !type:PolygonShape
+        vertices:
+        - 0.49,-0.49
+        - 0.49,0.49
+        - -0.49,0.49
+        - -0.49,-0.49
+      mask:
+      - Impassable
+      - MidImpassable
+      - HighImpassable
+      - LowImpassable
+      - InteractImpassable
+      layer:
+      - MidImpassable
+      - HighImpassable
+      - BulletImpassable
+      - InteractImpassable
+      - Opaque
+    - shape: !type:PhysShapeCircle
+        position: 0,-0.5
+        radius: 0.2
+      hard: False
+      id: docking
+    type: Fixtures
+- uid: 181
+  type: AirlockGlassShuttle
+  components:
+  - rot: 1.5707963267948966 rad
+    pos: 8.5,15.5
+    parent: 408
+    type: Transform
+  - fixtures:
+    - density: 100
+      shape: !type:PolygonShape
+        vertices:
+        - 0.49,-0.49
+        - 0.49,0.49
+        - -0.49,0.49
+        - -0.49,-0.49
+      mask:
+      - Impassable
+      - MidImpassable
+      - HighImpassable
+      - LowImpassable
+      - InteractImpassable
+      layer:
+      - MidImpassable
+      - HighImpassable
+      - BulletImpassable
+      - InteractImpassable
+      - Opaque
+    - shape: !type:PhysShapeCircle
+        position: 0,-0.5
+        radius: 0.2
+      hard: False
+      id: docking
+    type: Fixtures
 - uid: 404
   type: Grille
   components:
@@ -1264,11 +1560,31 @@ entities:
     type: Transform
 - uid: 408
   components:
+  - type: MetaData
   - pos: 17.578129,1.4298215
-    parent: null
+    parent: invalid
     type: Transform
-  - index: 0
+  - chunks:
+      -1,-1:
+        ind: -1,-1
+        tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABXAAAAVwAAAFcAAABXAAAAVwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABXAAAAWAAAAFgAAAA0AAAANAAAADQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWAAAAFgAAAApAAAAKQAAACkAAAApAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVwAAADQAAABYAAAAWAAAAFgAAABYAAAAWAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFgAAABYAAAALwAAAC8AAAAvAAAAWAAAAA4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFgAAABYAAAALwAAAC8AAAAvAAAALwAAAFgAAABYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA0AAAADgAAAC8AAAAvAAAALwAAAC8AAAAvAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWAAAAFgAAAAVAAAAFQAAABUAAAAVAAAALwAAAC8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFcAAABYAAAAWAAAAFgAAABYAAAAWAAAAFgAAAAxAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABXAAAANAAAABUAAAAzAAAAMwAAABUAAABYAAAAFQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVwAAADQAAAAVAAAAMwAAADMAAAAVAAAANAAAABUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFcAAAA0AAAAFQAAADMAAAAzAAAAFQAAADQAAAAVAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABXAAAAWAAAABUAAAAzAAAAMwAAABUAAAA0AAAAFQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVwAAADQAAAAVAAAAMwAAADMAAAAVAAAANAAAABUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFcAAAA0AAAAFQAAADMAAAAzAAAAFQAAABUAAAAVAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABXAAAANAAAADQAAAAxAAAAMwAAAFgAAAAVAAAAFQAAAA==
+      0,-1:
+        ind: 0,-1
+        tiles: VwAAAFcAAABXAAAAVwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADQAAAA0AAAAWAAAAFgAAABXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAApAAAAKQAAACkAAABYAAAAWAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWAAAAFgAAABYAAAAWAAAADQAAABXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFgAAAAvAAAALwAAAC8AAABYAAAAWAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABYAAAALwAAAC8AAAAvAAAALwAAAFgAAABYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAC8AAAAvAAAALwAAAC8AAAAOAAAANAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC8AAAAVAAAAFQAAABUAAAAVAAAAWAAAAFgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA0AAAAWAAAAFgAAABYAAAAWAAAAFgAAABXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFQAAAFgAAABLAAAASwAAAEsAAAA0AAAAVwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABUAAAAxAAAASwAAAEsAAABLAAAANAAAAFcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVAAAAWAAAAEsAAABLAAAASwAAADQAAABXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFQAAAFgAAABYAAAAWAAAAFgAAABYAAAAVwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABUAAABYAAAAFQAAABUAAAAVAAAANAAAAFcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVAAAAFQAAABUAAAAVAAAAFQAAADQAAABXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFQAAABUAAAAVAAAAFQAAABUAAAA0AAAAVwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+      -1,0:
+        ind: -1,0
+        tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABXAAAAWAAAABUAAAAzAAAAMwAAABUAAAAVAAAAFQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVwAAAFgAAAAVAAAAMwAAADMAAAAzAAAAFQAAABUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFcAAAA0AAAAFQAAABUAAAAVAAAAFQAAABUAAAAzAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFgAAABYAAAAWAAAABUAAAAVAAAAFQAAABUAAAAVAAAAFQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFgAAABYAAAANAAAAFgAAAA0AAAANAAAADQAAABYAAAAMQAAADEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA0AAAANAAAADQAAAA0AAAAFQAAABUAAAAVAAAAFQAAABUAAAAVAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWAAAAFgAAABYAAAAWAAAABUAAAAzAAAAFQAAABUAAAAzAAAAFQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADQAAAA0AAAANAAAADQAAAAVAAAAFQAAABUAAAAVAAAAFQAAABUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABYAAAAWAAAAFgAAABYAAAAMQAAADEAAAAxAAAAWAAAADQAAAAxAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVwAAAFcAAABXAAAANAAAABUAAAAVAAAAFQAAAFgAAAAVAAAAFQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFcAAAAAAAAAVwAAADQAAAAVAAAAMwAAABUAAAA0AAAAFQAAABUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABXAAAAVwAAAFcAAAA0AAAAFQAAABUAAAAVAAAANAAAABUAAAAVAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWAAAAFgAAABYAAAAWAAAABUAAAAVAAAAFQAAAFgAAAAVAAAAFQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADQAAAA0AAAANAAAADQAAAAVAAAAFQAAABUAAABYAAAAWAAAADEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABYAAAAWAAAAFgAAABYAAAAFQAAADMAAAAVAAAAWAAAAC8AAAAvAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAANAAAADQAAAA0AAAANAAAABUAAAAVAAAAFQAAAFgAAAAvAAAALwAAAA==
+      0,0:
+        ind: 0,0
+        tiles: FQAAABUAAAAVAAAAVQAAAFUAAABYAAAAVwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABUAAAAVAAAAFQAAAFUAAABVAAAAWAAAAFcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVAAAAFQAAABUAAABVAAAAVQAAADQAAABXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFQAAABUAAAAVAAAAVQAAAFUAAABYAAAAWAAAAFgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADEAAABYAAAAWAAAAFgAAABYAAAAWAAAADQAAABYAAAAWAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVAAAAFQAAABUAAAAVAAAAFQAAADQAAAA0AAAANAAAADQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMwAAABUAAAAVAAAAMwAAABUAAABYAAAAWAAAAFgAAABYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABUAAAAVAAAAFQAAABUAAAAVAAAANAAAADQAAAA0AAAANAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA0AAAAWAAAADEAAAAxAAAAMQAAAFgAAABYAAAAWAAAAFgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFQAAAFgAAAAVAAAAFQAAABUAAAA0AAAAVwAAAFcAAABXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABUAAAA0AAAAFQAAADMAAAAVAAAANAAAAFcAAAAAAAAAVwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVAAAANAAAABUAAAAVAAAAFQAAADQAAABXAAAAVwAAAFcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFQAAAFgAAAAVAAAAFQAAABUAAABYAAAAWAAAAFgAAABYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFgAAABYAAAAFQAAABUAAAAVAAAANAAAADQAAAA0AAAANAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAvAAAAWAAAABUAAAAzAAAAFQAAAFgAAABYAAAAWAAAAFgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAFgAAAAVAAAAFQAAABUAAAA0AAAANAAAADQAAAA0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+      0,1:
+        ind: 0,1
+        tiles: WAAAAFgAAAAxAAAAMQAAADEAAABYAAAANAAAAFgAAABYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABUAAAAVAAAAFQAAABUAAAAVAAAAWAAAAFgAAABYAAAAVwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAzAAAAFQAAADMAAAAVAAAAFQAAABUAAABYAAAAVwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFQAAABUAAAAVAAAAFQAAABUAAABYAAAAWAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADQAAABYAAAANAAAADQAAABYAAAAWAAAAFcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABLAAAASwAAAEsAAABLAAAASwAAADQAAABXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAASwAAAEsAAABLAAAASwAAAEsAAAA0AAAAVwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEsAAABLAAAASwAAAEsAAABLAAAANAAAAFcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABYAAAAWAAAAFgAAABYAAAAWAAAAFgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMwAAADMAAAAzAAAAMwAAABUAAAA0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABUAAAAzAAAAFQAAABUAAAA0AAAANAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVAAAAMwAAABUAAAA0AAAANAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAANAAAADQAAAA0AAAANAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+      -1,1:
+        ind: -1,1
+        tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWAAAAFgAAAA0AAAAWAAAADEAAAAxAAAAMQAAAFgAAABYAAAAWAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFcAAABYAAAAWAAAAFgAAAAVAAAAFQAAABUAAAAVAAAAFQAAADMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVwAAAFgAAAAVAAAAFQAAABUAAAAzAAAAFQAAADMAAAAzAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABYAAAAWAAAABUAAAAVAAAAFQAAABUAAAAVAAAAMwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVwAAAFgAAAAVAAAAMwAAABUAAABYAAAANAAAADEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFcAAAA0AAAAFQAAABUAAAAVAAAAWAAAAEsAAABLAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABXAAAANAAAABUAAAAVAAAAFQAAADQAAABLAAAASwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVwAAADQAAAAVAAAAMwAAABUAAABYAAAASwAAAEsAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABYAAAANAAAADEAAAA0AAAAWAAAAFgAAABYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAANAAAABUAAAAzAAAAMwAAADMAAAAzAAAAMwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADQAAAA0AAAAFQAAABUAAAAzAAAAFQAAADMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAANAAAADQAAAAVAAAAMwAAABUAAAAzAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA0AAAANAAAADQAAAA0AAAANAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
     type: MapGrid
+  - type: Broadphase
   - angularDamping: 0.05
     linearDamping: 0.05
     fixedRotation: False
@@ -3172,6 +3488,11 @@ entities:
       - 0
       - 0
     type: GridAtmosphere
+  - type: OccluderTree
+  - type: Shuttle
+  - type: GridPathfinding
+  - type: GasTileOverlay
+  - type: RadiationGridResistance
 - uid: 409
   type: Catwalk
   components:
@@ -4918,262 +5239,6 @@ entities:
   - pos: -7.5,-9.5
     parent: 408
     type: Transform
-- uid: 734
-  type: AirlockExternalGlassShuttleEmergencyLocked
-  components:
-  - rot: 1.5707963267948966 rad
-    pos: 8.5,7.5
-    parent: 408
-    type: Transform
-  - fixtures:
-    - shape: !type:PolygonShape
-        vertices:
-        - 0.49,-0.49
-        - 0.49,0.49
-        - -0.49,0.49
-        - -0.49,-0.49
-      mask:
-      - Impassable
-      - MidImpassable
-      - HighImpassable
-      - LowImpassable
-      - InteractImpassable
-      layer:
-      - MidImpassable
-      - HighImpassable
-      - BulletImpassable
-      - InteractImpassable
-      - Opaque
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
-- uid: 735
-  type: AirlockExternalGlassShuttleEmergencyLocked
-  components:
-  - rot: 1.5707963267948966 rad
-    pos: 8.5,5.5
-    parent: 408
-    type: Transform
-  - fixtures:
-    - shape: !type:PolygonShape
-        vertices:
-        - 0.49,-0.49
-        - 0.49,0.49
-        - -0.49,0.49
-        - -0.49,-0.49
-      mask:
-      - Impassable
-      - MidImpassable
-      - HighImpassable
-      - LowImpassable
-      - InteractImpassable
-      layer:
-      - MidImpassable
-      - HighImpassable
-      - BulletImpassable
-      - InteractImpassable
-      - Opaque
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
-- uid: 736
-  type: AirlockExternalGlassShuttleEmergencyLocked
-  components:
-  - rot: 1.5707963267948966 rad
-    pos: 8.5,15.5
-    parent: 408
-    type: Transform
-  - fixtures:
-    - shape: !type:PolygonShape
-        vertices:
-        - 0.49,-0.49
-        - 0.49,0.49
-        - -0.49,0.49
-        - -0.49,-0.49
-      mask:
-      - Impassable
-      - MidImpassable
-      - HighImpassable
-      - LowImpassable
-      - InteractImpassable
-      layer:
-      - MidImpassable
-      - HighImpassable
-      - BulletImpassable
-      - InteractImpassable
-      - Opaque
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
-- uid: 737
-  type: AirlockExternalGlassShuttleEmergencyLocked
-  components:
-  - rot: 1.5707963267948966 rad
-    pos: 8.5,13.5
-    parent: 408
-    type: Transform
-  - fixtures:
-    - shape: !type:PolygonShape
-        vertices:
-        - 0.49,-0.49
-        - 0.49,0.49
-        - -0.49,0.49
-        - -0.49,-0.49
-      mask:
-      - Impassable
-      - MidImpassable
-      - HighImpassable
-      - LowImpassable
-      - InteractImpassable
-      layer:
-      - MidImpassable
-      - HighImpassable
-      - BulletImpassable
-      - InteractImpassable
-      - Opaque
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
-- uid: 738
-  type: AirlockExternalGlassShuttleEmergencyLocked
-  components:
-  - rot: -1.5707963267948966 rad
-    pos: -9.5,5.5
-    parent: 408
-    type: Transform
-  - fixtures:
-    - shape: !type:PolygonShape
-        vertices:
-        - 0.49,-0.49
-        - 0.49,0.49
-        - -0.49,0.49
-        - -0.49,-0.49
-      mask:
-      - Impassable
-      - MidImpassable
-      - HighImpassable
-      - LowImpassable
-      - InteractImpassable
-      layer:
-      - MidImpassable
-      - HighImpassable
-      - BulletImpassable
-      - InteractImpassable
-      - Opaque
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
-- uid: 739
-  type: AirlockExternalGlassShuttleEmergencyLocked
-  components:
-  - rot: -1.5707963267948966 rad
-    pos: -9.5,7.5
-    parent: 408
-    type: Transform
-  - fixtures:
-    - shape: !type:PolygonShape
-        vertices:
-        - 0.49,-0.49
-        - 0.49,0.49
-        - -0.49,0.49
-        - -0.49,-0.49
-      mask:
-      - Impassable
-      - MidImpassable
-      - HighImpassable
-      - LowImpassable
-      - InteractImpassable
-      layer:
-      - MidImpassable
-      - HighImpassable
-      - BulletImpassable
-      - InteractImpassable
-      - Opaque
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
-- uid: 740
-  type: AirlockExternalGlassShuttleEmergencyLocked
-  components:
-  - rot: -1.5707963267948966 rad
-    pos: -9.5,13.5
-    parent: 408
-    type: Transform
-  - fixtures:
-    - shape: !type:PolygonShape
-        vertices:
-        - 0.49,-0.49
-        - 0.49,0.49
-        - -0.49,0.49
-        - -0.49,-0.49
-      mask:
-      - Impassable
-      - MidImpassable
-      - HighImpassable
-      - LowImpassable
-      - InteractImpassable
-      layer:
-      - MidImpassable
-      - HighImpassable
-      - BulletImpassable
-      - InteractImpassable
-      - Opaque
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
-- uid: 741
-  type: AirlockExternalGlassShuttleEmergencyLocked
-  components:
-  - rot: -1.5707963267948966 rad
-    pos: -9.5,15.5
-    parent: 408
-    type: Transform
-  - fixtures:
-    - shape: !type:PolygonShape
-        vertices:
-        - 0.49,-0.49
-        - 0.49,0.49
-        - -0.49,0.49
-        - -0.49,-0.49
-      mask:
-      - Impassable
-      - MidImpassable
-      - HighImpassable
-      - LowImpassable
-      - InteractImpassable
-      layer:
-      - MidImpassable
-      - HighImpassable
-      - BulletImpassable
-      - InteractImpassable
-      - Opaque
-    - shape: !type:PhysShapeCircle
-        position: 0,-0.5
-        radius: 0.2
-      hard: False
-      id: docking
-    type: Fixtures
 - uid: 742
   type: AirlockMedicalGlassLocked
   components:
@@ -5277,12 +5342,16 @@ entities:
   - pos: 0.5,24.5
     parent: 408
     type: Transform
+  - canCollide: False
+    type: Physics
 - uid: 766
   type: SubstationWallBasic
   components:
   - pos: 2.5,-7.5
     parent: 408
     type: Transform
+  - canCollide: False
+    type: Physics
 - uid: 767
   type: GeneratorUranium
   components:
@@ -5331,28 +5400,18 @@ entities:
   - pos: -0.5,-11.5
     parent: 408
     type: Transform
-  - enabled: False
-    type: AmbientSound
-  - powerLoad: 500
-    type: ApcPowerReceiver
-  - radius: 2.5
-    type: PointLight
 - uid: 775
   type: Gyroscope
   components:
   - pos: -6.5,-9.5
     parent: 408
     type: Transform
-  - enabled: False
-    type: AmbientSound
 - uid: 776
   type: Gyroscope
   components:
   - pos: 5.5,-9.5
     parent: 408
     type: Transform
-  - enabled: False
-    type: AmbientSound
 - uid: 777
   type: Thruster
   components:
@@ -5360,8 +5419,6 @@ entities:
     pos: -6.5,-12.5
     parent: 408
     type: Transform
-  - enabled: False
-    type: AmbientSound
 - uid: 778
   type: Thruster
   components:
@@ -5369,8 +5426,6 @@ entities:
     pos: 5.5,-12.5
     parent: 408
     type: Transform
-  - enabled: False
-    type: AmbientSound
 - uid: 779
   type: Thruster
   components:
@@ -5378,8 +5433,6 @@ entities:
     pos: -5.5,-14.5
     parent: 408
     type: Transform
-  - enabled: False
-    type: AmbientSound
 - uid: 780
   type: Thruster
   components:
@@ -5387,8 +5440,6 @@ entities:
     pos: -4.5,-15.5
     parent: 408
     type: Transform
-  - enabled: False
-    type: AmbientSound
 - uid: 781
   type: Thruster
   components:
@@ -5396,8 +5447,6 @@ entities:
     pos: 3.5,-15.5
     parent: 408
     type: Transform
-  - enabled: False
-    type: AmbientSound
 - uid: 782
   type: Thruster
   components:
@@ -5405,8 +5454,6 @@ entities:
     pos: 4.5,-14.5
     parent: 408
     type: Transform
-  - enabled: False
-    type: AmbientSound
 - uid: 783
   type: Thruster
   components:
@@ -5414,8 +5461,6 @@ entities:
     pos: -7.5,-7.5
     parent: 408
     type: Transform
-  - enabled: False
-    type: AmbientSound
 - uid: 784
   type: Thruster
   components:
@@ -5423,8 +5468,6 @@ entities:
     pos: 6.5,-7.5
     parent: 408
     type: Transform
-  - enabled: False
-    type: AmbientSound
 - uid: 785
   type: Thruster
   components:
@@ -5432,8 +5475,6 @@ entities:
     pos: -8.5,18.5
     parent: 408
     type: Transform
-  - enabled: False
-    type: AmbientSound
 - uid: 786
   type: Thruster
   components:
@@ -5441,24 +5482,18 @@ entities:
     pos: 7.5,18.5
     parent: 408
     type: Transform
-  - enabled: False
-    type: AmbientSound
 - uid: 787
   type: Thruster
   components:
   - pos: 6.5,20.5
     parent: 408
     type: Transform
-  - enabled: False
-    type: AmbientSound
 - uid: 788
   type: Thruster
   components:
   - pos: -7.5,20.5
     parent: 408
     type: Transform
-  - enabled: False
-    type: AmbientSound
 - uid: 791
   type: CableHV
   components:
@@ -6071,6 +6106,7 @@ entities:
     pos: -5.5,10.5
     parent: 408
     type: Transform
+  - type: ActiveEmergencyLight
 - uid: 915
   type: EmergencyLight
   components:
@@ -6078,6 +6114,7 @@ entities:
     pos: 4.5,10.5
     parent: 408
     type: Transform
+  - type: ActiveEmergencyLight
 - uid: 916
   type: EmergencyLight
   components:
@@ -6085,6 +6122,7 @@ entities:
     pos: -0.5,17.5
     parent: 408
     type: Transform
+  - type: ActiveEmergencyLight
 - uid: 929
   type: EmergencyLight
   components:
@@ -6092,12 +6130,14 @@ entities:
     pos: -0.5,-13.5
     parent: 408
     type: Transform
+  - type: ActiveEmergencyLight
 - uid: 931
   type: EmergencyLight
   components:
   - pos: 1.5,23.5
     parent: 408
     type: Transform
+  - type: ActiveEmergencyLight
 - uid: 932
   type: EmergencyLight
   components:
@@ -6105,12 +6145,14 @@ entities:
     pos: -0.5,25.5
     parent: 408
     type: Transform
+  - type: ActiveEmergencyLight
 - uid: 933
   type: EmergencyLight
   components:
   - pos: -0.5,15.5
     parent: 408
     type: Transform
+  - type: ActiveEmergencyLight
 - uid: 934
   type: PoweredlightSodium
   components:
@@ -7610,6 +7652,8 @@ entities:
 - uid: 1226
   type: VendingMachineWallMedical
   components:
+  - flags: SessionSpecific
+    type: MetaData
   - pos: 2.5,24.5
     parent: 408
     type: Transform
@@ -7667,32 +7711,24 @@ entities:
   - pos: 3.5,21.5
     parent: 408
     type: Transform
-  - canCollide: False
-    type: Physics
 - uid: 1236
   type: HospitalCurtainsOpen
   components:
   - pos: 4.5,21.5
     parent: 408
     type: Transform
-  - canCollide: False
-    type: Physics
 - uid: 1237
   type: HospitalCurtainsOpen
   components:
   - pos: 4.5,23.5
     parent: 408
     type: Transform
-  - canCollide: False
-    type: Physics
 - uid: 1238
   type: HospitalCurtainsOpen
   components:
   - pos: 3.5,23.5
     parent: 408
     type: Transform
-  - canCollide: False
-    type: Physics
 - uid: 1239
   type: ChairPilotSeat
   components:
@@ -7889,7 +7925,8 @@ entities:
 - uid: 1277
   type: VendingMachineDonut
   components:
-  - name: Donut
+  - flags: SessionSpecific
+    name: Donut
     type: MetaData
   - pos: -1.5,12.5
     parent: 408
@@ -7897,12 +7934,16 @@ entities:
 - uid: 1282
   type: VendingMachineYouTool
   components:
+  - flags: SessionSpecific
+    type: MetaData
   - pos: -5.5,-10.5
     parent: 408
     type: Transform
 - uid: 1283
   type: VendingMachineEngivend
   components:
+  - flags: SessionSpecific
+    type: MetaData
   - pos: -4.5,-11.5
     parent: 408
     type: Transform
@@ -7933,7 +7974,8 @@ entities:
 - uid: 1288
   type: VendingMachineTankDispenserEVA
   components:
-  - name: tank dispenser
+  - flags: SessionSpecific
+    name: tank dispenser
     type: MetaData
   - pos: 4.5,-10.5
     parent: 408
@@ -7941,7 +7983,8 @@ entities:
 - uid: 1289
   type: VendingMachineTankDispenserEngineering
   components:
-  - name: tank dispenser
+  - flags: SessionSpecific
+    name: tank dispenser
     type: MetaData
   - pos: 3.5,-11.5
     parent: 408
@@ -8093,57 +8136,49 @@ entities:
 - uid: 1329
   type: AtmosDeviceFanTiny
   components:
-  - anchored: True
-    pos: -9.5,5.5
+  - pos: -9.5,5.5
     parent: 408
     type: Transform
 - uid: 1330
   type: AtmosDeviceFanTiny
   components:
-  - anchored: True
-    pos: -9.5,7.5
+  - pos: -9.5,7.5
     parent: 408
     type: Transform
 - uid: 1331
   type: AtmosDeviceFanTiny
   components:
-  - anchored: True
-    pos: -9.5,13.5
+  - pos: -9.5,13.5
     parent: 408
     type: Transform
 - uid: 1332
   type: AtmosDeviceFanTiny
   components:
-  - anchored: True
-    pos: -9.5,15.5
+  - pos: -9.5,15.5
     parent: 408
     type: Transform
 - uid: 1333
   type: AtmosDeviceFanTiny
   components:
-  - anchored: True
-    pos: 8.5,13.5
+  - pos: 8.5,13.5
     parent: 408
     type: Transform
 - uid: 1334
   type: AtmosDeviceFanTiny
   components:
-  - anchored: True
-    pos: 8.5,15.5
+  - pos: 8.5,15.5
     parent: 408
     type: Transform
 - uid: 1335
   type: AtmosDeviceFanTiny
   components:
-  - anchored: True
-    pos: 8.5,7.5
+  - pos: 8.5,7.5
     parent: 408
     type: Transform
 - uid: 1336
   type: AtmosDeviceFanTiny
   components:
-  - anchored: True
-    pos: 8.5,5.5
+  - pos: 8.5,5.5
     parent: 408
     type: Transform
 - uid: 1337


### PR DESCRIPTION
## About the PR 

On the Kaeri (Angle's evac shuttle) and Nyano's default evac shuttle, replaced the shuttle airlocks with ones that do not require "External" access on an equipped ID.

**Changelog**
:cl:
- fix: Fixed evac shuttle airlocks requiring "External" access.