### PR TITLE
Evil twin fixes

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/humanoid.yml
@@ -43,3 +43,6 @@
   - type: GhostTakeoverAvailable
     name: evil twin
     description: Replace your other twin.
+    rules: |
+      Try and replace your twin with this funny roleplay antag rather than
+      plasma flooding the station or something.


### PR DESCRIPTION
:cl: Rane
- fix: Evil twins are a bit closer to their targets.
- fix: Evil twin spawn fallback is more robust.

