### PR TITLE
Delete client-side shots when transferring ammo.

### DIFF
--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
@@ -120,6 +120,9 @@ public abstract partial class SharedGunSystem
             {
                 SimulateInsertAmmo(cast.Owner, args.Target.Value, Transform(args.Target.Value).Coordinates);
             }
+
+            if (cast.Owner.IsClientSide())
+                Del(cast.Owner);
         }
     }
 


### PR DESCRIPTION
Fix a bug where when you transfer ammo from one box to another, it left behind client-side-only entities on the floor.