### PR TITLE
Reduce yield for mineable mountain

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Walls/mountain.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/mountain.yml
@@ -2,7 +2,7 @@
   id: MountainRockMining
   parent: AsteroidRock
   name: mountain rock
-  suffix: Higher Value Ore
+  suffix: Low Yield/Higher Value Ore
   description: A craggy mountain wall.
   components:
   - type: Sprite
@@ -17,7 +17,7 @@
       - !type:DoActsBehavior
         acts: ["Destruction"]
   - type: OreVein
-    oreChance: 0.33
+    oreChance: 0.20
     oreRarityPrototypeId: RandomOreDistributionHigh    
 
 - type: entity


### PR DESCRIPTION
Changelog:

- I'm sorry, but I flipped this when I swapped mountain values yesterday and that was a mistake. They should not have high yield and high value pool. It's too unbalanced. This changes it back to the low yield value. I'm done fucking with mountains now.
