### PR TITLE
Revengineering20230130

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
@@ -268,3 +268,7 @@
   - type: Sprite
     sprite: Objects/Devices/encryption_keys.rsi
     state: syn_cypherkey
+  - type: ReverseEngineering
+    difficulty: 5
+    recipes:
+      - EncryptionKeySyndie

--- a/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
@@ -68,6 +68,10 @@
     - type: Appearance
     - type: DynamicPrice
       price: 100
+    - type: ReverseEngineering
+      difficulty: 3
+      recipes:
+        - JetpackBlue
 
 #Empty blue
 - type: entity
@@ -184,6 +188,10 @@
       outputPressure: 42.6
       air:
         volume: 4
+    - type: ReverseEngineering
+      difficulty: 2
+      recipes:
+        - JetpackMini
 
 # Filled mini
 - type: entity
@@ -216,6 +224,7 @@
     sprite: Objects/Tanks/Jetpacks/security.rsi
     slots:
       - Back
+
 
 #Filled security
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -311,7 +311,7 @@
   parent: Protolathe
   id: ExosuitFabricator
   name: exosuit fabricator
-  description: Creates parts for robotics and other mechanical needs
+  description: Creates parts for mechs and hardsuits.
   components:
   - type: Sprite
     netsync: false
@@ -339,6 +339,8 @@
     - RipleyRLeg
     - MechEquipmentGrabber
     - ClothingOuterHardsuitSyndieReverseEngineered
+    - JetpackBlue
+    - JetpackMini
   - type: MaterialStorage
     whitelist:
       tags:

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -392,6 +392,7 @@
       - ShellShotgunFlare
       - ShellTranquilizer
       - ShellSoulbreaker
+      - EncryptionKeySyndie
       - TargetHuman
       - TargetSyndicate
       - TargetClown

--- a/Resources/Prototypes/Nyanotrasen/Entities/Structures/Machines/reverseEngineering.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Structures/Machines/reverseEngineering.yml
@@ -9,7 +9,6 @@
     sprite: Nyanotrasen/Structures/Machines/reverse_engineering.rsi
     snapCardinals: true
     offset: "0.0,0.5"
-    drawdepth: Mobs
     layers:
     - state: open
       map: ["open"]

--- a/Resources/Prototypes/Nyanotrasen/Recipes/Lathes/devices.yml
+++ b/Resources/Prototypes/Nyanotrasen/Recipes/Lathes/devices.yml
@@ -1,0 +1,8 @@
+- type: latheRecipe
+  id: EncryptionKeySyndie
+  result: EncryptionKeySyndie
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 100
+     Gold: 100

--- a/Resources/Prototypes/Nyanotrasen/Recipes/Lathes/devices.yml
+++ b/Resources/Prototypes/Nyanotrasen/Recipes/Lathes/devices.yml
@@ -6,3 +6,21 @@
      Steel: 100
      Glass: 100
      Gold: 100
+
+- type: latheRecipe
+  id: JetpackBlue
+  result: JetpackBlue
+  completetime: 10
+  materials:
+    Steel: 8000
+    Plastic: 8000
+    Gold: 50
+
+- type: latheRecipe
+  id: JetpackMini
+  result: JetpackMini
+  completetime: 10
+  materials:
+    Steel: 4000
+    Plastic: 4000
+    Gold: 50


### PR DESCRIPTION
:cl: Rane
- add: Jetpacks and syndicate encryption keys can be reverse engineered.
- fix: Fixed the draw depth for the reverse engineering machine.

