### PR TITLE
Prevent Unbuckle and ToggleInternal actions while Incapacitated

### DIFF
--- a/Content.Server/Body/Systems/InternalsSystem.cs
+++ b/Content.Server/Body/Systems/InternalsSystem.cs
@@ -12,8 +12,6 @@ using Content.Server.Popups;
 using Content.Server.DoAfter;
 using System.Threading;
 using Content.Shared.ActionBlocker;
-using Content.Shared.Mobs.Components;
-using Content.Shared.Mobs.Systems;
 
 namespace Content.Server.Body.Systems;
 

--- a/Content.Server/Body/Systems/InternalsSystem.cs
+++ b/Content.Server/Body/Systems/InternalsSystem.cs
@@ -11,6 +11,7 @@ using Content.Shared.Verbs;
 using Content.Server.Popups;
 using Content.Server.DoAfter;
 using System.Threading;
+using Content.Shared.ActionBlocker;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 
@@ -26,7 +27,7 @@ public sealed class InternalsSystem : EntitySystem
     [Dependency] private readonly HandsSystem _hands = default!;
     [Dependency] private readonly InventorySystem _inventory = default!;
     [Dependency] private readonly PopupSystem _popupSystem = default!;
-    [Dependency] private readonly MobStateSystem _mobState = default!;
+    [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
 
     public override void Initialize()
     {
@@ -66,10 +67,8 @@ public sealed class InternalsSystem : EntitySystem
             return;
         }
 
-        if (TryComp<MobStateComponent>(user, out var userMobState) && _mobState.IsIncapacitated(user, userMobState))
-        {
+        if (_actionBlocker.CanInteract(user, uid) == false)
             return;
-        }
 
         // Toggle off if they're on
         if (AreInternalsWorking(internals))

--- a/Content.Server/Body/Systems/InternalsSystem.cs
+++ b/Content.Server/Body/Systems/InternalsSystem.cs
@@ -11,6 +11,8 @@ using Content.Shared.Verbs;
 using Content.Server.Popups;
 using Content.Server.DoAfter;
 using System.Threading;
+using Content.Shared.Mobs.Components;
+using Content.Shared.Mobs.Systems;
 
 namespace Content.Server.Body.Systems;
 
@@ -24,6 +26,7 @@ public sealed class InternalsSystem : EntitySystem
     [Dependency] private readonly HandsSystem _hands = default!;
     [Dependency] private readonly InventorySystem _inventory = default!;
     [Dependency] private readonly PopupSystem _popupSystem = default!;
+    [Dependency] private readonly MobStateSystem _mobState = default!;
 
     public override void Initialize()
     {
@@ -59,6 +62,11 @@ public sealed class InternalsSystem : EntitySystem
     public void ToggleInternals(EntityUid uid, EntityUid user, bool force, InternalsComponent? internals = null)
     {
         if (!Resolve(uid, ref internals, false))
+        {
+            return;
+        }
+
+        if (TryComp<MobStateComponent>(user, out var userMobState) && _mobState.IsIncapacitated(user, userMobState))
         {
             return;
         }

--- a/Content.Server/Buckle/Systems/BuckleSystem.Buckle.cs
+++ b/Content.Server/Buckle/Systems/BuckleSystem.Buckle.cs
@@ -321,6 +321,9 @@ public sealed partial class BuckleSystem
             if (HasComp<SleepingComponent>(buckleId) && buckleId == user)
                 return false;
 
+            if (TryComp<MobStateComponent>(user, out var userMobState) && _mobState.IsIncapacitated(user, userMobState))
+                return false;
+
             // If the strap is a vehicle and the rider is not the person unbuckling, return.
             if (TryComp(oldBuckledTo.Owner, out VehicleComponent? vehicle) &&
                 vehicle.Rider != user)

--- a/Content.Server/Buckle/Systems/BuckleSystem.Buckle.cs
+++ b/Content.Server/Buckle/Systems/BuckleSystem.Buckle.cs
@@ -321,7 +321,7 @@ public sealed partial class BuckleSystem
             if (HasComp<SleepingComponent>(buckleId) && buckleId == user)
                 return false;
 
-            if (TryComp<MobStateComponent>(user, out var userMobState) && _mobState.IsIncapacitated(user, userMobState))
+            if (_actionBlocker.CanInteract(user, buckleId) == false)
                 return false;
 
             // If the strap is a vehicle and the rider is not the person unbuckling, return.


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This prevents players from unbuckling or toggling internals while dead or incapacitated.

**Media**
<!-- 
If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 
(adding clothing, items, new features, etc) must include ingame media or the PR will not be merged, in accordance with our PR guidelines.
This makes it much easier for us to merge PRs and find media for progress reports. If you include media in your pull request, we 
may potentially use it in the SS14 progress reports, with clear credit given.

Use screenshot software like Window's built in snipping tool, ShareX, Lightshot, or recording software like ShareX (gif), ScreenToGif, or Open Broadcaster Software (cross platform).
If you're unsure whether your PR will require media, ask a maintainer.

Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Players can no longer unbuckle or toggle internals while dead or in critical condition
