### PR TITLE
Standardize Command headsets

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -18,7 +18,6 @@
       - id: CigPackGreen
         prob: 0.50
       - id: RubberStampQm
-      - id: ClothingHeadsetAltCargo
 
 - type: entity
   id: LockerCaptainFilled
@@ -65,7 +64,7 @@
       - id: ClothingHeadHatHopcap
       - id: HoPIDCard
         prob: 0.9
-      - id: ClothingHeadsetCommand
+      - id: ClothingHeadsetAltCommand
       - id: BoxPDA
       - id: BoxID
       - id: BoxHeadset

--- a/Resources/Prototypes/Entities/Clothing/Ears/headsets_alt.yml
+++ b/Resources/Prototypes/Entities/Clothing/Ears/headsets_alt.yml
@@ -92,6 +92,7 @@
     - Command
     - Common
     - Engineering
+    - Binary
   - type: Sprite
     sprite: Clothing/Ears/Headsets/engineering.rsi
   - type: Clothing

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/mystagogue.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/mystagogue.yml
@@ -41,7 +41,7 @@
     outerClothing: ClothingOuterRobeMystic
     belt: BibleMystagogue
     id: MystaPDA
-    ears: ClothingHeadsetMystagogue
+    ears: ClothingHeadsetAltMystagogue
   innerclothingskirt: ClothingUniformJumpskirtColorWhite
   satchel: ClothingBackpackSatchelScienceFilled
   duffelbag: ClothingBackpackDuffelScienceFilled

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -42,7 +42,7 @@
     shoes: ClothingShoesColorBrown
     id: CEPDA
     eyes: ClothingEyesGlassesMeson
-    ears: ClothingHeadsetCE
+    ears: ClothingHeadsetAltEngineering
     belt: ClothingBeltChiefEngineerFilled
   innerclothingskirt: ClothingUniformJumpskirtChiefEngineer
   satchel: ClothingBackpackSatchelEngineeringFilled


### PR DESCRIPTION
The mystagogue and CE were starting with non-Alt headsets, whereas everyone else had Alt headsets. The Alt engineering headset had no Binary channel. I decided it made the most sense to go with the majority here and make all Command personnel have the Alt variant of the headset. Removed the Alt variant of the Cargo headset from the QM locker since it had no difference from the regular cargo headset.