### PR TITLE
servant damage and range nerf and AI faction stuff

### DIFF
--- a/Content.Server/RatKing/RatKingSystem.cs
+++ b/Content.Server/RatKing/RatKingSystem.cs
@@ -159,6 +159,7 @@ namespace Content.Server.RatKing
             {
                 UpdateAIFaction(servant, component.HostileServants);
             }
+            UpdateAIFaction(uid, component.HostileServants);
 
             _action.SetToggled(component.ActionToggleFaction, component.HostileServants);
             args.Handled = true;

--- a/Content.Server/RatKing/RatKingSystem.cs
+++ b/Content.Server/RatKing/RatKingSystem.cs
@@ -25,8 +25,8 @@ namespace Content.Server.RatKing
         [Dependency] private readonly FactionSystem _factionSystem = default!;
         [Dependency] private readonly IGameTiming _timing = default!;
 
-        private const string NeutralAIFaction = "SimpleNeutral";
-        private const string HostileAIFaction = "SimpleHostile";
+        private const string NeutralAIFaction = "RatPassive";
+        private const string HostileAIFaction = "RatHostile";
 
         private TimeSpan _nextRefresh = TimeSpan.FromSeconds(1.5);
 

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1614,6 +1614,16 @@
       - MobMask
       layer:
       - MobLayer
+  - type: MeleeWeapon
+    hidden: true
+    soundHit:
+        path: /Audio/Effects/bite.ogg
+    angle: 0
+    animation: WeaponArcBite
+    damage:
+      types:
+        Slash: 2
+        Piercing: 5
   - type: Appearance
   - type: Inventory
     speciesId: cat
@@ -1648,6 +1658,11 @@
       gender: epicene
   - type: MobPrice
     price: 200
+  - type: Faction
+    factions:
+    - Cat
+  - type: HTN
+    rootTask: SimpleHostileCompound
 
 - type: entity
   name: calico cat

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1492,6 +1492,11 @@
   - type: MobPrice
     price: 200
   - type: DogVision
+  - type: HTN
+    rootTask: SimpleHostileCompound
+  - type: Faction
+    factions:
+    - Pet
 
 - type: entity
   name: corrupted corgi

--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -30,11 +30,6 @@
     spawned:
     - id: FoodMeatCorgi
       amount: 2
-  - type: HTN
-    rootTask: SimpleHostileCompound
-  - type: Faction
-    faction:
-    - Pet
 
 - type: entity
   name: Old Ian
@@ -61,11 +56,6 @@
     attributes:
       proper: true
       gender: male
-  - type: HTN
-    rootTask: SimpleHostileCompound
-  - type: Faction
-    faction:
-    - Pet
 
 - type: entity
   name: Lisa
@@ -92,11 +82,6 @@
     attributes:
       proper: true
       gender: female
-  - type: HTN
-    rootTask: SimpleHostileCompound
-  - type: Faction
-    faction:
-    - Pet
 
 - type: entity
   name: Runtime
@@ -150,7 +135,7 @@
   - type: HTN
     rootTask: SimpleHostileCompound
   - type: Faction
-    faction:
+    factions:
     - Pet
 
 - type: entity
@@ -209,7 +194,7 @@
   - type: HTN
     rootTask: SimpleHostileCompound
   - type: Faction
-    faction:
+    factions:
     - Pet
 
 - type: entity
@@ -272,7 +257,7 @@
   - type: HTN
     rootTask: SimpleHostileCompound
   - type: Faction
-    faction:
+    factions:
     - Pet
 
 - type: entity
@@ -311,7 +296,7 @@
   - type: HTN
     rootTask: SimpleHostileCompound
   - type: Faction
-    faction:
+    factions:
     - Pet
 
 - type: entity
@@ -374,7 +359,7 @@
   - type: HTN
     rootTask: SimpleHostileCompound
   - type: Faction
-    faction:
+    factions:
     - Pet
 
 - type: entity
@@ -392,7 +377,7 @@
   - type: HTN
     rootTask: SimpleHostileCompound
   - type: Faction
-    faction:
+    factions:
     - Pet
 
 - type: entity
@@ -410,7 +395,7 @@
   - type: HTN
     rootTask: SimpleHostileCompound
   - type: Faction
-    faction:
+    factions:
     - Pet
 
 - type: entity
@@ -425,7 +410,7 @@
   - type: HTN
     rootTask: SimpleHostileCompound
   - type: Faction
-    faction:
+    factions:
     - Pet
 
 - type: entity
@@ -449,7 +434,7 @@
   - type: HTN
     rootTask: SimpleHostileCompound
   - type: Faction
-    faction:
+    factions:
     - Pet
 
 - type: entity

--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -30,6 +30,11 @@
     spawned:
     - id: FoodMeatCorgi
       amount: 2
+  - type: HTN
+    rootTask: SimpleHostileCompound
+  - type: Faction
+    faction:
+    - Pet
 
 - type: entity
   name: Old Ian
@@ -56,6 +61,11 @@
     attributes:
       proper: true
       gender: male
+  - type: HTN
+    rootTask: SimpleHostileCompound
+  - type: Faction
+    faction:
+    - Pet
 
 - type: entity
   name: Lisa
@@ -82,6 +92,11 @@
     attributes:
       proper: true
       gender: female
+  - type: HTN
+    rootTask: SimpleHostileCompound
+  - type: Faction
+    faction:
+    - Pet
 
 - type: entity
   name: Runtime
@@ -132,6 +147,11 @@
   - type: Grammar
     attributes:
       gender: male
+  - type: HTN
+    rootTask: SimpleHostileCompound
+  - type: Faction
+    faction:
+    - Pet
 
 - type: entity
   name: bingus
@@ -186,9 +206,14 @@
   - type: Grammar
     attributes:
       gender: epicene
+  - type: HTN
+    rootTask: SimpleHostileCompound
+  - type: Faction
+    faction:
+    - Pet
 
 - type: entity
-  name: mcgriff
+  name: McGriff
   parent: SimpleMobBase
   id: MobMcGriff
   description: This dog can tell something smells around here, and that something is CRIME!
@@ -244,6 +269,11 @@
       proper: true
       gender: male
   - type: DogVision
+  - type: HTN
+    rootTask: SimpleHostileCompound
+  - type: Faction
+    faction:
+    - Pet
 
 - type: entity
   name: Paperwork
@@ -278,6 +308,11 @@
     attributes:
       proper: true
       gender: male
+  - type: HTN
+    rootTask: SimpleHostileCompound
+  - type: Faction
+    faction:
+    - Pet
 
 - type: entity
   name: Walter
@@ -336,6 +371,11 @@
       proper: true
       gender: male
   - type: DogVision
+  - type: HTN
+    rootTask: SimpleHostileCompound
+  - type: Faction
+    faction:
+    - Pet
 
 - type: entity
   name: Morty
@@ -349,6 +389,11 @@
     attributes:
       proper: true
       gender: male
+  - type: HTN
+    rootTask: SimpleHostileCompound
+  - type: Faction
+    faction:
+    - Pet
 
 - type: entity
   name: Morticia
@@ -362,6 +407,11 @@
     attributes:
       proper: true
       gender: female
+  - type: HTN
+    rootTask: SimpleHostileCompound
+  - type: Faction
+    faction:
+    - Pet
 
 - type: entity
   name: Alexander
@@ -372,7 +422,12 @@
   - type: Grammar
     attributes:
       gender: male
-      
+  - type: HTN
+    rootTask: SimpleHostileCompound
+  - type: Faction
+    faction:
+    - Pet
+
 - type: entity
   name: Renault
   parent: MobFox
@@ -391,6 +446,11 @@
     attributes:
       proper: true
       gender: female
+  - type: HTN
+    rootTask: SimpleHostileCompound
+  - type: Faction
+    faction:
+    - Pet
 
 - type: entity
   name: Hamlet
@@ -417,4 +477,3 @@
     attributes:
       proper: true
       gender: male
-

--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -48,8 +48,9 @@
     animation: WeaponArcClaw
     damage:
       types:
-        Slash: 12
-        Piercing: 8
+        Slash: 8
+        Piercing: 4
+    range: 1
   - type: Body
     prototype: Rat
     requiredLegs: 1 # TODO: More than 1 leg

--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -16,7 +16,7 @@
       Extinguish: [Touch]
   - type: Faction
     factions:
-    - SimpleHostile
+    - RatPassive
   - type: Sprite
     drawdepth: Mobs
     sprite: Mobs/Animals/regalrat.rsi
@@ -48,9 +48,8 @@
     animation: WeaponArcClaw
     damage:
       types:
-        Slash: 8
-        Piercing: 4
-    range: 1
+        Slash: 12
+        Piercing: 8
   - type: Body
     prototype: Rat
     requiredLegs: 1 # TODO: More than 1 leg
@@ -239,8 +238,9 @@
     animation: WeaponArcClaw
     damage:
       types:
-        Slash: 5
-        Piercing: 3
+        Slash: 4
+        Piercing: 2
+    range: 1
   - type: Body
     prototype: Rat
     requiredLegs: 1 # TODO: More than 1 leg

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/NPCs/mutants.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/NPCs/mutants.yml
@@ -195,7 +195,7 @@
   components:
     - type: Faction
       factions:
-        - Xeno
+        - SimpleHostile
     - type: InputMover
     - type: MobMover
     - type: HTN

--- a/Resources/Prototypes/ai_factions.yml
+++ b/Resources/Prototypes/ai_factions.yml
@@ -3,6 +3,9 @@
   hostile:
     - NanoTrasen
     - Syndicate
+    - RatPassive
+    - RatHostile
+    - SimpleHostile
     - Xeno
 
 - type: faction
@@ -10,6 +13,7 @@
   hostile:
   - SimpleHostile
   - Syndicate
+  - RatHostile
   - Xeno
 
 - type: faction
@@ -17,6 +21,11 @@
   hostile:
   - NanoTrasen
   - Syndicate
+  - RatPassive
+  - RatHostile
+  - Cat
+  - Xeno
+  - Dragon
 
 - type: faction
   id: SimpleNeutral
@@ -33,3 +42,31 @@
   hostile:
   - NanoTrasen
   - Syndicate
+  - SimpleHostile
+  - RatPassive
+  - RatHostile
+
+- type: faction
+  id: RatPassive
+  hostile:
+  - Cat
+  - SimpleHostile
+  - Xeno
+  - Dragon
+
+- type: faction
+  id: RatHostile
+  hostile:
+  - Cat
+  - SimpleHostile
+  - Xeno
+  - Dragon
+  - NanoTrasen
+  - Syndicate
+
+- type: faction
+  id: Cat
+  hostile:
+  - RatPassive
+  - RatHostile
+  - SimpleHostile

--- a/Resources/Prototypes/ai_factions.yml
+++ b/Resources/Prototypes/ai_factions.yml
@@ -7,6 +7,7 @@
     - RatHostile
     - SimpleHostile
     - Xeno
+    - Pet
 
 - type: faction
   id: NanoTrasen
@@ -26,6 +27,7 @@
   - Cat
   - Xeno
   - Dragon
+  - Pet
 
 - type: faction
   id: SimpleNeutral
@@ -63,6 +65,15 @@
   - Dragon
   - NanoTrasen
   - Syndicate
+  - Pet
+
+- type: faction
+  id: Pet
+  hostile:
+  - SimpleHostile
+  - Xeno
+  - Dragon
+  - RatHostile
 
 - type: faction
   id: Cat


### PR DESCRIPTION
:cl: Rane
- tweak: Rat servant attack range from 1.5m to 1m.
- tweak: Rat servant attack damage from 5 slash 3 piercing to 4 slash 2 piercing.
- add: Added new AI factions for rats and cats.
- add: Cats are now always hostile to rats.
- add: A bunch of other factions that weren't hostile before are now hostile to either passive rats or all rats.

