### PR TITLE
Check IsFirstTimePredicted instead of ApplyingState.

### DIFF
--- a/Content.Shared/Inventory/InventorySystem.Equip.cs
+++ b/Content.Shared/Inventory/InventorySystem.Equip.cs
@@ -80,7 +80,7 @@ public abstract partial class InventorySystem
         if(!TryGetSlot(uid, args.Container.ID, out var slotDef, inventory: component))
             return;
 
-        if (!_gameTiming.ApplyingState)
+        if (!_gameTiming.IsFirstTimePredicted)
             return;
 
         var unequippedEvent = new DidUnequipEvent(uid, args.Entity, slotDef);
@@ -95,7 +95,7 @@ public abstract partial class InventorySystem
         if(!TryGetSlot(uid, args.Container.ID, out var slotDef, inventory: component))
             return;
 
-        if (!_gameTiming.ApplyingState)
+        if (!_gameTiming.IsFirstTimePredicted)
             return;
 
         var equippedEvent = new DidEquipEvent(uid, args.Entity, slotDef);


### PR DESCRIPTION
Events that should've been sent to the client were getting dropped, resulting in inability to use equipment-based actions such as PDAs, masks, oxygen tanks. Blindfolds should still not remove permanent blindness with this in place.