### PR TITLE
restore x-no-y naming scheme

### DIFF
--- a/Content.Shared/Humanoid/NamingSystem.cs
+++ b/Content.Shared/Humanoid/NamingSystem.cs
@@ -32,6 +32,9 @@ namespace Content.Shared.Humanoid
                 case SpeciesNaming.FirstDashFirst:
                     return Loc.GetString("namepreset-firstdashfirst",
                         ("first1", GetFirstName(speciesProto, gender)), ("first2", GetFirstName(speciesProto, gender)));
+                case SpeciesNaming.XnoY:
+                    return Loc.GetString("namepreset-x-no-y",
+                        ("first", GetFirstName(speciesProto, gender)), ("last", GetLastName(speciesProto)));
                 case SpeciesNaming.FirstLast:
                 default:
                     return Loc.GetString("namepreset-firstlast",

--- a/Resources/Locale/en-US/species/namepreset.ftl
+++ b/Resources/Locale/en-US/species/namepreset.ftl
@@ -1,3 +1,4 @@
 namepreset-firstlast = {$first} {$last}
 namepreset-firstdashfirst = {$first1}-{$first2}
 namepreset-thefirstoflast = The {$first} of {$last}
+namepreset-x-no-y = {$last}-no-{$first}


### PR DESCRIPTION
:cl: Rane
- fix: Restored the oni naming scheme that got accidentally removed at some point.

