### PR TITLE
Fix draw depth of the reverse engineering machine.

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Entities/Structures/Machines/reverseEngineering.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Structures/Machines/reverseEngineering.yml
@@ -17,6 +17,7 @@
       map: ["enum.PowerDeviceVisualLayers.Powered"]
     netsync: false
     noRot: true
+    drawdepth: Mobs
   - type: ActivatableUI
     key: enum.ReverseEngineeringMachineUiKey.Key
   - type: UserInterface


### PR DESCRIPTION
You would visually float in front/on top of these before. Now you can go behind them just like trees and the Oracle.