### PR TITLE
Update speech_emotes.yml

### DIFF
--- a/Resources/Prototypes/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/Voice/speech_emotes.yml
@@ -2,14 +2,18 @@
 - type: emote
   id: Scream
   category: Vocal
-  chatMessages: [screams, yells]
+  chatMessages: [screams!]
   chatTriggers:
     - scream
     - screams
+    - screams.
+    - screams!
     - screaming
     - screamed
     - shriek
     - shrieks
+    - shrieks.
+    - shrieks!
     - shrieking
     - shrieked
     - screech
@@ -18,6 +22,8 @@
     - screeched
     - yell
     - yells
+    - yells.
+    - yells!
     - yelled
     - yelling
 
@@ -28,14 +34,20 @@
   chatTriggers:
     - laugh
     - laughs
+    - laughs.
+    - laughs!
     - laughing
     - laughed
     - chuckle
     - chuckles
+    - chuckles.
+    - chuckles!
     - chuckled
     - chuckling
     - giggle
     - giggles
+    - giggles.
+    - giggles!
     - giggling
     - giggled
 
@@ -43,17 +55,19 @@
 - type: emote
   id: Clap
   category: Hands
-  chatMessages: [claps]
+  chatMessages: [claps!]
   chatTriggers:
     - clap
     - claps
+    - claps.
+    - claps!
     - clapping
     - clapped
 
 - type: emote
   id: Snap
   category: Hands
-  chatMessages: [snaps fingers]
+  chatMessages: [snaps fingers] # snaps <{THEIR($ent)}> fingers?
   chatTriggers:
     - snap
     - snaps
@@ -61,6 +75,11 @@
     - snapped
     - snap fingers
     - snaps fingers
+    - snaps fingers.
+    - snaps fingers!
+    - snaps their fingers
+    - snaps their fingers.
+    - snaps their fingers!
     - snapping fingers
     - snapped fingers
 


### PR DESCRIPTION
i do not like the speech emote system, time to commit ss13 emoting

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

**Media**
<!-- 
If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 
(adding clothing, items, new features, etc) must include ingame media or the PR will not be merged, in accordance with our PR guidelines.
This makes it much easier for us to merge PRs and find media for progress reports. If you include media in your pull request, we 
may potentially use it in the SS14 progress reports, with clear credit given.

Use screenshot software like Window's built in snipping tool, ShareX, Lightshot, or recording software like ShareX (gif), ScreenToGif, or Open Broadcaster Software (cross platform).
If you're unsure whether your PR will require media, ask a maintainer.

Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: router
- tweak: Added more triggers to the emoting system.

