### PR TITLE
Adds Colored Lights

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Nyanotrasen/Catalog/Fills/Boxes/general.yml
@@ -1,0 +1,27 @@
+- type: entity
+  name: colored lighttube box
+  parent: BoxCardboard
+  id: BoxColoredLighttube
+  description: This box is shaped on the inside so that only light tubes and bulbs fit.
+  components:
+  - type: StorageFill
+    contents:
+      - id: ColoredLightTubeRed
+        amount: 4
+      - id: ColoredLightTubeFrostyBlue
+        amount: 4
+      - id: ColoredLightTubeBlackLight
+        amount: 4
+  - type: Sprite
+    layers:
+      - state: box
+      - state: lighttube
+  - type: Storage
+    capacity: 60
+    whitelist:
+      components:
+      - LightBulb
+  - type: Tag
+    tags:
+      - DroneUsable
+      

--- a/Resources/Prototypes/Nyanotrasen/Catalog/Fills/Cargo/cargo_service.yml
+++ b/Resources/Prototypes/Nyanotrasen/Catalog/Fills/Cargo/cargo_service.yml
@@ -1,0 +1,9 @@
+- type: cargoProduct
+  id: ServiceColoredLightsReplacement
+  icon:
+    sprite: Objects/Power/light_bulb.rsi
+    state: normal
+  product: CrateServiceReplacementColoredLights
+  cost: 600
+  category: Service
+  group: market

--- a/Resources/Prototypes/Nyanotrasen/Catalog/Fills/Crates/service.yml
+++ b/Resources/Prototypes/Nyanotrasen/Catalog/Fills/Crates/service.yml
@@ -1,0 +1,9 @@
+- type: entity
+  id: CrateServiceReplacementColoredLights
+  name: Colored Lights Crate
+  parent: CrateGenericSteel
+  components:
+  - type: StorageFill
+    contents:
+      - id: BoxColoredLighttube
+        amount: 2

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Power/lights.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Power/lights.yml
@@ -1,0 +1,50 @@
+- type: entity
+  parent: BaseLightbulb
+  name: red light tube
+  description: A colorful light tube. These emit a red hue.
+  id: ColoredLightTubeRed
+  components:
+  - type: LightBulb
+    bulb: Tube
+    color: "#FF6666"
+    lightEnergy: 0.8
+    lightRadius: 10
+    lightSoftness: 0.5
+    PowerUse: 25
+  - type: Sprite
+    sprite:  Objects/Power/light_tube.rsi
+    state: normal 
+
+- type: entity
+  parent: BaseLightbulb
+  name: blue light tube
+  description: A colorful light tube. These emit a frosty blue hue.
+  id: ColoredLightTubeFrostyBlue
+  components:
+  - type: LightBulb
+    bulb: Tube
+    color: "#00FFFF"
+    lightEnergy: 0.8
+    lightRadius: 10
+    lightSoftness: 1
+    PowerUse: 25
+  - type: Sprite
+    sprite:  Objects/Power/light_tube.rsi
+    state: normal 
+    
+- type: entity
+  parent: BaseLightbulb
+  name: black light tube
+  description: A colorful light tube. These emit "black light".
+  id: ColoredLightTubeBlackLight
+  components:
+  - type: LightBulb
+    bulb: Tube
+    color: "#5D0CED"
+    lightEnergy: 0.8
+    lightRadius: 10
+    lightSoftness: 1
+    PowerUse: 25
+  - type: Sprite
+    sprite:  Objects/Power/light_tube.rsi
+    state: normal 

--- a/Resources/Prototypes/Nyanotrasen/Entities/Structures/Lighting/colored_lighting.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Structures/Lighting/colored_lighting.yml
@@ -1,0 +1,54 @@
+#Colored lights
+
+- type: entity
+  id: PoweredlightColoredRed
+  description: "A light fixture. Draws power and produces light when equipped with a light tube."
+  suffix: Red
+  parent: Poweredlight
+  components:
+  - type: PoweredLight
+    hasLampOnSpawn: ColoredLightTubeRed
+    damage:
+      types:
+        Heat: 5
+
+- type: entity
+  id: PoweredlightColoredFrostyBlue
+  description: "A light fixture. Draws power and produces light when equipped with a light tube."
+  suffix: Frosty
+  parent: Poweredlight
+  components:
+  - type: PoweredLight
+    hasLampOnSpawn: ColoredLightTubeFrostyBlue
+    damage:
+      types:
+        Heat: 5
+
+- type: entity
+  id: PoweredlightColoredBlack
+  description: "A light fixture. Draws power and produces light when equipped with a light tube."
+  suffix: Black
+  parent: Poweredlight
+  components:
+  - type: PoweredLight
+    hasLampOnSpawn: ColoredLightTubeBlackLight
+    damage:
+      types:
+        Heat: 5
+
+- type: entity
+  id: PoweredLightPostSmallRed
+  name: post light
+  description: "A light fixture. Draws power and produces light when equipped with a light tube."
+  suffix: Red
+  parent: PoweredLightPostSmallEmpty
+  components:
+  - type: Sprite
+    layers:
+    - state: off
+      map: [ "enum.PoweredLightLayers.Base" ]
+  - type: PoweredLight
+    hasLampOnSpawn: ColoredLightTubeRed
+    damage:
+      types:
+        Heat: 20

--- a/Resources/Prototypes/Nyanotrasen/Markers/Spawners/Random/boxes.yml
+++ b/Resources/Prototypes/Nyanotrasen/Markers/Spawners/Random/boxes.yml
@@ -16,6 +16,7 @@
       - BoxLightbulb
       - BoxLighttube
       - BoxLightMixed
+      - BoxColoredLighttube
       - BoxMesonScanners
       - BoxMRE
       - BoxInflatable

--- a/Resources/Prototypes/Nyanotrasen/Markers/Spawners/Random/devices.yml
+++ b/Resources/Prototypes/Nyanotrasen/Markers/Spawners/Random/devices.yml
@@ -44,10 +44,14 @@
       - SolarTrackerElectronics
       - Mousetrap
       - RadioHandheld
+      - DeepFryerMachineCircuitboard
+      - BoozeDispenserMachineCircuitboard
+      - SodaDispenserMachineCircuitboard
     chance: 0.8
     rarePrototypes:
       - TraversalDistorterMachineCircuitboard
       - CloningPodMachineCircuitboard
+      - MetempsychoticMachineCircuitboard
       - MedicalScannerMachineCircuitboard
       - ChemDispenserMachineCircuitboard
       - DawInstrumentMachineCircuitboard


### PR DESCRIPTION
Changelog:
-Adds 3 colored variants of light tubes (Red, Frosty Blue, Black{purple})
-Adds red post light
-Adds restock boxes/crates/cargo order
-Updates spawners

![Screenshot 2023-01-17 141724](https://user-images.githubusercontent.com/107660393/213004642-a7f26775-e0b8-4e16-a462-8130656e302c.jpg)
![Screenshot 2023-01-17 141717](https://user-images.githubusercontent.com/107660393/213004648-5e334247-7049-46b0-9f83-f32f6cb00ffc.jpg)
![Screenshot 2023-01-17 141709](https://user-images.githubusercontent.com/107660393/213004650-633be76d-6e1f-4c73-abf7-0e2c89e03d93.jpg)
![Screenshot 2023-01-17 141704](https://user-images.githubusercontent.com/107660393/213004653-aa429a2d-02d9-404a-98c7-bf577d5aba66.jpg)

