### PR TITLE
Brief command

### DIFF
--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -160,17 +160,20 @@ namespace Content.Server.Ghost
 
         private void OnMindRemovedMessage(EntityUid uid, GhostComponent component, MindRemovedMessage args)
         {
-            DeleteEntity(uid);
+            if (!EntityManager.HasComponent<BriefOfficerComponent>(uid))
+                DeleteEntity(uid);
         }
 
         private void OnMindUnvisitedMessage(EntityUid uid, GhostComponent component, MindUnvisitedMessage args)
         {
-            DeleteEntity(uid);
+            if (!EntityManager.HasComponent<BriefOfficerComponent>(uid))
+                DeleteEntity(uid);
         }
 
         private void OnPlayerDetached(EntityUid uid, GhostComponent component, PlayerDetachedEvent args)
         {
-            QueueDel(uid);
+            if (!EntityManager.HasComponent<BriefOfficerComponent>(uid))
+                QueueDel(uid);
         }
 
         private void OnGhostWarpsRequest(GhostWarpsRequestEvent msg, EntitySessionEventArgs args)

--- a/Content.Server/SimpleStation14/Administration/Commands/BriefCommand.cs
+++ b/Content.Server/SimpleStation14/Administration/Commands/BriefCommand.cs
@@ -1,0 +1,144 @@
+using System.Linq;
+using Content.Server.GameTicking;
+using Content.Server.Players;
+using Content.Shared.Administration;
+using Content.Shared.Roles;
+using Robust.Server.Player;
+using Robust.Shared.Console;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.Administration.Commands.Brief
+{
+    [AdminCommand(AdminFlags.Admin)]
+    public sealed class BriefCommand : IConsoleCommand
+    {
+        [Dependency] private readonly IEntityManager _entities = default!;
+        [Dependency] private readonly IEntitySystemManager _entitysys = default!;
+        [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+
+        public string Command => "brief";
+        public string Description => "Makes you a mob of choice until the command is rerun.";
+        public string Help => $"Usage: {Command} <outfit> <name> <entity> <force>";
+
+        public void Execute(IConsoleShell shell, string argStr, string[] args)
+        {
+            var player = shell.Player as IPlayerSession;
+            if (player == null)
+            {
+                shell.WriteLine("You aren't a player.");
+                return;
+            }
+
+            var mind = player.ContentData()?.Mind;
+
+            if (mind == null)
+            {
+                shell.WriteLine("You can't spawn without a mind.");
+                return;
+            }
+
+            if (mind.VisitingEntity != default)
+            {
+                var didYouBrief = false;
+                if (args.Length >= 4)
+                    if (args[3].ToLower() == "true")
+                        didYouBrief = true;
+
+                foreach (var officer in _entities.EntityQuery<BriefOfficerComponent>(true))
+                {
+                    if (officer.Owner == mind.VisitingEntity)
+                    {
+                        didYouBrief = true;
+                        player.ContentData()!.Mind?.UnVisit();
+                        if (mind.CurrentEntity != null) _entities.RemoveComponent<BriefOfficerComponent>((EntityUid) mind.CurrentEntity);
+                        _entities.QueueDeleteEntity(officer.Owner);
+                        return;
+                    }
+                }
+
+                if (didYouBrief == false)
+                {
+                    shell.WriteError("You are visiting something other than a brief already.");
+                    return;
+                }
+            }
+
+            var outfit = "CentcomGear";
+            if (args.Length >= 1)
+                if (_prototypeManager.TryIndex<StartingGearPrototype>(args[0], out var outfitProto))
+                    outfit = outfitProto.ID;
+                else
+                {
+                    shell.WriteError("Given outfit is invalid.");
+                    return;
+                }
+
+            var coordinates = player.AttachedEntity != null
+                ? _entities.GetComponent<TransformComponent>(player.AttachedEntity.Value).Coordinates
+                : _entitysys.GetEntitySystem<GameTicker>().GetObserverSpawnPoint();
+
+            var entName = "MobHuman";
+            if (args.Length >= 3)
+                entName = args[2];
+            _prototypeManager.TryIndex<EntityPrototype>(entName, out var entProto);
+            if (entProto == null)
+            {
+                shell.WriteError("Entity prototype is invalid.");
+                return;
+            }
+
+            var brief = _entities.SpawnEntity(entName, coordinates);
+            _entities.EnsureComponent<BriefOfficerComponent>(brief);
+            _entities.TryGetComponent<TransformComponent>(brief, out var briefTransform);
+            if (briefTransform != null)
+                briefTransform.AttachToGridOrMap();
+
+            if (args.Length >= 2)
+                _entities.GetComponent<MetaDataComponent>(brief).EntityName = args[1];
+
+            if (mind.CurrentEntity != null) _entities.EnsureComponent<BriefOfficerComponent>((EntityUid) mind.CurrentEntity);
+            mind.Visit(brief);
+            SetOutfitCommand.SetOutfit(brief, outfit, _entities);
+        }
+
+        public CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+        {
+            if (args.Length == 1)
+            {
+                var options = IoCManager.Resolve<IPrototypeManager>()
+                    .EnumeratePrototypes<StartingGearPrototype>()
+                    .Select(p => new CompletionOption(p.ID))
+                    .OrderBy(p => p.Value);
+
+                return CompletionResult.FromHintOptions(options, Loc.GetString("brief-command-arg-outfit"));
+            }
+            if (args.Length == 2)
+            {
+                // what a great solution
+                List<string> list = new();
+                list.Add("");
+                return CompletionResult.FromHintOptions(list, Loc.GetString("brief-command-arg-name"));
+            }
+            if (args.Length == 3)
+            {
+                var options = IoCManager.Resolve<IPrototypeManager>()
+                    .EnumeratePrototypes<EntityPrototype>()
+                    .Where(p => p.ID.StartsWith("Mob"))
+                    .Select(p => new CompletionOption(p.ID))
+                    .OrderBy(p => p.Value);
+
+                return CompletionResult.FromHintOptions(options, Loc.GetString("brief-command-arg-species"));
+            }
+            if (args.Length == 4)
+            {
+                // what a great solution 2
+                List<string> list = new();
+                list.Add("true");
+                list.Add("false");
+                return CompletionResult.FromHintOptions(list, Loc.GetString("brief-command-arg-force"));
+            }
+
+            return CompletionResult.Empty;
+        }
+    }
+}

--- a/Content.Shared/SimpleStation14/Administration/BriefOfficerComponent.cs
+++ b/Content.Shared/SimpleStation14/Administration/BriefOfficerComponent.cs
@@ -1,0 +1,6 @@
+namespace Content.Shared.Administration
+{
+    [RegisterComponent]
+    public sealed class BriefOfficerComponent : Component
+    {}
+}

--- a/Resources/Locale/en-US/simplestation14/administration/commands/brief-command.ftl
+++ b/Resources/Locale/en-US/simplestation14/administration/commands/brief-command.ftl
@@ -1,0 +1,4 @@
+brief-command-arg-outfit = Outfit
+brief-command-arg-name = Name
+brief-command-arg-species = Entity Prototype
+brief-command-arg-force = Force


### PR DESCRIPTION
Allows the user to specify an outfit set, name, and mob (or any entity) to transfer your mind temporarily (until the command is rerun).

*Instead of*
Find and spawn an entity in the browser, find and set an outfit, navigate vv and set a name, control it, and do whatever.
*You can*
Run the command `brief <outfit> <name> <entity> <force>` and immediately do whatever you wanted (all arguments are optional, and have a default).


Argument descriptions
Outfit: What outfit to attempt to equip on the Brief (autocompletes)
Name: What name to set on the Brief
Entity: What entity will the Brief be (autocomplete shows prototypes starting with Mob, but could be any entity)
Force: Forces you to run the brief command, in the case of your mind already visiting an entity preventing you from doing so


Changelog in case you want it

:cl:
- add: Added a Brief command for admins, allowing transferring to and from a mob of choice with a custom outfit and name.
