### PR TITLE
fix bluespace crystal machine storage decon

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Materials/materials.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Materials/materials.yml
@@ -14,3 +14,6 @@
     tags:
       - BluespaceCrystal
       - RawMaterial
+  - type: Stack
+    stackType: Bluespace
+    count: 1

--- a/Resources/Prototypes/Nyanotrasen/Reagents/Materials/materials.yml
+++ b/Resources/Prototypes/Nyanotrasen/Reagents/Materials/materials.yml
@@ -3,4 +3,5 @@
   name: bluespace
   icon: /Textures/Nyanotrasen/Objects/Materials/materials.rsi/bluespace.png
   color: "#53a9ff"
+  stackEntity: MaterialBluespace
   price: 15

--- a/Resources/Prototypes/Nyanotrasen/Stacks/materials.yml
+++ b/Resources/Prototypes/Nyanotrasen/Stacks/materials.yml
@@ -1,0 +1,6 @@
+- type: stack
+  id: Bluespace
+  name: bluespace
+  icon: { sprite: Nyanotrasen/Objects/Materials/materials.rsi, state: bluespace }
+  spawn: MaterialBluespace
+  maxCount: 1


### PR DESCRIPTION
:cl: Rane
- fix: Bluespace crystals can be recovered from deconstruction.
