### PR TITLE
fix oracle guidebook appearance

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Entities/Structures/Research/oracle.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Structures/Research/oracle.yml
@@ -13,7 +13,7 @@
     layers:
       - state: oracle-0
       - map: ["enum.SolutionContainerLayers.Fill"]
-        state: oracle-1
+        state: oracle-0
   - type: Oracle
   - type: Speech
     speechSounds: Tenor


### PR DESCRIPTION
:cl: Rane
- fix: Oracle no longer has a blank solution in the guidebook. The guidebook still cannot render entities larger than 32x32

