### PR TITLE
Add missing startAnnouncement for KudzuGrowth event.

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -110,6 +110,7 @@
   config:
     !type:StationEventRuleConfiguration
     id: KudzuGrowth
+    startAnnouncement: station-event-kudzu-growth-start-announcement
     startAudio:
       path: /Audio/Announcements/kudzu.ogg
     earliestStart: 15


### PR DESCRIPTION
Our new voice would announce it, but there was no corresponding text.