### PR TITLE
Fix vaccinator server not connecting on init.

### DIFF
--- a/Content.Client/Disease/UI/VaccineMachineBoundUserInterface.cs
+++ b/Content.Client/Disease/UI/VaccineMachineBoundUserInterface.cs
@@ -54,6 +54,7 @@ namespace Content.Client.Disease.UI
                     _machineMenu?.PopulateDiseases(msg.Diseases);
                     _machineMenu?.PopulateBiomass(Machine);
                     _machineMenu?.UpdateCost(msg.BiomassCost);
+                    _machineMenu?.UpdateServerConnection(msg.HasServer);
                     break;
             }
         }

--- a/Content.Client/Disease/UI/VaccineMachineMenu.xaml.cs
+++ b/Content.Client/Disease/UI/VaccineMachineMenu.xaml.cs
@@ -102,6 +102,11 @@ namespace Content.Client.Disease.UI
             Locked = locked;
         }
 
+        public void UpdateServerConnection(bool hasServer)
+        {
+            ServerSyncButton.Disabled = !hasServer;
+        }
+
         private void HandleAmountChanged(object? sender, ValueChangedEventArgs args)
         {
             UpdateCost(CostPer);

--- a/Content.Server/Disease/DiseaseDiagnosisSystem.cs
+++ b/Content.Server/Disease/DiseaseDiagnosisSystem.cs
@@ -33,6 +33,8 @@ namespace Content.Server.Disease
         [Dependency] private readonly InventorySystem _inventorySystem = default!;
         [Dependency] private readonly PaperSystem _paperSystem = default!;
         [Dependency] private readonly StationSystem _stationSystem = default!;
+        [Dependency] private readonly VaccineSystem _vaccineSystem = default!;
+
         public override void Initialize()
         {
             base.Initialize();
@@ -357,6 +359,17 @@ namespace Content.Server.Disease
             MetaData(printed).EntityName = reportTitle;
 
             _paperSystem.SetContent(printed, contents.ToMarkup(), paper);
+
+            // Update the UI for all DiseaseVaccineCreators on the station so
+            // players watching for the vaccine to be available see it as soon
+            // as possible.
+            foreach (var creator in EntityQuery<DiseaseVaccineCreatorComponent>())
+            {
+                if (_stationSystem.GetOwningStation(creator.Owner) != _stationSystem.GetOwningStation(uid))
+                    continue;
+
+                _vaccineSystem.UpdateUserInterfaceState(creator.Owner, creator);
+            }
         }
 
         /// <summary>

--- a/Content.Server/Disease/VaccineSystem.cs
+++ b/Content.Server/Disease/VaccineSystem.cs
@@ -32,13 +32,17 @@ namespace Content.Server.Disease
         [Dependency] private readonly AudioSystem _audioSystem = default!;
         [Dependency] private readonly TagSystem _tagSystem = default!;
         [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+
         public override void Initialize()
         {
             base.Initialize();
+
+            SubscribeLocalEvent<DiseaseVaccineCreatorComponent, ResearchRegistrationChangedEvent>(OnResearchRegistrationChanged);
             SubscribeLocalEvent<DiseaseVaccineCreatorComponent, CreateVaccineMessage>(OnCreateVaccineMessageReceived);
             SubscribeLocalEvent<DiseaseVaccineCreatorComponent, DiseaseMachineFinishedEvent>(OnVaccinatorFinished);
             SubscribeLocalEvent<DiseaseVaccineCreatorComponent, MaterialAmountChangedEvent>(OnVaccinatorAmountChanged);
             SubscribeLocalEvent<DiseaseVaccineCreatorComponent, ResearchClientServerSelectedMessage>(OnServerSelected);
+            SubscribeLocalEvent<DiseaseVaccineCreatorComponent, ResearchClientServerDeselectedMessage>(OnServerDeselected);
             SubscribeLocalEvent<DiseaseVaccineCreatorComponent, VaccinatorSyncRequestMessage>(OnSyncRequest);
             SubscribeLocalEvent<DiseaseVaccineCreatorComponent, VaccinatorServerSelectionMessage>(OpenServerList);
             SubscribeLocalEvent<DiseaseVaccineCreatorComponent, AfterActivatableUIOpenEvent>(AfterUIOpen);
@@ -51,6 +55,14 @@ namespace Content.Server.Disease
             SubscribeLocalEvent<TargetVaxxSuccessfulEvent>(OnTargetVaxxSuccessful);
             SubscribeLocalEvent<VaxxCancelledEvent>(OnVaxxCancelled);
 
+        }
+
+        private void OnResearchRegistrationChanged(EntityUid uid, DiseaseVaccineCreatorComponent component, ref ResearchRegistrationChangedEvent args)
+        {
+            if (TryComp<DiseaseServerComponent>(args.Server, out var diseaseServer))
+                component.DiseaseServer = diseaseServer;
+            else
+                component.DiseaseServer = null;
         }
 
         /// <summary>
@@ -140,6 +152,12 @@ namespace Content.Server.Disease
                 return;
 
             component.DiseaseServer = diseaseServer;
+            UpdateUserInterfaceState(uid, component);
+        }
+
+        private void OnServerDeselected(EntityUid uid, DiseaseVaccineCreatorComponent component, ResearchClientServerDeselectedMessage args)
+        {
+            component.DiseaseServer = null;
             UpdateUserInterfaceState(uid, component);
         }
 

--- a/Content.Server/Disease/VaccineSystem.cs
+++ b/Content.Server/Disease/VaccineSystem.cs
@@ -180,6 +180,7 @@ namespace Content.Server.Disease
             var biomass = _storageSystem.GetMaterialAmount(uid, "Biomass");
 
             var diseases = new List<(string id, string name)>();
+            var hasServer = false;
 
             if (component.DiseaseServer != null)
             {
@@ -190,12 +191,13 @@ namespace Content.Server.Disease
 
                     diseases.Add((disease.ID, disease.Name));
                 }
+
+                hasServer = true;
             }
-            var state = new VaccineMachineUpdateState(biomass, component.BiomassCost, diseases, overrideLocked ?? HasComp<DiseaseMachineRunningComponent>(uid));
+
+            var state = new VaccineMachineUpdateState(biomass, component.BiomassCost, diseases, overrideLocked ?? HasComp<DiseaseMachineRunningComponent>(uid), hasServer);
             _uiSys.SetUiState(ui, state);
         }
-
-
 
         /// <summary>
         /// Called when a vaccine is used on someone
@@ -303,6 +305,7 @@ namespace Content.Server.Disease
         {
             args.Vaxx.CancelToken = null;
         }
+
         /// These two are standard doafter stuff you can ignore
         private sealed class VaxxCancelledEvent : EntityEventArgs
         {
@@ -312,6 +315,7 @@ namespace Content.Server.Disease
                 Vaxx = vaxx;
             }
         }
+
         private sealed class TargetVaxxSuccessfulEvent : EntityEventArgs
         {
             public EntityUid User { get; }

--- a/Content.Shared/Disease/DiseaseVaccineCreatorMessages.cs
+++ b/Content.Shared/Disease/DiseaseVaccineCreatorMessages.cs
@@ -45,12 +45,15 @@ namespace Content.Shared.Disease.Components
 
         public bool Locked;
 
-        public VaccineMachineUpdateState(int biomass, int biomassCost, List<(string id, string name)> diseases, bool locked)
+        public bool HasServer;
+
+        public VaccineMachineUpdateState(int biomass, int biomassCost, List<(string id, string name)> diseases, bool locked, bool hasServer)
         {
             Biomass = biomass;
             BiomassCost = biomassCost;
             Diseases = diseases;
             Locked = locked;
+            HasServer = hasServer;
         }
     }
 


### PR DESCRIPTION
Here's some quality-of-life changes for the vaccinator.
- It uses ResearchClient's events now to register the DiseaseServer.
- It will now clear the DiseaseServer when a server's deselected.
- UI will update as soon as a vaccine is available.
- Sync button will now be disabled if no server is connected, preventing some confusion from the player. (Sync is made almost pointless by the previous bullet, but I've left it in for the time being.)

:cl:
- tweak: The Vaccinator's UI will now update as soon as a vaccine is available.
- fix: Fixed the Vaccinator not connecting to a server on startup.
