### PR TITLE
metempsychotic machine changes

### DIFF
--- a/Content.Server/Cloning/CloningConsoleSystem.cs
+++ b/Content.Server/Cloning/CloningConsoleSystem.cs
@@ -168,7 +168,7 @@ namespace Content.Server.Cloning
             if (mind == null || mind.UserId.HasValue == false || mind.Session == null)
                 return;
 
-            _cloningSystem.TryCloning(cloningPodUid, body.Value, mind, cloningPod, scannerComp.CloningFailChanceMultiplier);
+            _cloningSystem.TryCloning(cloningPodUid, body.Value, mind, cloningPod, scannerComp.CloningFailChanceMultiplier, scannerComp.MetemKarmaBonus);
         }
 
         public void RecheckConnections(EntityUid console, EntityUid? cloningPod, EntityUid? scanner, CloningConsoleComponent? consoleComp = null)

--- a/Content.Server/Medical/Components/MedicalScannerComponent.cs
+++ b/Content.Server/Medical/Components/MedicalScannerComponent.cs
@@ -16,6 +16,8 @@ namespace Content.Server.Medical.Components
         [ViewVariables(VVAccess.ReadWrite)]
         public float CloningFailChanceMultiplier = 1f;
 
+        public float MetemKarmaBonus = 0.25f;
+
         [DataField("machinePartCloningFailChance", customTypeSerializer: typeof(PrototypeIdSerializer<MachinePartPrototype>))]
         public string MachinePartCloningFailChance = "ScanningModule";
 

--- a/Content.Server/Medical/MedicalScannerSystem.cs
+++ b/Content.Server/Medical/MedicalScannerSystem.cs
@@ -233,11 +233,14 @@ namespace Content.Server.Medical
             var ratingFail = args.PartRatings[component.MachinePartCloningFailChance];
 
             component.CloningFailChanceMultiplier = MathF.Pow(component.PartRatingFailMultiplier, ratingFail - 1);
+            component.MetemKarmaBonus = 0.25f * ratingFail;
         }
 
         private void OnUpgradeExamine(EntityUid uid, MedicalScannerComponent component, UpgradeExamineEvent args)
         {
+            Logger.Error("metem karma bonus: " + component.MetemKarmaBonus);
             args.AddPercentageUpgrade("medical-scanner-upgrade-cloning", component.CloningFailChanceMultiplier);
+            args.AddPercentageUpgrade("medical-scanner-upgrade-metem", component.MetemKarmaBonus + 0.75f);
         }
     }
 }

--- a/Content.Server/Medical/MedicalScannerSystem.cs
+++ b/Content.Server/Medical/MedicalScannerSystem.cs
@@ -238,7 +238,6 @@ namespace Content.Server.Medical
 
         private void OnUpgradeExamine(EntityUid uid, MedicalScannerComponent component, UpgradeExamineEvent args)
         {
-            Logger.Error("metem karma bonus: " + component.MetemKarmaBonus);
             args.AddPercentageUpgrade("medical-scanner-upgrade-cloning", component.CloningFailChanceMultiplier);
             args.AddPercentageUpgrade("medical-scanner-upgrade-metem", component.MetemKarmaBonus + 0.75f);
         }

--- a/Content.Server/Nyanotrasen/Cloning/MetempsychoticMachineComponent.cs
+++ b/Content.Server/Nyanotrasen/Cloning/MetempsychoticMachineComponent.cs
@@ -7,6 +7,6 @@ namespace Content.Server.Cloning
         /// Chance you will spawn as a humanoid instead of a non humanoid.
         /// </summary>
         [DataField("humanoidBaseChance")]
-        public float HumanoidBaseChance = 0.85f;
+        public float HumanoidBaseChance = 0.75f;
     }
 }

--- a/Content.Server/Nyanotrasen/Cloning/MetempsychoticMachineSystem.cs
+++ b/Content.Server/Nyanotrasen/Cloning/MetempsychoticMachineSystem.cs
@@ -14,7 +14,7 @@ namespace Content.Server.Cloning
         [Dependency] private readonly IRobustRandom _random = default!;
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
 
-        public string GetSpawnEntity(EntityUid uid, out SpeciesPrototype? species, int? karma = null, MetempsychoticMachineComponent? component = null)
+        public string GetSpawnEntity(EntityUid uid, float karmaBonus, SpeciesPrototype oldSpecies, out SpeciesPrototype? species, int? karma = null, MetempsychoticMachineComponent? component = null)
         {
             if (!Resolve(uid, ref component))
             {
@@ -23,12 +23,27 @@ namespace Content.Server.Cloning
                 return "MobHuman";
             }
 
-            var chance = component.HumanoidBaseChance;
+            var chance = component.HumanoidBaseChance + karmaBonus;
 
             if (karma != null)
             {
                 chance -= ((1 - component.HumanoidBaseChance) * (float) karma);
             }
+
+            if (chance > 1)
+            {
+                if (_random.Prob(chance - 1))
+                {
+                    species = oldSpecies;
+                    return oldSpecies.Prototype;
+                }
+                else
+                {
+                    chance = 1;
+                }
+            }
+
+            chance = Math.Clamp(chance, 0, 1);
 
             if (_random.Prob(chance))
             {

--- a/Resources/Locale/en-US/medical/components/medical-scanner-component.ftl
+++ b/Resources/Locale/en-US/medical/components/medical-scanner-component.ftl
@@ -4,3 +4,4 @@ medical-scanner-verb-enter = Enter
 medical-scanner-verb-noun-occupant = occupant
 
 medical-scanner-upgrade-cloning = Cloning fail chance
+medical-scanner-upgrade-metem = Metempsychotic machine karma bonus

--- a/Resources/Prototypes/Nyanotrasen/Entities/Structures/Machines/metempsychoticMachine.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Structures/Machines/metempsychoticMachine.yml
@@ -6,7 +6,7 @@
   components:
   - type: MetempsychoticMachine
   - type: CloningPod
-    constantBiomassCost: 40
+    constantBiomassCost: 35
     checkGeneticDamage: false
   - type: Machine
     board: MetempsychoticMachineCircuitboard


### PR DESCRIPTION
:cl: Rane
- tweak: Metempsychotic machine changes to karma: Your chance for humanoid is now 75% + 25% for each tier of medical scanner part upgrades. This means at tier 1 your chance on first metempsychosis for a humanoid is 100%. However, the penalty for consecutive metempsychoses has been increased to 25%.
- fix: The biomass cost reduction upgrade now works on the metempsychotic machine.

