### PR TITLE
Convert passenger references to assistant.

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Ears/headsets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Ears/headsets.yml
@@ -24,7 +24,7 @@
 - type: entity
   parent: ClothingHeadset
   id: ClothingHeadsetGrey
-  name: passenger headset
+  name: assistant headset
   components:
   - type: Sprite
     sprite: Clothing/Ears/Headsets/base.rsi

--- a/Resources/Prototypes/Entities/Clothing/Ears/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Ears/specific.yml
@@ -1,7 +1,7 @@
 ﻿- type: entity
   parent: ClothingHeadsetGrey
   id: ClothingHeadsetChameleon
-  name: passenger headset
+  name: assistant headset
   description: An updated, modular intercom that fits over the head. Takes encryption keys.
   suffix: Chameleon
   components:

--- a/Resources/Prototypes/Entities/Markers/Spawners/jobs.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/jobs.yml
@@ -55,7 +55,7 @@
 - type: entity
   id: SpawnPointAssistant # TODO rename, but requires map changes.
   parent: SpawnPointJobBase
-  name: passenger
+  name: assistant
   components:
   - type: SpawnPoint
     job_id: Passenger

--- a/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
@@ -16,7 +16,7 @@
 - type: entity
   parent: EncryptionKey
   id: EncryptionKeyCommon
-  name: passenger encryption key
+  name: assistant encryption key
   description: An encryption key used by anyone.
   components:
   - type: EncryptionKey

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -101,7 +101,7 @@
 - type: entity
   parent: BasePDA
   id: PassengerPDA
-  name: passenger PDA
+  name: assistant PDA
   description: Why isn't it gray?
   components:
   - type: PDA

--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -347,7 +347,7 @@
 - type: entity
   parent: BaseItem
   id: ToyAssistant # TODO rename but needs map changes
-  name: passenger toy
+  name: assistant toy
   description: Grey tide world wide!
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -25,7 +25,7 @@
 - type: entity
   parent: IDCardStandard
   id: PassengerIDCard
-  name: passenger ID card
+  name: assistant ID card
   components:
   - type: Sprite
     layers:


### PR DESCRIPTION
Replaces the word "passenger" with "assistant" in the last places I could find.
