### PR TITLE
disallow ghost command during active mindswap

### DIFF
--- a/Content.Server/Ghost/Ghost.cs
+++ b/Content.Server/Ghost/Ghost.cs
@@ -1,7 +1,6 @@
 using Content.Server.GameTicking;
 using Content.Server.Players;
 using Content.Shared.Administration;
-using Content.Server.Abilities.Psionics;
 using Robust.Server.Player;
 using Robust.Shared.Console;
 
@@ -16,17 +15,10 @@ namespace Content.Server.Ghost
 
         public void Execute(IConsoleShell shell, string argStr, string[] args)
         {
-            var entityManager = IoCManager.Resolve<IEntityManager>();
             var player = shell.Player as IPlayerSession;
             if (player == null)
             {
                 shell?.WriteLine("You have no session, you can't ghost.");
-                return;
-            }
-
-            if (entityManager.HasComponent<MindSwappedComponent>(player.AttachedEntity))
-            {
-                shell?.WriteLine("You cannot ghost while actively mindswapped.");
                 return;
             }
 

--- a/Content.Server/Ghost/Ghost.cs
+++ b/Content.Server/Ghost/Ghost.cs
@@ -1,6 +1,7 @@
 using Content.Server.GameTicking;
 using Content.Server.Players;
 using Content.Shared.Administration;
+using Content.Server.Abilities.Psionics;
 using Robust.Server.Player;
 using Robust.Shared.Console;
 
@@ -15,10 +16,17 @@ namespace Content.Server.Ghost
 
         public void Execute(IConsoleShell shell, string argStr, string[] args)
         {
+            var entityManager = IoCManager.Resolve<IEntityManager>();
             var player = shell.Player as IPlayerSession;
             if (player == null)
             {
                 shell?.WriteLine("You have no session, you can't ghost.");
+                return;
+            }
+
+            if (entityManager.HasComponent<MindSwappedComponent>(player.AttachedEntity))
+            {
+                shell?.WriteLine("You cannot ghost while actively mindswapped.");
                 return;
             }
 

--- a/Content.Server/Nyanotrasen/Abilities/Psionics/Abilities/MindSwapPowerSystem.cs
+++ b/Content.Server/Nyanotrasen/Abilities/Psionics/Abilities/MindSwapPowerSystem.cs
@@ -8,6 +8,7 @@ using Content.Server.Players;
 using Content.Shared.Mobs.Systems;
 using Content.Server.Popups;
 using Content.Server.Psionics;
+using Content.Server.GameTicking;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using Robust.Server.GameObjects;
@@ -31,6 +32,7 @@ namespace Content.Server.Abilities.Psionics
             SubscribeLocalEvent<MindSwapPowerActionEvent>(OnPowerUsed);
             SubscribeLocalEvent<MindSwappedComponent, MindSwapPowerReturnActionEvent>(OnPowerReturned);
             SubscribeLocalEvent<MindSwappedComponent, DispelledEvent>(OnDispelled);
+            SubscribeLocalEvent<GhostAttemptHandleEvent>(OnGhostAttempt);
             //
             SubscribeLocalEvent<MindSwappedComponent, ComponentInit>(OnSwapInit);
         }
@@ -108,6 +110,18 @@ namespace Content.Server.Abilities.Psionics
         private void OnDispelled(EntityUid uid, MindSwappedComponent component, DispelledEvent args)
         {
             Swap(uid, component.OriginalEntity, true);
+            args.Handled = true;
+        }
+
+        private void OnGhostAttempt(GhostAttemptHandleEvent args)
+        {
+            if (args.Handled)
+                return;
+
+            if (!HasComp<MindSwappedComponent>(args.Mind.CurrentEntity))
+                return;
+
+            args.Result = false;
             args.Handled = true;
         }
 


### PR DESCRIPTION
As a note, testing it didn't seem to do anything anyway but there is probably some bug or exploit related to this.
