### PR TITLE
Update20230110

### DIFF
--- a/Content.Server/Chemistry/Components/HyposprayComponent.cs
+++ b/Content.Server/Chemistry/Components/HyposprayComponent.cs
@@ -21,6 +21,13 @@ namespace Content.Server.Chemistry.Components
         [DataField("injectSound")]
         public SoundSpecifier InjectSound = new SoundPathSpecifier("/Audio/Items/hypospray.ogg");
 
+        /// <summary>
+        ///     Whether the hypospray uses a needle (i.e. medipens)
+        ///     or sci fi bullshit that sprays into the bloodstream directly (i.e. hypos)
+        /// </summary>
+        [DataField("pierceArmor")]
+        public bool PierceArmor = false;
+
         public override ComponentState GetComponentState()
         {
             var solutionSys = _entMan.EntitySysManager.GetEntitySystem<SolutionContainerSystem>();

--- a/Content.Server/Chemistry/EntitySystems/ChemistrySystemHypospray.cs
+++ b/Content.Server/Chemistry/EntitySystems/ChemistrySystemHypospray.cs
@@ -11,7 +11,8 @@ using Content.Shared.Interaction;
 using Content.Shared.Interaction.Events;
 using Content.Shared.MobState.Components;
 using Content.Shared.Weapons.Melee.Events;
-using Robust.Shared.Player;
+using Content.Shared.Tag;
+using Content.Shared.Popups;
 
 namespace Content.Server.Chemistry.EntitySystems
 {
@@ -66,6 +67,18 @@ namespace Content.Server.Chemistry.EntitySystems
                 return false;
 
             string? msgFormat = null;
+
+            if (!component.PierceArmor && _entMan.TryGetComponent<TagComponent>(target, out var tag))
+            {
+                if (tag.Tags.Contains("HardsuitOn"))
+                {
+                    if (target == null) return false;
+                    var taget = (EntityUid) target;
+
+                    _popup.PopupEntity("You cant get the needle to go through the thick plating!", taget, user, PopupType.MediumCaution);
+                    return false;
+                }
+            }
 
             if (target == user)
                 msgFormat = "hypospray-component-inject-self-message";

--- a/Content.Server/Interaction/InteractionPopupSystem.cs
+++ b/Content.Server/Interaction/InteractionPopupSystem.cs
@@ -1,8 +1,8 @@
 using Content.Server.Interaction.Components;
-using Content.Server.MobState;
 using Content.Server.Popups;
-using Content.Server.Body.Systems;
 using Content.Shared.IdentityManagement;
+using Content.Shared.Interaction;
+using Content.Shared.MobState.Components;
 using Robust.Shared.Audio;
 using Robust.Shared.Player;
 using Robust.Shared.Random;
@@ -15,7 +15,20 @@ public sealed class InteractionPopupSystem : EntitySystem
     [Dependency] private readonly IGameTiming _gameTiming = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly PopupSystem _popupSystem = default!;
-    [Dependency] private readonly RespiratorSystem _respiratorSystem = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<InteractionPopupComponent, InteractHandEvent>(OnInteractHand);
+    }
+
+    private void OnInteractHand(EntityUid uid, InteractionPopupComponent component, InteractHandEvent args)
+    {
+        if (HasComp<MobStateComponent>(uid))
+            return;
+
+        TryHug(uid, component, args.User);
+    }
 
     public void TryHug(EntityUid uid, InteractionPopupComponent component, EntityUid user)
     {

--- a/Content.Server/Nyanotrasen/Abilities/Medical/MedicalTrainingComponent.cs
+++ b/Content.Server/Nyanotrasen/Abilities/Medical/MedicalTrainingComponent.cs
@@ -1,0 +1,8 @@
+namespace Content.Server.Abilities
+{
+    [RegisterComponent]
+    public sealed class MedicalTrainingComponent : Component
+    {
+
+    }
+}

--- a/Content.Server/Nyanotrasen/Arachne/ArachneSystem.cs
+++ b/Content.Server/Nyanotrasen/Arachne/ArachneSystem.cs
@@ -28,7 +28,6 @@ using Content.Server.Vampiric;
 using Content.Server.Speech.Components;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Player;
-using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Containers;
 using Robust.Shared.Map;
@@ -55,6 +54,7 @@ namespace Content.Server.Arachne
         [Dependency] private readonly BloodSuckerSystem _bloodSuckerSystem = default!;
         [Dependency] private readonly InventorySystem _inventorySystem = default!;
         [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
+        [Dependency] private readonly SharedContainerSystem _containerSystem = default!;
 
         private const string BodySlot = "body_slot";
 
@@ -249,6 +249,9 @@ namespace Content.Server.Arachne
         private void OnSpinWeb(SpinWebActionEvent args)
         {
             if (!TryComp<ArachneComponent>(args.Performer, out var arachne) || arachne.CancelToken != null)
+                return;
+
+            if (_containerSystem.IsEntityInContainer(args.Performer))
                 return;
 
             TryComp<HungerComponent>(args.Performer, out var hunger);

--- a/Resources/Locale/en-US/body/respirator/cpr.ftl
+++ b/Resources/Locale/en-US/body/respirator/cpr.ftl
@@ -2,3 +2,4 @@ cpr-start-second-person = You start performing CPR on {THE($target)}.
 cpr-start-second-person-patient = {CAPITALIZE(THE($user))} starts performing CPR on you.
 cpr-must-remove = You must remove {THE($clothing)}.
 cpr-end-pvs = {CAPITALIZE(THE($user))} performs CPR on {THE($target)}.
+cpr-end-pvs-crack = {CAPITALIZE(THE($user))} accidentally cracks {THE($target)}'s sternum.

--- a/Resources/Locale/en-US/body/respirator/cpr.ftl
+++ b/Resources/Locale/en-US/body/respirator/cpr.ftl
@@ -1,3 +1,4 @@
 cpr-start-second-person = You start performing CPR on {THE($target)}.
 cpr-start-second-person-patient = {CAPITALIZE(THE($user))} starts performing CPR on you.
+cpr-must-remove = You must remove {THE($clothing)}.
 cpr-end-pvs = {CAPITALIZE(THE($user))} performs CPR on {THE($target)}.

--- a/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
@@ -151,8 +151,6 @@
   - type: DiseaseProtection
     protection: 0.05
   - type: IdentityBlocker
-  - type: ClothingGrantComponent
-    tag: HardsuitOn
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -77,6 +77,8 @@
     tags:
       - FullBodyOuter
   - type: GroupExamine
+  - type: ClothingGrantComponent
+    tag: HardsuitOn
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Entities/Mobs/Player/observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/observer.yml
@@ -41,6 +41,7 @@
     - Security
     - Service
     - Syndicate
+    - Binary
   - type: Sprite
     overrideContainerOcclusion: true # Ghosts always show up regardless of where they're contained.
     netsync: false

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -18,6 +18,7 @@
   - type: ExaminableSolution
     solution: hypospray
   - type: Hypospray
+    pierceArmor: true
   - type: StaticPrice
     price: 750
 
@@ -41,6 +42,7 @@
   - type: ExaminableSolution
     solution: hypospray
   - type: Hypospray
+    pierceArmor: true
 
 - type: entity
   name: chemical medipen

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/NPCs/mutants.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/NPCs/mutants.yml
@@ -339,3 +339,12 @@
     attributes:
       proper: true
       gender: male
+  - type: IntrinsicRadioReceiver
+    channels:
+    - Common
+  - type: IntrinsicRadioTransmitter
+    channels:
+    - Common
+  - type: ActiveRadio
+    channels:
+    - Common

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/borgs.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/borgs.yml
@@ -58,8 +58,30 @@
     - DoorBumpOpener
     - ShoesRequiredStepTriggerImmune
   - type: Access
-    groups:
-    - AllAccess
+    tags:
+    - ChiefEngineer
+    - ChiefMedicalOfficer
+    - ResearchDirector
+    - Command
+    - Brig
+    - Detective
+    - Engineering
+    - Medical
+    - Mail
+    - Salvage
+    - Cargo
+    - Research
+    - Service
+    - Maintenance
+    - External
+    - Janitor
+    - Theatre
+    - Bar
+    - Chemistry
+    - Kitchen
+    - Chapel
+    - Hydroponics
+    - Atmospherics
   - type: Hands
     showInHands: false
   - type: Body

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Borgs/borgs_tools.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Borgs/borgs_tools.yml
@@ -20,6 +20,7 @@
   - type: ExaminableSolution
     solution: hypospray
   - type: Hypospray
+    pierceArmor: true
 
 - type: entity
   parent: HyposprayBorgStandard

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -29,6 +29,7 @@
     components:
     - type: PsionicBonusChance
       flatBonus: 0.025
+    - type: MedicalTraining
 
 - type: startingGear
   id: CMOGear

--- a/Resources/Prototypes/Roles/Jobs/Medical/medical_doctor.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/medical_doctor.yml
@@ -10,6 +10,10 @@
   - Medical
   - Maintenance
   - Chemistry
+  special:
+  - !type:AddComponentSpecial
+    components:
+    - type: MedicalTraining
 
 - type: startingGear
   id: DoctorGear


### PR DESCRIPTION
:cl: Rane
- remove: Borgs have lost a few particular accesses before we get a Butlerian jihad.
- add: Cancer Mouse has a built in radio so he can soapbox more effectively.
- tweak: CPR requires removing any outer clothing, like coats.
- tweak: Non-medically trained people can crack the sternum during CPR. The chance scales off of relative mass.
- tweak: Medipens will no longer go through hardsuits.
- fix: Fixed knocking.
- fix: Ghosts can see binary chat.
- fix: Spiders can no longer spin webs from inside containers.

