### PR TITLE
Prevent NukeOperatives from receiving mail.

### DIFF
--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -7,6 +7,7 @@ using Content.Server.GameTicking.Rules.Configurations;
 using Content.Server.Ghost.Roles.Components;
 using Content.Server.Ghost.Roles.Events;
 using Content.Server.Humanoid.Systems;
+using Content.Server.Mail.Components;
 using Content.Server.Mind.Components;
 using Content.Server.NPC.Systems;
 using Content.Server.Nuke;
@@ -178,6 +179,8 @@ public sealed class NukeopsRuleSystem : GameRuleSystem
         var name = MetaData(uid).EntityName;
         if (session != null)
             _operativePlayers.Add(name, session);
+
+        RemCompDeferred<MailReceiverComponent>(uid);
     }
 
     private void OnComponentRemove(EntityUid uid, NukeOperativeComponent component, ComponentRemove args)


### PR DESCRIPTION
This could probably be reverted once I set it up so operatives get random IC names and can identify each other via a faction HUD.

:cl:
- fix: Nuke operatives no longer receive station mail.