### PR TITLE
Changes EncryptionKeyRobo's defualtChannel to Engineering

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
@@ -188,7 +188,7 @@
     - Common
     - Engineering
     - Binary
-    defaultChannel: Science
+    defaultChannel: Engineering
   - type: Sprite
     sprite: Objects/Devices/encryption_keys.rsi
     state: rob_cypherkey


### PR DESCRIPTION


**Changelog**
Changes EncryptionKeyRobo's defualtChannel to Engineering

![image](https://user-images.githubusercontent.com/96095110/216420066-42776853-e040-450d-89bb-0251b345b5b6.png)

