### PR TITLE
Supply and Demand

### DIFF
--- a/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
@@ -328,7 +328,7 @@ namespace Content.Server.Atmos.EntitySystems
 
         private void OnGasTankPrice(EntityUid uid, GasTankComponent component, ref PriceCalculationEvent args)
         {
-            args.Price += _atmosphereSystem.GetPrice(component.Air);
+            args.Price += _atmosphereSystem.GetPrice(component.Air, args.Sale);
         }
     }
 }

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasCanisterSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasCanisterSystem.cs
@@ -18,7 +18,6 @@ using Content.Shared.Interaction;
 using JetBrains.Annotations;
 using Robust.Server.GameObjects;
 using Robust.Shared.Containers;
-using Robust.Shared.Player;
 
 namespace Content.Server.Atmos.Piping.Unary.EntitySystems
 {
@@ -313,7 +312,7 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
 
         private void CalculateCanisterPrice(EntityUid uid, GasCanisterComponent component, ref PriceCalculationEvent args)
         {
-            args.Price += _atmosphereSystem.GetPrice(component.Air);
+            args.Price += _atmosphereSystem.GetPrice(component.Air, args.Sale);
         }
 
                 /// <summary>

--- a/Content.Server/Cargo/Components/DynamicPriceComponent.cs
+++ b/Content.Server/Cargo/Components/DynamicPriceComponent.cs
@@ -1,0 +1,33 @@
+namespace Content.Server.Cargo.Components;
+
+/// <summary>
+/// This component indicates an entity with a price that is subject to the laws
+/// of supply and demand.
+/// </summary>
+[RegisterComponent]
+public sealed class DynamicPriceComponent : Component
+{
+    /// <summary>
+    /// In a neutral environment, what does this entity cost?
+    /// </summary>
+    [DataField("price", required: true)]
+    public double Price;
+
+    /// <summary>
+    /// How many surplus units of this entity need to be on the market before
+    /// the price reaches half of its default price?
+    /// </summary>
+    [DataField("halfPriceSurplus")]
+    public int HalfPriceSurplus = 5;
+
+    /// <summary>
+    /// What arbitrary identifier represents this entity in the marketplace?
+    /// </summary
+    /// <remarks>
+    /// This can be used to group similar items so the sale of one has
+    /// influence on the price of another. If one is not specified, the system
+    /// defaults to the entity prototype ID.
+    /// </remarks>
+    [DataField("commodity")]
+    public string? CommodityId;
+}

--- a/Content.Server/Cargo/Components/StackPriceComponent.cs
+++ b/Content.Server/Cargo/Components/StackPriceComponent.cs
@@ -11,4 +11,11 @@ public sealed class StackPriceComponent : Component
     /// </summary>
     [DataField("price", required: true)]
     public double Price;
+
+    /// <summary>
+    /// How many surplus units of this stack need to be on the market before
+    /// the price reaches half of its default price?
+    /// </summary>
+    [DataField("halfPriceSurplus")]
+    public int HalfPriceSurplus = 60;
 }

--- a/Content.Server/Cargo/Systems/CargoSystem.Shuttle.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.Shuttle.cs
@@ -333,7 +333,7 @@ public sealed partial class CargoSystem
                 if (blacklistQuery.HasComponent(ent))
                     continue;
 
-                var price = _pricing.GetPrice(ent);
+                var price = _pricing.GetPrice(ent, true);
                 if (price == 0)
                     continue;
                 toSell.Add(ent);

--- a/Content.Server/Cargo/Systems/PricingSystem.SupplyDemand.cs
+++ b/Content.Server/Cargo/Systems/PricingSystem.SupplyDemand.cs
@@ -1,0 +1,262 @@
+using Robust.Shared.Random;
+using Robust.Shared.Timing;
+using Content.Server.Cargo.Components;
+using Content.Shared.Atmos.Prototypes;
+using Content.Shared.Chemistry.Reagent;
+using Content.Shared.FixedPoint;
+using Content.Shared.GameTicking;
+using Content.Shared.Stacks;
+
+namespace Content.Server.Cargo.Systems
+{
+    public sealed partial class PricingSystem
+    {
+        [Dependency] private readonly IGameTiming _gameTiming = default!;
+        [Dependency] private readonly IRobustRandom _random = default!;
+
+        // The galactic supply & demand rates.
+        private Dictionary<string, int> _supplyEntity = new();
+        private Dictionary<string, int> _demandEntity = new();
+
+        private Dictionary<string, float> _supplyGas = new();
+        private Dictionary<string, float> _demandGas = new();
+
+        private Dictionary<string, int> _supplyStack = new();
+        private Dictionary<string, int> _demandStack = new();
+
+        private Dictionary<string, FixedPoint2> _supplyReagent = new();
+        private Dictionary<string, FixedPoint2> _demandReagent = new();
+
+
+        private TimeSpan _updateInterval = TimeSpan.FromMinutes(1);
+        private TimeSpan _nextUpdate = TimeSpan.Zero;
+        private float _supplyReductionChance = 0.33f;
+
+
+        public void InitializeSupplyDemand()
+        {
+            SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundRestartCleanup);
+            SubscribeLocalEvent<DynamicPriceComponent, PriceCalculationEvent>(CalculateDynamicPrice);
+        }
+
+        private void OnRoundRestartCleanup(RoundRestartCleanupEvent args)
+        {
+            _supplyEntity.Clear();
+            _demandEntity.Clear();
+            _supplyGas.Clear();
+            _demandGas.Clear();
+            _supplyStack.Clear();
+            _demandStack.Clear();
+            _supplyReagent.Clear();
+            _demandReagent.Clear();
+        }
+
+        public override void Update(float frameTime)
+        {
+            base.Update(frameTime);
+
+            if (_gameTiming.CurTime < _nextUpdate)
+                return;
+
+            // Randomly reduce the market's entity supply.
+            foreach (var (key, units) in _supplyEntity)
+            {
+                if (_random.Prob(_supplyReductionChance))
+                    _supplyEntity[key] = Math.Max(0, units - 1);
+            }
+
+            // Randomly reduce the market's stack supply.
+            foreach (var (key, units) in _supplyStack)
+            {
+                if (_random.Prob(_supplyReductionChance))
+                    _supplyStack[key] = Math.Max(0, units - 10);
+            }
+
+            // Randomly reduce the market's reagent supply.
+            var fixedReduction = FixedPoint2.New(20f);
+            foreach (var (key, units) in _supplyReagent)
+            {
+                if (_random.Prob(_supplyReductionChance))
+                    _supplyReagent[key] = FixedPoint2.Max(FixedPoint2.Zero, units - fixedReduction);
+            }
+
+            // Randomly reduce the market's gas supply.
+            foreach (var (key, units) in _supplyGas)
+            {
+                if (_random.Prob(_supplyReductionChance))
+                    _supplyGas[key] = Math.Max(0f, units - 100f);
+            }
+
+            _nextUpdate = _gameTiming.CurTime + _updateInterval;
+        }
+
+        public double GetSupplyDemandPrice(double basePrice, float halfPriceSurplus, float supply, float demand)
+        {
+            return basePrice *
+                demand /
+                Math.Max(1f, halfPriceSurplus + supply);
+        }
+
+        public double GetSupplyDemandPrice(double basePrice, int halfPriceSurplus, int supply, int demand)
+        {
+            return basePrice *
+                (float) demand /
+                (float) Math.Max(1f, halfPriceSurplus + supply);
+        }
+
+        public double GetSupplyDemandPrice(double basePrice, FixedPoint2 halfPriceSurplus, FixedPoint2 supply, FixedPoint2 demand)
+        {
+            return basePrice *
+                (float) demand /
+                (float) Math.Max(1f, (float) (halfPriceSurplus + supply));
+        }
+
+        /// <summary>
+        /// Return a string identifier for an entity in the marketplace.
+        /// </summary>
+        public string GetEntityCommodityId(EntityUid uid, DynamicPriceComponent component)
+        {
+            if (component.CommodityId != null)
+                return component.CommodityId;
+
+            var proto = MetaData(uid).EntityPrototype?.ID;
+            if (proto != null)
+                return proto;
+
+            return "UnknownCommodity"; // Who knows.
+        }
+
+        public void AddEntitySupply(EntityUid uid, DynamicPriceComponent component, int units)
+        {
+            var id = GetEntityCommodityId(uid, component);
+
+            if (_supplyEntity.ContainsKey(id))
+                _supplyEntity[id] = Math.Max(0, _supplyEntity[id] + units);
+            else
+                _supplyEntity[id] = Math.Max(0, units);
+        }
+
+        public int GetEntitySupply(EntityUid uid, DynamicPriceComponent component)
+        {
+            var id = GetEntityCommodityId(uid, component);
+
+            if (!_supplyEntity.ContainsKey(id))
+                return 0;
+
+            return _supplyEntity[id];
+        }
+
+        public int GetEntityDemand(EntityUid uid, DynamicPriceComponent component)
+        {
+            var id = GetEntityCommodityId(uid, component);
+
+            if (!_demandEntity.ContainsKey(id))
+                return component.HalfPriceSurplus;
+
+            return _demandEntity[id];
+        }
+
+        private void CalculateDynamicPrice(EntityUid uid, DynamicPriceComponent component, ref PriceCalculationEvent args)
+        {
+            var id = GetEntityCommodityId(uid, component);
+
+            var supply = GetEntitySupply(uid, component);
+            var demand = GetEntityDemand(uid, component);
+
+            args.Price += GetSupplyDemandPrice(component.Price, component.HalfPriceSurplus, supply, demand);
+
+            if (args.Sale)
+                AddEntitySupply(uid, component, 1);
+        }
+
+        public void AddGasSupply(GasPrototype gas, float moles)
+        {
+            if (_supplyGas.ContainsKey(gas.ID))
+                _supplyGas[gas.ID] = Math.Max(0f, _supplyGas[gas.ID] + moles);
+            else
+                _supplyGas[gas.ID] = Math.Max(0f, moles);
+        }
+
+        public float GetGasSupply(GasPrototype gas)
+        {
+            if (!_supplyGas.ContainsKey(gas.ID))
+                return 0f;
+
+            return _supplyGas[gas.ID];
+        }
+
+        public float GetGasDemand(GasPrototype gas)
+        {
+            if (!_demandGas.ContainsKey(gas.ID))
+                return gas.HalfPriceSurplus;
+
+            return _demandGas[gas.ID];
+        }
+
+        public void AddStackSupply(StackComponent stack, int units)
+        {
+            if (stack.StackTypeId == null)
+            {
+                _sawmill.Error($"AddStackSupply: StackTypeId is null for {ToPrettyString(stack.Owner)}.");
+                return;
+            }
+
+            if (_supplyStack.ContainsKey(stack.StackTypeId))
+                _supplyStack[stack.StackTypeId] = Math.Max(0, _supplyStack[stack.StackTypeId] + units);
+            else
+                _supplyStack[stack.StackTypeId] = Math.Max(0, units);
+        }
+
+        public int GetStackSupply(StackComponent stack)
+        {
+            if (stack.StackTypeId == null)
+            {
+                _sawmill.Error($"GetStackSupply: StackTypeId is null for {ToPrettyString(stack.Owner)}.");
+                return 0;
+            }
+
+            if (!_supplyStack.ContainsKey(stack.StackTypeId))
+                return 0;
+
+            return _supplyStack[stack.StackTypeId];
+        }
+
+        public int GetStackDemand(StackPriceComponent component, StackComponent stack)
+        {
+            if (stack.StackTypeId == null)
+            {
+                _sawmill.Error($"GetStackDemand: StackTypeId is null for {ToPrettyString(stack.Owner)}.");
+                return 60;
+            }
+
+            if (!_demandStack.ContainsKey(stack.StackTypeId))
+                return component.HalfPriceSurplus;
+
+            return _demandStack[stack.StackTypeId];
+        }
+
+        public void AddReagentSupply(ReagentPrototype reagent, FixedPoint2 units)
+        {
+            if (_supplyReagent.ContainsKey(reagent.ID))
+                _supplyReagent[reagent.ID] = FixedPoint2.Max(FixedPoint2.Zero, _supplyReagent[reagent.ID] + units);
+            else
+                _supplyReagent[reagent.ID] = FixedPoint2.Max(FixedPoint2.Zero, units);
+        }
+
+        public FixedPoint2 GetReagentSupply(ReagentPrototype reagent)
+        {
+            if (!_supplyReagent.ContainsKey(reagent.ID))
+                return FixedPoint2.Zero;
+
+            return _supplyReagent[reagent.ID];
+        }
+
+        public FixedPoint2 GetReagentDemand(ReagentPrototype reagent)
+        {
+            if (!_demandReagent.ContainsKey(reagent.ID))
+                return reagent.HalfPriceSurplus;
+
+            return _demandReagent[reagent.ID];
+        }
+    }
+}

--- a/Content.Server/VendingMachines/VendingMachineSystem.cs
+++ b/Content.Server/VendingMachines/VendingMachineSystem.cs
@@ -46,7 +46,7 @@ namespace Content.Server.VendingMachines
             SubscribeLocalEvent<VendingMachineComponent, BreakageEventArgs>(OnBreak);
             SubscribeLocalEvent<VendingMachineComponent, GotEmaggedEvent>(OnEmagged);
             SubscribeLocalEvent<VendingMachineComponent, DamageChangedEvent>(OnDamage);
-            SubscribeLocalEvent<VendingMachineComponent, PriceCalculationEvent>(OnVendingPrice);
+            /* SubscribeLocalEvent<VendingMachineComponent, PriceCalculationEvent>(OnVendingPrice); */
 
             SubscribeLocalEvent<VendingMachineComponent, ActivatableUIOpenAttemptEvent>(OnActivatableUIOpenAttempt);
             SubscribeLocalEvent<VendingMachineComponent, BoundUIOpenedEvent>(OnBoundUIOpened);

--- a/Content.Shared/Atmos/Prototypes/GasPrototype.cs
+++ b/Content.Shared/Atmos/Prototypes/GasPrototype.cs
@@ -83,5 +83,12 @@ namespace Content.Shared.Atmos.Prototypes
 
         [DataField("pricePerMole")]
         public float PricePerMole { get; set; } = 0;
+
+        /// <summary>
+        /// How many surplus moles of this gas need to be on the market before
+        /// the price reaches half of its default price?
+        /// </summary>
+        [DataField("halfPriceSurplus")]
+        public float HalfPriceSurplus { get; set; } = 2000f;
     }
 }

--- a/Content.Shared/Chemistry/Reagent/ReagentPrototype.cs
+++ b/Content.Shared/Chemistry/Reagent/ReagentPrototype.cs
@@ -88,6 +88,13 @@ namespace Content.Shared.Chemistry.Reagent
         public float PricePerUnit { get; }
 
         /// <summary>
+        /// How many surplus units of this reagent need to be on the market before
+        /// the price reaches half of its default price?
+        /// </summary>
+        [DataField("halfPriceSurplus")]
+        public float HalfPriceSurplus { get; } = 100f;
+
+        /// <summary>
         /// If the substance color is too dark we user a lighter version to make the text color readable when the user examines a solution.
         /// </summary>
         public Color GetSubstanceTextColor()

--- a/Resources/Prototypes/Body/Organs/animal.yml
+++ b/Resources/Prototypes/Body/Organs/animal.yml
@@ -7,7 +7,7 @@
   - type: Sprite
     netsync: false
     sprite: Mobs/Species/Human/organs.rsi
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 50
 
 

--- a/Resources/Prototypes/Body/Parts/animal.yml
+++ b/Resources/Prototypes/Body/Parts/animal.yml
@@ -15,7 +15,7 @@
     containers:
       bodypart: !type:Container
         ents: []
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 50
 
 # For primates mainly

--- a/Resources/Prototypes/Body/Parts/diona.yml
+++ b/Resources/Prototypes/Body/Parts/diona.yml
@@ -16,7 +16,7 @@
     sprite: Mobs/Species/Diona/parts.rsi
   - type: Icon
     sprite: Mobs/Species/Diona/parts.rsi
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 100
 
 - type: entity

--- a/Resources/Prototypes/Body/Parts/human.yml
+++ b/Resources/Prototypes/Body/Parts/human.yml
@@ -13,7 +13,7 @@
     containers:
       bodypart: !type:Container
         ents: []
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 100
 
 - type: entity

--- a/Resources/Prototypes/Body/Parts/silicon.yml
+++ b/Resources/Prototypes/Body/Parts/silicon.yml
@@ -11,7 +11,7 @@
     containers:
       bodypart: !type:Container
         ents: []
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 100
 
 - type: entity

--- a/Resources/Prototypes/Body/Parts/skeleton.yml
+++ b/Resources/Prototypes/Body/Parts/skeleton.yml
@@ -12,7 +12,7 @@
     containers:
       bodypart: !type:Container
         ents: []
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 20
 
 - type: entity

--- a/Resources/Prototypes/Body/Parts/slime.yml
+++ b/Resources/Prototypes/Body/Parts/slime.yml
@@ -12,7 +12,7 @@
     containers:
       bodypart: !type:Container
         ents: []
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 100
 
 - type: entity

--- a/Resources/Prototypes/Body/Parts/vox.yml
+++ b/Resources/Prototypes/Body/Parts/vox.yml
@@ -13,7 +13,7 @@
     containers:
       bodypart: !type:Container
         ents: []
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 100
 
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -40,7 +40,7 @@
     interfaces:
     - key: enum.StorageUiKey.Key
       type: StorageBoundUserInterface
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 80
 
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -254,7 +254,7 @@
     damageCoefficient: 0.5
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitRd
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 750
 
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
@@ -31,7 +31,7 @@
           enum.ToggleVisuals.Layer:
             True: {state: icon-on}
             False: {state: icon}
-    - type: StaticPrice
+    - type: DynamicPrice
       price: 200
 
 - type: entity
@@ -58,7 +58,7 @@
     sprintModifier: 1
     enabled: false
   - type: NoSlip
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 750
 
 - type: entity
@@ -71,7 +71,7 @@
     walkModifier: 2.5 #PVS isn't too much of an issue when you are blind...
     sprintModifier: 2.5
     enabled: false
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 3000
   - type: Blindfold
 

--- a/Resources/Prototypes/Entities/Clothing/base_clothing.yml
+++ b/Resources/Prototypes/Entities/Clothing/base_clothing.yml
@@ -8,7 +8,7 @@
   - type: Tag
     tags:
       - WhitelistChameleon
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 15
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/condiments.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/condiments.yml
@@ -10,7 +10,7 @@
   abstract: true
   description: A small plastic pack with condiments to put on your food.
   components:
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 0.50
   - type: Drink
     solution: food
@@ -46,7 +46,7 @@
   parent: BaseFoodCondimentPacket
   id: FoodCondimentPacket
   components:
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 0
   - type: Tag
     tags:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/plate.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/plate.yml
@@ -12,7 +12,7 @@
   id: FoodPlate
   description: A large plate, excellent for bread.
   components:
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 15
   - type: Sprite
     sprite: Objects/Consumable/Food/plates.rsi
@@ -56,7 +56,7 @@
   id: FoodPlateTrash
   description: A broken plate. Useless.
   components:
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 0
   - type: Sprite
     sprite: Objects/Consumable/Food/plates.rsi
@@ -76,7 +76,7 @@
   id: FoodPlateSmall
   description: A small plate. Delicate.
   components:
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 10
   - type: Sprite
     sprite: Objects/Consumable/Food/plates.rsi
@@ -103,7 +103,7 @@
   parent: FoodPlateTrash
   id: FoodPlateSmallTrash
   components:
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 0
   - type: Sprite
     sprite: Objects/Consumable/Food/plates.rsi
@@ -118,7 +118,7 @@
   id: FoodPlatePlastic
   description: A large blue plastic plate, excellent for a birthday cake.
   components:
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 1.50
   - type: Sprite
     sprite: Objects/Consumable/Food/plates.rsi
@@ -134,7 +134,7 @@
   id: FoodPlateSmallPlastic
   description: A blue plastic plate, excellent for slices of birthday cake.
   components:
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 0.75
   - type: Sprite
     sprite: Objects/Consumable/Food/plates.rsi
@@ -152,7 +152,7 @@
   id: FoodPlateTin
   description: A cheap foil tin for pies.
   components:
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 0.25
   - type: Sprite
     sprite: Objects/Consumable/Food/plates.rsi

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/food_base.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/food_base.yml
@@ -14,7 +14,7 @@
   - type: SpaceGarbage
   - type: Sprite
     netsync: false
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 0
 
 # This base type is used to cover all of the "obvious" things that should be doable to open-package food.

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/meat.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/meat.yml
@@ -211,7 +211,7 @@
         reagents:
         - ReagentId: Bicaridine
           Quantity: 20
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 750
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
@@ -389,7 +389,7 @@
     - Trash
   - type: Recyclable
   - type: SpaceGarbage
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 0
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/base_smokeables.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/base_smokeables.yml
@@ -15,7 +15,7 @@
     - Trash
   - type: Recyclable
   - type: SpaceGarbage
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 5
 
 # Base for all cigars and cigarettes.

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/base_machineboard.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/base_machineboard.yml
@@ -12,5 +12,5 @@
     - type: Tag
       tags:
         - DroneUsable
-    - type: StaticPrice
+    - type: DynamicPrice
       price: 100

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
@@ -11,7 +11,7 @@
     - type: Tag
       tags:
         - DroneUsable
-    - type: StaticPrice
+    - type: DynamicPrice
       price: 100
 
 - type: entity
@@ -66,7 +66,7 @@
       state: cpu_supply
     - type: ComputerBoard
       prototype: ComputerCargoOrders
-    - type: StaticPrice
+    - type: DynamicPrice
       price: 750
 
 - type: entity
@@ -176,7 +176,7 @@
       state: cpu_command
     - type: ComputerBoard
       prototype: ComputerId
-    - type: StaticPrice
+    - type: DynamicPrice
       price: 750
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/base_electronics.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/base_electronics.yml
@@ -12,5 +12,5 @@
     - type: Tag
       tags:
         - DroneUsable
-    - type: StaticPrice
+    - type: DynamicPrice
       price: 100

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/signaller.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/signaller.yml
@@ -11,7 +11,7 @@
     state: signaller
   - type: Signaller
   - type: UseDelay
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 40
   - type: SignalTransmitter
     outputs:

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/triggers.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/triggers.yml
@@ -25,7 +25,7 @@
       delayOptions: [3, 5, 10, 15, 30]
       initialBeepDelay: 0
       beepSound: /Audio/Machines/Nuke/general_beep.ogg
-    - type: StaticPrice
+    - type: DynamicPrice
       price: 40
 
 - type: entity
@@ -41,7 +41,7 @@
     components:
     - type: TriggerOnSignal
     - type: SignalReceiver
-    - type: StaticPrice
+    - type: DynamicPrice
       price: 40
 
 - type: entity
@@ -56,5 +56,5 @@
   - type: PayloadTrigger
     components:
     - type: TriggerOnVoice
-    - type: StaticPrice
+    - type: DynamicPrice
       price: 40

--- a/Resources/Prototypes/Entities/Objects/Devices/holoprojectors.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/holoprojectors.yml
@@ -42,5 +42,5 @@
   - type: Tag
     tags:
       - HolofanProjector
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 80

--- a/Resources/Prototypes/Entities/Objects/Devices/nuke.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/nuke.yml
@@ -47,7 +47,7 @@
     interfaces:
     - key: enum.NukeUiKey.Key
       type: NukeBoundUserInterface
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 50000 # YOU STOLE A NUCLEAR FISSION EXPLOSIVE?!
   - type: CargoSellBlacklist
   - type: ItemSlots
@@ -95,5 +95,5 @@
           Quantity: 3000
   - type: ReagentTank
     transferAmount: 100
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 5000 # That's a pretty fancy keg you got there.

--- a/Resources/Prototypes/Entities/Objects/Devices/payload.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/payload.yml
@@ -81,7 +81,7 @@
     containers:
       BeakerSlotA: !type:ContainerSlot
       BeakerSlotB: !type:ContainerSlot
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 60
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Fun/Instruments/base_instruments.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/Instruments/base_instruments.yml
@@ -18,7 +18,7 @@
       type: InstrumentBoundUserInterface
   - type: Item
     size: 24
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 200
 
 #These are for instruments that are larger, can't be picked up, or have collision
@@ -69,7 +69,7 @@
       - HighImpassable
       - MidImpassable
       - BulletImpassable
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 300
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Fun/crayons.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/crayons.yml
@@ -27,7 +27,7 @@
           Quantity: 3
         - ReagentId: MindbreakerToxin
           Quantity: 2
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 5
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -801,5 +801,5 @@
     available:
       - enum.DamageStateVisualLayers.Base:
           base: Sixteen
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 3

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/glass.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/glass.yml
@@ -9,7 +9,7 @@
     sprite: Objects/Materials/Sheets/glass.rsi
   - type: Item
     sprite: Objects/Materials/Sheets/glass.rsi
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 0
   - type: ItemStatus
   - type: Tag

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/metal.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/metal.yml
@@ -9,7 +9,7 @@
     sprite: Objects/Materials/Sheets/metal.rsi
   - type: Item
     sprite: Objects/Materials/Sheets/metal.rsi
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 0
   - type: ItemStatus
   - type: Tag

--- a/Resources/Prototypes/Entities/Objects/Materials/ingots.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/ingots.yml
@@ -9,7 +9,7 @@
     sprite: Objects/Materials/ingots.rsi
   - type: Item
     sprite: Objects/Materials/ingots.rsi
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 0
   - type: ItemStatus
   - type: Tag

--- a/Resources/Prototypes/Entities/Objects/Materials/parts.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/parts.yml
@@ -53,7 +53,7 @@
     outputs:
     - Lattice
     - FloorReinforced
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 0
   - type: StackPrice
     price: 5

--- a/Resources/Prototypes/Entities/Objects/Misc/bedsheets.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/bedsheets.yml
@@ -19,7 +19,7 @@
     quickEquip: true
     slots:
     - neck
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 100
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Misc/botparts.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/botparts.yml
@@ -10,5 +10,5 @@
   - type: Tag
     tags:
       - ProximitySensor
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 40

--- a/Resources/Prototypes/Entities/Objects/Misc/dat_fukken_disk.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/dat_fukken_disk.yml
@@ -11,7 +11,7 @@
     netsync: false
     sprite: Objects/Misc/nukedisk.rsi
     state: icon
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 2000
   - type: CargoSellBlacklist
   - type: WarpPoint
@@ -29,5 +29,5 @@
     netsync: false
     sprite: Objects/Misc/nukedisk.rsi
     state: icon
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 1 # it's worth even less than normal items. Perfection.

--- a/Resources/Prototypes/Entities/Objects/Misc/space_cash.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/space_cash.yml
@@ -7,7 +7,7 @@
   - type: Material
     materials:
       Credit: 1
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 0
   - type: Stack
     stackType: Credit

--- a/Resources/Prototypes/Entities/Objects/Misc/utensils.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/utensils.yml
@@ -3,7 +3,7 @@
   id: UtensilBase
   abstract: true
   components:
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 3
   - type: Sprite
     sprite: Objects/Misc/utensils.rsi
@@ -42,7 +42,7 @@
   name: plastic fork
   description: An eating utensil, perfect for stabbing.
   components:
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 0.75
   - type: Sprite
     state: plastic_fork
@@ -82,7 +82,7 @@
   name: plastic spoon
   description: There is no spoon.
   components:
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 0.75
   - type: Tag
     tags:
@@ -102,7 +102,7 @@
   name: plastic knife
   description: That's not a knife. This is a knife.
   components:
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 0.75
   - type: Tag
     tags:

--- a/Resources/Prototypes/Entities/Objects/Power/antimatter_jar.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/antimatter_jar.yml
@@ -12,5 +12,5 @@
     state: jar
     netsync: false
   - type: AMEFuelContainer
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 500

--- a/Resources/Prototypes/Entities/Objects/Power/antimatter_part.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/antimatter_part.yml
@@ -11,5 +11,5 @@
     sprite: Objects/Power/AME/ame_part.rsi
     state: box
   - type: AMEPart
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 500

--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -51,7 +51,7 @@
   id: RiotShield
   description: A large tower shield. Good for controlling crowds.
   components:
-    - type: StaticPrice
+    - type: DynamicPrice
       price: 100
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/seeds.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/seeds.yml
@@ -10,7 +10,7 @@
       netsync: true
     - type: Item
       size: 2
-    - type: StaticPrice
+    - type: DynamicPrice
       price: 20
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/tools.yml
@@ -62,7 +62,7 @@
     sprite: Objects/Tools/Hydroponics/scythe.rsi
     slots:
     - back
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 40
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/handheld_crew_monitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/handheld_crew_monitor.yml
@@ -20,5 +20,5 @@
     receiveFrequencyId: SuitSensor
   - type: WirelessNetworkConnection
     range: 500
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 500

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -9,7 +9,7 @@
     sprite: Objects/Specific/Medical/medical.rsi
     heldPrefix: ointment
   # Inherited
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 0
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -19,7 +19,7 @@
     solution: hypospray
   - type: Hypospray
     pierceArmor: true
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 750
 
 - type: entity
@@ -78,7 +78,7 @@
     - Trash
   - type: Recyclable
   - type: SpaceGarbage
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 75 # These are limited supply items.
   - type: TrashOnEmpty
     solution: pen
@@ -178,5 +178,5 @@
   - type: Tag
     tags:
     - Write
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 75

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/morgue.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/morgue.yml
@@ -72,7 +72,7 @@
     containers:
       entity_storage: !type:Container
       paper_label: !type:ContainerSlot
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 50
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
@@ -7,7 +7,7 @@
   components:
   - type: Sprite
     netsync: false
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 60
 
 # Cautery

--- a/Resources/Prototypes/Entities/Objects/Specific/Security/barrier.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Security/barrier.yml
@@ -56,5 +56,5 @@
   - type: Appearance
     visuals:
     - type: DeployableBarrierVisualizer
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 200

--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/artifact_equipment.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/artifact_equipment.yml
@@ -73,5 +73,5 @@
       containers:
         entity_storage: !type:Container
         paper_label: !type:ContainerSlot
-    - type: StaticPrice
+    - type: DynamicPrice
       price: 250

--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/item_artifacts.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/item_artifacts.yml
@@ -49,7 +49,7 @@
     - key: enum.InstrumentUiKey.Key
       type: InstrumentBoundUserInterface
   - type: Appearance
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 500
   - type: Item
     size: 40

--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/structure_artifacts.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/structure_artifacts.yml
@@ -42,7 +42,7 @@
     - type: Artifact
     - type: RandomArtifactSprite
     - type: Appearance
-    - type: StaticPrice
+    - type: DynamicPrice
       price: 500
     - type: Actions
     - type: Psionic

--- a/Resources/Prototypes/Entities/Objects/Specific/atmos.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/atmos.yml
@@ -30,5 +30,5 @@
   - type: Tag
     tags:
       - DroneUsable
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 80

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry-bottles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry-bottles.yml
@@ -43,7 +43,7 @@
     solution: drink
   - type: TrashOnEmpty
     solution: drink
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 0
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -80,7 +80,7 @@
     damage:
       types:
         Blunt: 5
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 30
 
 - type: entity
@@ -119,7 +119,7 @@
   - type: SolutionContainerVisuals
     maxFillLevels: 6
     fillBaseName: beakerlarge
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 40
 
 - type: entity
@@ -212,7 +212,7 @@
   - type: SolutionContainerVisuals
     maxFillLevels: 1
     fillBaseName: dropper
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 40
 
 - type: entity
@@ -288,7 +288,7 @@
   - type: DeleteOnTrigger
   - type: Extractable
     grindableSolutionName: food
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 0
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
@@ -14,7 +14,7 @@
   - type: Stack
     count: 20
     stackType: Telecrystal
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 0
   - type: StackPrice
     price: 200

--- a/Resources/Prototypes/Entities/Objects/Tools/airlock_painter.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/airlock_painter.yml
@@ -18,5 +18,5 @@
       whitelist:
         tags:
           - PaintableAirlock
-    - type: StaticPrice
+    - type: DynamicPrice
       price: 40

--- a/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
@@ -22,7 +22,7 @@
     sprite: Objects/Tools/cable-coils.rsi
   - type: CablePlacer
   - type: Clickable
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 0
   - type: StackPrice
     price: 5

--- a/Resources/Prototypes/Entities/Objects/Tools/flashlights.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/flashlights.yml
@@ -83,7 +83,7 @@
     autoRot: true
     radius: 4.5
   - type: Appearance
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 40
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
@@ -66,7 +66,7 @@
         useDelay: 1.0
         event: !type:ToggleJetpackEvent
     - type: Appearance
-    - type: StaticPrice
+    - type: DynamicPrice
       price: 100
 
 #Empty blue

--- a/Resources/Prototypes/Entities/Objects/Tools/light_replacer.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/light_replacer.yml
@@ -20,7 +20,7 @@
   - type: Tag
     tags:
       - DroneUsable
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 100
   - type: ContainerContainer
     containers:

--- a/Resources/Prototypes/Entities/Objects/Tools/t-ray.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/t-ray.yml
@@ -22,5 +22,5 @@
   - type: Tag
     tags:
       - DroneUsable
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 60

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -37,7 +37,7 @@
   - type: Item
     sprite: Objects/Tools/wirecutters.rsi
   - type: LatticeCutting
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 40
 
 - type: entity
@@ -76,7 +76,7 @@
     available:
       - enum.DamageStateVisualLayers.Base:
           screwdriver: Rainbow
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 40
 
 - type: entity
@@ -112,7 +112,7 @@
       - Anchoring
     useSound:
       path: /Audio/Items/ratchet.ogg
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 40
 
 - type: entity
@@ -145,7 +145,7 @@
     useSound:
       path: /Audio/Items/crowbar.ogg
   - type: TilePrying
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 40
 
 - type: entity
@@ -206,7 +206,7 @@
   - type: Tag
     tags:
       - DroneUsable
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 60
   - type: MeleeWeapon
     damage:
@@ -252,7 +252,7 @@
           path: /Audio/Items/drill_use.ogg
         changeSound:
           path: /Audio/Items/change_drill.ogg
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 60
 
 - type: entity
@@ -274,7 +274,7 @@
     quickEquip: false
     slots:
     - Belt
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 100
 
 - type: entity
@@ -298,7 +298,7 @@
   - type: Item
     sprite: Objects/Tools/rcd.rsi
     heldPrefix: ammo
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 60
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/welders.yml
@@ -61,7 +61,7 @@
     color: orange
   - type: Appearance
   - type: RequiresEyeProtection
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 40
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Vehicles/buckleable.yml
+++ b/Resources/Prototypes/Entities/Objects/Vehicles/buckleable.yml
@@ -70,7 +70,7 @@
           path: /Audio/Effects/Vehicle/vehiclestartup.ogg
           params:
             volume: -3
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 750 # Grand Theft Auto.
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/antimaterial.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/antimaterial.yml
@@ -16,5 +16,5 @@
       map: ["enum.AmmoVisualLayers.Base"]
   - type: Appearance
   - type: SpentAmmoVisuals
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 20

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/caseless_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/caseless_rifle.yml
@@ -19,7 +19,7 @@
       map: ["enum.AmmoVisualLayers.Base"]
   - type: Appearance
   - type: SpentAmmoVisuals
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 10
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/heavy_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/heavy_rifle.yml
@@ -18,7 +18,7 @@
       map: ["enum.AmmoVisualLayers.Base"]
   - type: Appearance
   - type: SpentAmmoVisuals
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 10
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/light_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/light_rifle.yml
@@ -18,7 +18,7 @@
       map: ["enum.AmmoVisualLayers.Base"]
   - type: Appearance
   - type: SpentAmmoVisuals
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 10
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/magnum.yml
@@ -18,7 +18,7 @@
       map: ["enum.AmmoVisualLayers.Base"]
   - type: Appearance
   - type: SpentAmmoVisuals
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 10
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/pistol.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/pistol.yml
@@ -18,7 +18,7 @@
       map: ["enum.AmmoVisualLayers.Base"]
   - type: Appearance
   - type: SpentAmmoVisuals
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 10
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/rifle.yml
@@ -18,7 +18,7 @@
       map: ["enum.AmmoVisualLayers.Base"]
   - type: Appearance
   - type: SpentAmmoVisuals
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 10
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/toy.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/toy.yml
@@ -17,7 +17,7 @@
       map: ["enum.AmmoVisualLayers.Base"]
   - type: SpentAmmoVisuals
   - type: Appearance
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 5
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/explosives.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/explosives.yml
@@ -18,7 +18,7 @@
     netsync: false
     sprite: Objects/Weapons/Guns/Ammunition/Explosives/explosives.rsi
     state: rpg
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 20
 
 - type: entity
@@ -38,7 +38,7 @@
     - type: Sprite
       sprite: Objects/Weapons/Guns/Ammunition/Explosives/explosives.rsi
       state: frag
-    - type: StaticPrice
+    - type: DynamicPrice
       price: 20
 
 # Grenades

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -29,7 +29,7 @@
     steps: 5
     zeroVisible: false
   - type: Appearance
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 500
 
 - type: entity
@@ -368,7 +368,7 @@
     steps: 5
     zeroVisible: true
   - type: Appearance
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 750
 
 - type: entity
@@ -401,5 +401,5 @@
     steps: 5
     zeroVisible: true
   - type: Appearance
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 63

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/HMGs/hmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/HMGs/hmgs.yml
@@ -17,7 +17,7 @@
       path: /Audio/Weapons/Guns/Gunshots/lmg.ogg
     soundEmpty:
       path: /Audio/Weapons/Guns/Empty/lmg_empty.ogg
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 500
   # No chamber because HMG may want its own
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -51,7 +51,7 @@
     containers:
       gun_magazine: !type:ContainerSlot
       gun_chamber: !type:ContainerSlot
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 500
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -14,7 +14,7 @@
     - Back
   - type: Item
     size: 60
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 500
   - type: ContainerContainer
     containers:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -55,7 +55,7 @@
     steps: 1
     zeroVisible: true
   - type: Appearance
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 500
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -39,7 +39,7 @@
       path: /Audio/Weapons/Guns/MagOut/revolver_magout.ogg
     soundInsert:
       path: /Audio/Weapons/Guns/MagIn/revolver_magin.ogg
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 500
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -46,7 +46,7 @@
     containers:
       gun_magazine: !type:ContainerSlot
       gun_chamber: !type:ContainerSlot
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 500
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -49,7 +49,7 @@
     containers:
       gun_magazine: !type:ContainerSlot
       gun_chamber: !type:ContainerSlot
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 500
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -42,7 +42,7 @@
     containers:
       ballistic-ammo: !type:Container
         ents: []
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 500
 
 - type: entity
@@ -98,7 +98,7 @@
     steps: 1
     zeroVisible: true
   - type: Appearance
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 500
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -36,7 +36,7 @@
     containers:
       ballistic-ammo: !type:Container
         ents: []
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 500
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -42,7 +42,7 @@
         enum.ToggleVisuals.Layer:
           True: {state: stunbaton_on}
           False: {state: stunbaton_off}
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 100
 
 - type: entity
@@ -64,7 +64,7 @@
       size: 5
       sprite: Objects/Weapons/Melee/flash.rsi
     - type: ItemCooldown
-    - type: StaticPrice
+    - type: DynamicPrice
       price: 40
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/base_item.yml
+++ b/Resources/Prototypes/Entities/Objects/base_item.yml
@@ -6,7 +6,7 @@
   - type: Item
     size: 5
   - type: DynamicPrice
-    price: 20
+    price: 2
   - type: Clickable
   - type: InteractionOutline
   - type: MovedByPressure

--- a/Resources/Prototypes/Entities/Objects/base_item.yml
+++ b/Resources/Prototypes/Entities/Objects/base_item.yml
@@ -5,7 +5,7 @@
   components:
   - type: Item
     size: 5
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 20
   - type: Clickable
   - type: InteractionOutline

--- a/Resources/Prototypes/Entities/Structures/Dispensers/base_structuredispensers.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/base_structuredispensers.yml
@@ -60,5 +60,5 @@
       machine_board: !type:Container
       machine_parts: !type:Container
       beakerSlot: !type:ContainerSlot
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 1000

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
@@ -114,7 +114,7 @@
     mode: NoSprite
   - type: PaintableAirlock
     group: Standard
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 150
   placement:
     mode: SnapgridCenter

--- a/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
@@ -101,7 +101,7 @@
       enabled: false
     - type: WallMount
       arc: 360
-    - type: StaticPrice
+    - type: DynamicPrice
       price: 150
 
 - type: entity
@@ -174,5 +174,5 @@
       occludes: false
     - type: Physics
       canCollide: false
-    - type: StaticPrice
+    - type: DynamicPrice
       price: 100

--- a/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
@@ -124,7 +124,7 @@
     node: windoor
     containers:
     - board
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 100
 
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
@@ -40,7 +40,7 @@
       - !type:PlaySoundBehavior
         sound:
           path: /Audio/Effects/metalbreak.ogg
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 50
 
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Furniture/rollerbeds.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/rollerbeds.yml
@@ -55,7 +55,7 @@
         key: rollerbed
       - type: RollerbedVisualizer
         key: rollerbed
-    - type: StaticPrice
+    - type: DynamicPrice
       price: 200
 
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/arcades.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/arcades.yml
@@ -33,7 +33,7 @@
       bodyBroken: arcade
   - type: Anchorable
   - type: Pullable
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 300
 
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/base_structurecomputers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/base_structurecomputers.yml
@@ -54,5 +54,5 @@
     containers:
       board: !type:Container
         ents: []
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 400

--- a/Resources/Prototypes/Entities/Structures/Machines/cloning_machine.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/cloning_machine.yml
@@ -70,7 +70,7 @@
           enum.CloningPodStatus.Gore: pod_g
           enum.CloningPodStatus.Idle: pod_0
   - type: Climbable
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 1000
   - type: ContainerContainer
     containers:

--- a/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
@@ -74,7 +74,7 @@
     # Gravity generator is a large machine, not casting shadows is fine within the radius set above.
     castShadows: false
     color: "#a8ffd9"
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 5000
 
 - type: entity
@@ -113,5 +113,5 @@
     activePower: 500
     lightRadiusMin: 0.75
     lightRadiusMax: 2.5
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 2000

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -82,7 +82,7 @@
       - TRayScanner
       - GasAnalyzer
       - UtilityBelt
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 800
 
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -67,8 +67,6 @@
     powerLoad: 200
     priority: Low
   - type: Actions
-  - type: DynamicPrice
-    price: 200
   - type: Appearance
   - type: WiresVisuals
 

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -67,7 +67,7 @@
     powerLoad: 200
     priority: Low
   - type: Actions
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 200
   - type: Appearance
   - type: WiresVisuals

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/pipes.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/pipes.yml
@@ -48,7 +48,7 @@
     range: 2
     sound:
       path: /Audio/Ambience/Objects/gas_hiss.ogg
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 100
 
 #Note: The PipeDirection of the PipeNode should be the south-facing version, because the entity starts at an angle of 0 (south)

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -16,7 +16,7 @@
           nodeGroupID: Pipe
           pipeDirection: South
     - type: CollideOnAnchor
-    - type: StaticPrice
+    - type: DynamicPrice
       price: 200
 
 - type: entity
@@ -252,7 +252,7 @@
           !type:PipeNode
           nodeGroupID: Pipe
           pipeDirection: South
-    - type: StaticPrice
+    - type: DynamicPrice
       price: 500
 
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Piping/Disposal/pipes.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Disposal/pipes.yml
@@ -53,7 +53,7 @@
   - type: ContainerContainer
     containers:
       DisposalTube: !type:Container
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 100
 
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Piping/Disposal/units.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Disposal/units.yml
@@ -74,7 +74,7 @@
   - type: ContainerContainer
     containers:
       DisposalUnit: !type:Container
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 100
   - type: PowerSwitch
 

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/generators.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/generators.yml
@@ -67,7 +67,7 @@
     maxIntensity: 100
     intensitySlope: 2
     totalIntensity: 200
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 500
 
 # Base Wallmount Generator

--- a/Resources/Prototypes/Entities/Structures/Power/apc.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/apc.yml
@@ -92,7 +92,7 @@
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
   - type: StationInfiniteBatteryTarget
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 500
 
 # APC under construction

--- a/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
@@ -37,7 +37,7 @@
         behaviors:
           - !type:DoActsBehavior
             acts: ["Destruction"]
-    - type: StaticPrice
+    - type: DynamicPrice
       price: 1000
   placement:
     mode: SnapgridCenter
@@ -125,7 +125,7 @@
   - type: UpgradePowerDraw
     powerDrawMultiplier: 0.75
     scaling: Exponential
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 2000
 
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
@@ -84,7 +84,7 @@
           volume: 1
     - type: GasPortable
     - type: GasCanister
-    - type: StaticPrice
+    - type: DynamicPrice
       price: 1000
     - type: AccessReader
       access: [["Atmospherics"], ["ResearchDirector"]]

--- a/Resources/Prototypes/Entities/Structures/Storage/Tanks/tanks.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Tanks/tanks.yml
@@ -5,7 +5,7 @@
   parent: StorageTank
   suffix: Empty
   components:
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 1200
   - type: Sprite
     sprite: Structures/Storage/tanks.rsi
@@ -27,7 +27,7 @@
   parent: WeldingFuelTank
   suffix: Full
   components:
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 1200
   - type: SolutionContainerManager
     solutions:
@@ -43,7 +43,7 @@
   parent: StorageTank
   suffix: Empty
   components:
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 1200
   - type: Sprite
     sprite: Structures/Storage/tanks.rsi
@@ -54,7 +54,7 @@
   id: WaterTankFull
   suffix: Full
   components:
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 1200
   - type: SolutionContainerManager
     solutions:

--- a/Resources/Prototypes/Entities/Structures/Storage/morgue.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/morgue.yml
@@ -69,7 +69,7 @@
   - type: Transform
     anchored: true
   - type: AntiRottingContainer
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 200
 
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Storage/storage.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/storage.yml
@@ -50,5 +50,5 @@
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
   - type: Climbable
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 150

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/base_structuresigns.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/base_structuresigns.yml
@@ -33,5 +33,5 @@
     sprite: Structures/Wallmounts/signs.rsi
     netsync: false
     snapCardinals: true
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 20

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/surveillance_camera.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/surveillance_camera.yml
@@ -44,7 +44,7 @@
         type: SurveillanceCameraSetupBoundUi
       - key: enum.WiresUiKey.Key
         type: WiresBoundUserInterface
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 200
   - type: Destructible
     thresholds:

--- a/Resources/Prototypes/Entities/Structures/Walls/girders.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/girders.yml
@@ -48,7 +48,7 @@
             max: 1
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 0.5
 
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -43,7 +43,7 @@
       density: 1000
   - type: Occluder
   - type: Airtight
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 75
   - type: RadiationBlocker
     resistance: 2
@@ -463,7 +463,7 @@
   - type: Appearance
     visuals:
       - type: ReinforcedWallVisualizer
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 150
   - type: RadiationBlocker
     resistance: 5
@@ -498,7 +498,7 @@
   - type: IconSmooth
     key: walls
     base: riveted
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 150
 
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Windows/plasma.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/plasma.yml
@@ -39,7 +39,7 @@
     trackAllDamage: true
     damageOverlay:
       sprite: Structures/Windows/cracks.rsi
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 20.5
   - type: RadiationBlocker
     resistance: 2
@@ -80,5 +80,5 @@
             max: 2
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 20.5

--- a/Resources/Prototypes/Entities/Structures/Windows/reinforced.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/reinforced.yml
@@ -48,7 +48,7 @@
     trackAllDamage: true
     damageOverlay:
       sprite: Structures/Windows/cracks.rsi
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 150
 
 - type: entity
@@ -67,7 +67,7 @@
     graph: Window
     node: tintedWindow
   - type: Occluder
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 0.75
 
 - type: entity
@@ -108,5 +108,5 @@
             max: 2
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 0.75

--- a/Resources/Prototypes/Entities/Structures/Windows/rplasma.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/rplasma.yml
@@ -50,7 +50,7 @@
     trackAllDamage: true
     damageOverlay:
       sprite: Structures/Windows/cracks.rsi
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 20.75
 
 - type: entity
@@ -98,5 +98,5 @@
             max: 2
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 20.75

--- a/Resources/Prototypes/Entities/Structures/Windows/shuttle.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/shuttle.yml
@@ -45,5 +45,5 @@
     trackAllDamage: true
     damageOverlay:
       sprite: Structures/Windows/cracks.rsi
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 75

--- a/Resources/Prototypes/Entities/Structures/Windows/window.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/window.yml
@@ -84,7 +84,7 @@
     trackAllDamage: true
     damageOverlay:
       sprite: Structures/Windows/cracks.rsi
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 100
 
 - type: entity
@@ -168,7 +168,7 @@
   - type: Construction
     graph: WindowDirectional
     node: windowDirectional
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 0.5
 
 - type: entity
@@ -193,7 +193,7 @@
     state: tinted_window
   - type: Occluder
     boundingBox: "-0.5,-0.5,0.5,-0.3"
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 0.5
 
 - type: entity
@@ -213,5 +213,5 @@
   - type: Icon
     sprite: Structures/Windows/directional.rsi
     state: frosted_window
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 0.5

--- a/Resources/Prototypes/Entities/Structures/base_structure.yml
+++ b/Resources/Prototypes/Entities/Structures/base_structure.yml
@@ -53,7 +53,7 @@
       - MidImpassable
       - LowImpassable
   - type: Anchorable
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 50
 
 - type: Tag

--- a/Resources/Prototypes/Entities/Structures/conveyor.yml
+++ b/Resources/Prototypes/Entities/Structures/conveyor.yml
@@ -81,6 +81,6 @@
   - type: Construction
     graph: ConveyorGraph
     node: item
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 40
 

--- a/Resources/Prototypes/Nyanotrasen/Body/Parts/golem.yml
+++ b/Resources/Prototypes/Nyanotrasen/Body/Parts/golem.yml
@@ -11,7 +11,7 @@
     containers:
       bodypart: !type:Container
         ents: []
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 100
 
 - type: entity

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Chapel/amphorae.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Chapel/amphorae.yml
@@ -11,7 +11,7 @@
   - type: Item
     size: 10
     sprite: Nyanotrasen/Objects/Specific/Chapel/amphorae.rsi
-  - type: StaticPrice
+  - type: DynamicPrice
     price: 50
   - type: SolutionContainerManager
     solutions:


### PR DESCRIPTION
This PR introduces DynamicPriceComponent, a replacement for StaticPriceComponent, which has a price that is influenced by supply (things sold by the station) and demand (outside influence such as events which are not yet implemented). As supply increases towards a point determined by HalfPriceSurplus, the price falls off linearly. I.e. the default HalfPriceSurplus for entities is 5, so if something costs 20 zorkmids by default, selling 5 entities will bring the next sale to 10 zorkmids.

The supply slowly reduces over time, randomly. This also affects gas, reagents, and stacks. Notably, it does not affect armor and its special pricing yet. I've left that as-is for now.

This is in response to the popular strategy of selling unlimited fabricatable items for great sums of cash.

I have plans to introduce market fluctuation events and the ability to view what is high in demand, similar to the Oracle's demands. However for now, I want to see how this works in the wild and what the reception is like. Mail will still be a viable way to make money no matter what the market's like, which is a nice social incentive.

:cl:
- tweak: Vending machines are worth zero zorkmids now.
- tweak: The default price of items has been reduced from 20 to 2.
- add: The law of supply and demand now affects what is sold on the cargo shuttle.
