### PR TITLE
Increase sink water cap to Int32.MaxValue.

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Furniture/sink.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/sink.yml
@@ -15,7 +15,9 @@
   - type: SolutionContainerManager
     solutions:
       tank:
-        maxVol: 500
+        # FIXME(plumbing) Increased to int32MaxValue until plumbing is implemented
+        # This is done to workaround the issue of sinks not being refilled.
+        maxVol: 2,147,483,647
   - type: DrainableSolution
     solution: tank
   - type: ReagentTank
@@ -45,7 +47,9 @@
       tank:
         reagents:
         - ReagentId: Water
-          Quantity: 500
+          # FIXME(plumbing) Increased to int32MaxValue until plumbing is implemented
+          # This is done to workaround the issue of sinks not being refilled.
+          Quantity: 2,147,483,647
 
 - type: entity
   name: wide sink
@@ -56,7 +60,7 @@
     sprite: Structures/Furniture/sink.rsi
     state: sink_wide
     netsync: false
-    
+
 #Stemless Sink
 
 - type: entity
@@ -67,7 +71,7 @@
   - type: Sprite
     sprite: Structures/Furniture/sink.rsi
     state: sink
-    netsync: false    
+    netsync: false
 
 - type: entity
   name: sink
@@ -80,4 +84,6 @@
       tank:
         reagents:
         - ReagentId: Water
-          Quantity: 500
+          # FIXME(plumbing) Increased to int32MaxValue until plumbing is implemented
+          # This is done to workaround the issue of sinks not being refilled.
+          Quantity: 2,147,483,647


### PR DESCRIPTION
This is done as a workaround intended to fix running out of sink water while playing as bartender. This should be reverted when plumbing is implemented.

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

**Media**
<!-- 
If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 
(adding clothing, items, new features, etc) must include ingame media or the PR will not be merged, in accordance with our PR guidelines.
This makes it much easier for us to merge PRs and find media for progress reports. If you include media in your pull request, we 
may potentially use it in the SS14 progress reports, with clear credit given.

Use screenshot software like Window's built in snipping tool, ShareX, Lightshot, or recording software like ShareX (gif), ScreenToGif, or Open Broadcaster Software (cross platform).
If you're unsure whether your PR will require media, ask a maintainer.

Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Increase sink capacity and quantity of water to Int32.MaxValue (2,147,483,647)

NOTE: I currently cannot test this fix as I am unable to get the server to build on Ubuntu Studio 22.10. I'll be doing some troubleshooting and will look into improving the build documentation accordingly.