### PR TITLE
Drone interaction fix

### DIFF
--- a/Content.Shared/Drone/SharedDroneSystem.cs
+++ b/Content.Shared/Drone/SharedDroneSystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Interaction.Events;
 using Content.Shared.Interaction.Components;
+using Content.Shared.Damage;
 using Content.Shared.Item;
 using Content.Shared.Tag;
 using Robust.Shared.Serialization;
@@ -18,6 +19,9 @@ namespace Content.Shared.Drone
         {
             if (args.Target == null)
                 return;
+
+            if (TryComp<DamageableComponent>(args.Target, out var dmg) && dmg.DamageContainerID == "Biological")
+                args.Cancel();
 
             if (HasComp<ItemComponent>(args.Target) && !HasComp<UnremoveableComponent>(args.Target)
                 && !_tagSystem.HasAnyTag(args.Target.Value, "DroneUsable", "Trash"))

--- a/Content.Shared/Drone/SharedDroneSystem.cs
+++ b/Content.Shared/Drone/SharedDroneSystem.cs
@@ -16,7 +16,10 @@ namespace Content.Shared.Drone
 
         private void OnInteractionAttempt(EntityUid uid, DroneComponent component, InteractionAttemptEvent args)
         {
-            if (args.Target != null && !HasComp<UnremoveableComponent>(args.Target)
+            if (args.Target == null)
+                return;
+
+            if (HasComp<ItemComponent>(args.Target) && !HasComp<UnremoveableComponent>(args.Target)
                 && !_tagSystem.HasAnyTag(args.Target.Value, "DroneUsable", "Trash"))
                 args.Cancel();
         }


### PR DESCRIPTION
:cl: Rane
- fix: Drone restrictions only apply to items and mobs, not structures.

