### PR TITLE
Recipe for normality crystals.

### DIFF
--- a/Content.Server/Nyanotrasen/Chemistry/ReactionEffects/ChangeGlimmerReactionEffect.cs
+++ b/Content.Server/Nyanotrasen/Chemistry/ReactionEffects/ChangeGlimmerReactionEffect.cs
@@ -1,0 +1,21 @@
+using Content.Shared.Chemistry.Reagent;
+using Content.Shared.Psionics.Glimmer;
+
+namespace Content.Server.Chemistry.ReactionEffects;
+
+[DataDefinition]
+public sealed class ChangeGlimmerReactionEffect : ReagentEffect
+{
+    /// <summary>
+    ///     Added to glimmer when reaction occurs.
+    /// </summary>
+    [DataField("change")]
+    public int Change = 1;
+
+    public override void Effect(ReagentEffectArgs args)
+    {
+        var glimmersys = args.EntityManager.EntitySysManager.GetEntitySystem<SharedGlimmerSystem>();
+
+        glimmersys.Glimmer += Change;
+    }
+}

--- a/Content.Server/Revenant/EntitySystems/RevenantSystem.cs
+++ b/Content.Server/Revenant/EntitySystems/RevenantSystem.cs
@@ -141,7 +141,7 @@ public sealed partial class RevenantSystem : EntitySystem
             int i = 0;
             while (i < amt)
             {
-                Spawn("MaterialBluespace", Transform(uid).Coordinates);
+                Spawn("Ectoplasm", Transform(uid).Coordinates);
                 i++;
             }
             QueueDel(uid);

--- a/Resources/Locale/en-US/flavors/flavor-profiles.ftl
+++ b/Resources/Locale/en-US/flavors/flavor-profiles.ftl
@@ -178,3 +178,4 @@ flavor-complex-sax = like jazz
 
 ## Nyano???
 flavor-complex-enthralling = enthralling
+flavor-complex-sublime = sublime

--- a/Resources/Locale/en-US/reagents/meta/physical-desc.ftl
+++ b/Resources/Locale/en-US/reagents/meta/physical-desc.ftl
@@ -84,3 +84,4 @@ reagent-physical-desc-inky = inky
 reagent-physical-desc-enigmatic = enigmatic
 reagent-physical-desc-porous = porous
 reagent-physical-desc-exotic-smelling = exotic smelling
+reagent-physical-desc-ethereal = ethereal

--- a/Resources/Locale/en-US/reagents/meta/toxins.ftl
+++ b/Resources/Locale/en-US/reagents/meta/toxins.ftl
@@ -63,3 +63,6 @@ reagent-desc-soulbreaker-toxin = An anti-psionic about 4 times as powerful as mi
 
 reagent-name-lotophagoi-oil = lotophagoi oil
 reagent-desc-lotophagoi-oil = A super potent drug that is much better at inducing psionics than normal hallucinogens, but with worse side effects.
+
+reagent-name-ectoplasm = ectoplasm
+reagent-desc-ectoplasm = The physical component of semi-corporeal spirits.

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/NPCs/glimmer_monsters.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/NPCs/glimmer_monsters.yml
@@ -55,7 +55,7 @@
           path: /Audio/Nyanotrasen/Mobs/GlimmerWisp/wail.ogg
       - !type:SpawnEntitiesBehavior
         spawn:
-          MaterialBluespace:
+          Ectoplasm:
             min: 1
             max: 1
       - !type:DoActsBehavior

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Chapel/ectoplasm.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Chapel/ectoplasm.yml
@@ -1,0 +1,15 @@
+- type: entity
+  parent: Ash
+  id: Ectoplasm
+  name: ectoplasm
+  description: The remains of a spirit.
+  components:
+  - type: Sprite
+    color: "#61a79d"
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 50
+        reagents:
+        - ReagentId: Ectoplasm
+          Quantity: 10

--- a/Resources/Prototypes/Nyanotrasen/Flavors/flavors.yml
+++ b/Resources/Prototypes/Nyanotrasen/Flavors/flavors.yml
@@ -2,3 +2,8 @@
   id: enthralling
   flavorType: Complex
   description: flavor-complex-enthralling
+
+- type: flavor
+  id: sublime
+  flavorType: Complex
+  description: flavor-complex-sublime

--- a/Resources/Prototypes/Nyanotrasen/Reagents/psionic.yml
+++ b/Resources/Prototypes/Nyanotrasen/Reagents/psionic.yml
@@ -87,3 +87,20 @@
       - !type:GenericStatusEffect
         key: SlurredSpeech
         component: TelepathicRepeater
+
+- type: reagent
+  id: Ectoplasm
+  name: reagent-name-ectoplasm
+  group: Toxins
+  desc: reagent-desc-ectoplasm
+  flavor: sublime
+  color: "#61a79d"
+  physicalDesc: reagent-physical-desc-ethereal
+  metabolisms:
+    Poison:
+      effects:
+      - !type:HealthChange
+        probability: 0.4
+        damage:
+          groups:
+            Toxin: 2

--- a/Resources/Prototypes/Nyanotrasen/Recipes/Reactions/psionic.yml
+++ b/Resources/Prototypes/Nyanotrasen/Recipes/Reactions/psionic.yml
@@ -26,7 +26,7 @@
     Ectoplasm:
       amount: 10
     Plasma:
-      amount: 5
+      amount: 10
       catalyst: true
   effects:
     - !type:CreateEntityReactionEffect

--- a/Resources/Prototypes/Nyanotrasen/Recipes/Reactions/psionic.yml
+++ b/Resources/Prototypes/Nyanotrasen/Recipes/Reactions/psionic.yml
@@ -30,3 +30,5 @@
   effects:
     - !type:CreateEntityReactionEffect
       entity: CrystalNormality
+    - !type:ChangeGlimmerReactionEffect
+      change: -10

--- a/Resources/Prototypes/Nyanotrasen/Recipes/Reactions/psionic.yml
+++ b/Resources/Prototypes/Nyanotrasen/Recipes/Reactions/psionic.yml
@@ -15,6 +15,7 @@
   id: CreateNormalityCrystal
   impact: Low
   quantized: true
+  minTemp: 400
   reactants:
     Ash:
       amount: 10

--- a/Resources/Prototypes/Nyanotrasen/Recipes/Reactions/psionic.yml
+++ b/Resources/Prototypes/Nyanotrasen/Recipes/Reactions/psionic.yml
@@ -10,3 +10,23 @@
       catalyst: true
   products:
     LotophagoiOil: 1
+
+- type: reaction
+  id: CreateNormalityCrystal
+  impact: Low
+  quantized: true
+  reactants:
+    Ash:
+      amount: 10
+    Water:
+      amount: 10
+    Blood:
+      amount: 10
+    Ectoplasm:
+      amount: 10
+    Plasma:
+      amount: 5
+      catalyst: true
+  effects:
+    - !type:CreateEntityReactionEffect
+      entity: CrystalNormality

--- a/Resources/Server Info/Guidebook/Epi/Psionics.xml
+++ b/Resources/Server Info/Guidebook/Epi/Psionics.xml
@@ -67,4 +67,7 @@ Metabolizing 20u or more of mindbreaker will remove psionics from a person, mean
 <GuideEntityEmbed Entity="ShellSoulbreaker" />
 Soulbreaker shells will remove psionics from psychics they hit.
 
+<GuideEntityEmbed Entity="Ectoplasm" />
+Ectoplasm, combined in a beaker with equal parts water, ash, blood, and plasma, will produce a normality crystal when heated enough. Use a hot plate for this.
+
 </Document>


### PR DESCRIPTION
:cl: Rane
- add: Ectoplasm can be used to create normality crystals. Check the psionics guidebook page for details.
- add: Glimmer wisps and revenants drop ectoplasm.

