### PR TITLE
rat servant tweaks

### DIFF
--- a/Content.Shared/ActionBlocker/ActionBlockerSystem.cs
+++ b/Content.Shared/ActionBlocker/ActionBlockerSystem.cs
@@ -146,7 +146,8 @@ namespace Content.Shared.ActionBlocker
 
         public bool CanAttack(EntityUid uid, EntityUid? target = null)
         {
-            if (_container.IsEntityInContainer(uid))
+            _container.TryGetOuterContainer(uid, Transform(uid), out var outerContainer);
+            if (_container.IsEntityInContainer(uid) && target != outerContainer?.Owner)
             {
                 var containerEv = new CanAttackFromContainerEvent(uid, target);
                 RaiseLocalEvent(uid, containerEv);

--- a/Content.Shared/Mech/EntitySystems/SharedMechSystem.cs
+++ b/Content.Shared/Mech/EntitySystems/SharedMechSystem.cs
@@ -56,6 +56,7 @@ public abstract class SharedMechSystem : EntitySystem
 
         SubscribeLocalEvent<MechPilotComponent, GetMeleeWeaponEvent>(OnGetMeleeWeapon);
         SubscribeLocalEvent<MechPilotComponent, CanAttackFromContainerEvent>(OnCanAttackFromContainer);
+        SubscribeLocalEvent<MechPilotComponent, AttackAttemptEvent>(OnAttackAttempt);
     }
 
     #region State Handling
@@ -449,6 +450,12 @@ public abstract class SharedMechSystem : EntitySystem
     private void OnCanAttackFromContainer(EntityUid uid, MechPilotComponent component, CanAttackFromContainerEvent args)
     {
         args.CanAttack = true;
+    }
+
+    private void OnAttackAttempt(EntityUid uid, MechPilotComponent component, AttackAttemptEvent args)
+    {
+        if (args.Target == component.Mech)
+            args.Cancel();
     }
 
     private void UpdateAppearance(EntityUid uid, SharedMechComponent ? component = null, AppearanceComponent? appearance = null)

--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -299,7 +299,25 @@
       - FootstepSound
   - type: NoSlip
   - type: MobPrice
-    price: 500 # rat wealth
+    price: 100 # rat wealth
   - type: MobsterAccent
     isBoss: false
   - type: FelinidFood
+  - type: Bloodstream
+    bloodMaxVolume: 70
+  - type: Recyclable
+  - type: CanEscapeInventory
+  - type: Extractable
+    grindableSolutionName: food
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 2
+        - ReagentId: Blood
+          Quantity: 70
+  - type: Butcherable
+    spawned:
+    - id: FoodMeatRat
+      amount: 1

--- a/Resources/Prototypes/Nyanotrasen/Actions/types.yml
+++ b/Resources/Prototypes/Nyanotrasen/Actions/types.yml
@@ -140,4 +140,5 @@
   name: hairball-action
   description: hairball-action-desc
   charges: 1
+  useDelay: 30
   serverEvent: !type:HairballActionEvent


### PR DESCRIPTION
:cl: Rane
- fix: Rat servants can escape inventory and attack people holding them.
- fix: Felinids can't eat rats when the felinid is overfed.
- fix: Rats are grindable.

