### PR TITLE
Guidebook Proofing Pass and More Colourful Formatting

### DIFF
--- a/Resources/Server Info/Guidebook/Controls.xml
+++ b/Resources/Server Info/Guidebook/Controls.xml
@@ -11,7 +11,7 @@ Beyond that, there's a handful primary interactions in SS14, ordered by importan
 - [color=#a4885c]Left click[/color] to pick up items and activate objects like buttons or computers, and [color=#a4885c]E[/color] to activate items. You can also press [color=#a4885c]alt[/color] while doing this to trigger alternate interactions for some objects.
 - You can also quickly activate items you're holding by pressing [color=#a4885c]Z[/color] and [color=#a4885c]alt-Z[/color] respectively.
 - [color=#a4885c]Right click[/color] to open the context menu. You can then either left click an entry just like you would in the world, or right click it again to open the verb menu, which gives you more complex ways to interact with an object.
-- You can [color=#a4885c]shift-left click[/color] objects to examine them, and get their name and a detailed (though often humorous) description.
+- You can [color=#a4885c]shift-left click[/color] objects to examine them, and get their name and a detailed [color=#888084](though often humorous)[/color] description.
 
 You can quickly try out these controls with the monkey below (note: clicking it only works in-game and not in the lobby), and at any point in this guidebook if you're shown an entity, [color=#a4885c]shift-left click to examine will always work[/color]:
 
@@ -25,8 +25,8 @@ The items in your hands are only active one at a time, in order to swap between 
 
 Opening containers in your inventory is easy as well, either hover over the item and activate it with [color=#a4885c]E[/color] or [color=#a4885c]Z[/color], or click on the bag icon in the bottom right corner of the slot it is in.
 
-When you open a container a window will pop up showing the contents of the container and how much space it has available to hold things.
-All items have an assigned size, some too large to fit into most or all containers.
+When you open a container, a window will pop up showing the contents of the container and how much space it has available to hold things.
+All items have an assigned size, some are too large to fit into most or all containers.
 
 To drop items, you can press [color=#a4885c]Q[/color], and to drop them more violently (also known as throwing), you can press [color=#a4885c]ctrl-Q[/color].
 
@@ -35,12 +35,12 @@ To the left in your HUD there's a bar showing various actions you can take.
 You can hover over each one to see a name and description for the action that tells you what it is and how it works.
 You can click on an action to invoke it, or press a number key at any time to invoke the action without clicking on it.
 
-In order to rearrange your actions, simply drag and drop them to other slots, right click to remove them, and press the gear icon at the top of the bar to open a menu to (re)add them.
+In order to rearrange your actions, simply drag and drop them to other slots, right click to remove them, and press [color=#a4885c]K[/color] to open a menu to (re)add them.
 You have 10 pages of actions total that you can switch between by pressing [color=#a4885c]shift-(number)[/color].
-Additionally, you can press the lock icon to prevent the action bar from being modified.
 
 ## Movement
-There's a good few things that can modify your movement, most notably slipping (which requires you to walk with [color=#a4885c]shift[/color] to avoid, usually.) and a lack of gravity.
-Slipping simply stuns you for a bit, but no gravity can be deadly if you're off station and wander more than about 1.5m away from the nearest wall or solid structure, as you'll lose your grip and no longer be able to move without throwing something.
+There's a good few things that can modify your movement, most notably slipping (which requires you to walk with [color=#a4885c]shift[/color] to avoid, usually) and lack of gravity.
+
+Slipping simply stuns you for a bit, but weightlessness can be deadly if you're off station and wander more than about 1.5m away from the nearest wall or solid structure, as you'll lose your grip and no longer be able to move without throwing something.
 
 </Document>

--- a/Resources/Server Info/Guidebook/Eng/AME.xml
+++ b/Resources/Server Info/Guidebook/Eng/AME.xml
@@ -1,7 +1,7 @@
 <Document>
 # Antimatter Engine (AME)
 
-The AME is one of the simplest engines available. You put together the multi-tile structure, stick some fuel into it, and you're all set. This doesn't mean it isn't potentially dangerous with overheating though.
+The [color=#a4885c]AME[/color] is one of the simplest engines available. You put together the multi-tile structure, stick some fuel into it, and you're all set. This doesn't mean it isn't potentially dangerous with overheating though.
 
 ## Construction
 <Box>Required parts:</Box>
@@ -13,5 +13,7 @@ The AME is one of the simplest engines available. You put together the multi-til
 
 To assemble an AME, start by wrenching down the controller on the far end of a HV wire. On most stations, there's catwalks to assist with this. From there, start putting down a 3x3 or larger square of AME parts in preparation for construction, making sure to maximize the number of "center" pieces that are surrounded on all 8 sides.
 
-Once this is done, you can use a multitool to convert each AME part into shielding, which should form a finished AME configuration. From there, insert a fuel jar, set the fuel rate to [color=#a4885c]twice the core count or less[/color], and turn on injection.
+Once this is done, you can use a multitool to convert each AME part into shielding, which should form a finished AME configuration. From there, insert a fuel jar, set the fuel rate to twice the core count or less, and turn on injection.
+
+The AME has its power efficiency fall rapidly when not engaged at the maximum possible injection rate. If reducing the power output is required, consider removing some of the AME parts to reduce the core count [color=#fcdf03]and the injection rate also[/color]. To dismantle AME shielding, use a welder on the AME [color=#fcdf03]while it is deactivated.[/color]
 </Document>

--- a/Resources/Server Info/Guidebook/Eng/Atmospherics.xml
+++ b/Resources/Server Info/Guidebook/Eng/Atmospherics.xml
@@ -4,13 +4,13 @@
 Atmospherics setups are a necessity for your long-term comfort but are generally undocumented, resulting in them being a bit tricky to set up. The following attempts to cover the basics.
 
 ## Standard Mix
-Breathing pure O2 or pure N2 is generally bad for the health of your crew, and it is recommended to instead aim for a mix of [color=#a4885c]78% N2 and 22% O2 at 101.24kPa.[/color] It's recommended that your gas mixer setup be set to output at least 1000kPa for faster re-pressurization of rooms.
+Breathing pure O2 or pure N2 is generally bad for the health of your crew, so it is recommended to instead aim for a mix of [color=#a4885c]78% N2 and 22% O2 at 101.24kPa.[/color] It's recommended that your gas mixer setup be set to output at least 1000kPa for faster re-pressurization of rooms. [color=#fcdf03]Be advised this will make removing any pipe from the distribution network dangerous due to overpressure.[/color]
 <Box>
 <GuideEntityEmbed Entity="OxygenCanister"/>
 <GuideEntityEmbed Entity="NitrogenCanister"/>
 <GuideEntityEmbed Entity="AirCanister"/>
 </Box>
-Variations on this mix may be necessary for the long-term comfort of atypical crew, for example crew who require a plasma gas mix to survive. For atypical crew, it is recommended to try and give them their own personal space, isolated by either airlock or disposals section. Keep in mind both methods are leaky and you will need scrubbers on both sides of the lock to clean up any leaked gasses.
+Variations on this mix may be necessary for the long-term comfort of atypical crew, for example crew who require a plasma gas mix to survive. For atypical crew, it is possible to try and give them their own personal space, isolated by either airlock or disposals section. Keep in mind both methods are leaky and you will need scrubbers on both sides of the lock to clean up any leaked gasses.
 <Box>
 <GuideEntityEmbed Entity="PlasmaCanister"/>
 <GuideEntityEmbed Entity="StorageCanister"/>
@@ -21,7 +21,7 @@ Vents and scrubbers are core atmospherics devices that fill and cleanse rooms, r
 <GuideEntityEmbed Entity="GasVentPump"/>
 <GuideEntityEmbed Entity="GasVentScrubber"/>
 </Box>
-During standard operation, if a vent detects that the outside environment is space, it will automatically cease operation until a minimum pressure is reached to avoid destruction of necessary gasses. This can be fixed by pressurizing the room up to that minimum pressure by refilling it with gas canister (potentially multiple, if the room is of significant size).
+During standard operation, if a vent detects that the outside environment is space, it will automatically cease operation until a minimum pressure is reached to avoid waste of gasses. This can be fixed by pressurizing the room up to that minimum pressure by refilling it with gas canister (potentially multiple, if the room is of significant size). [color=#888084]You may need to unwrench and wrench the device to re-enable it.[/color]
 
 Should you encounter a situation where scrubbers aren't cleaning a room fast enough, employ portable scrubbers by dragging them to the affected location and wrenching them down. They work much faster than typical scrubbers and can clean up a room quite quickly. Large spills may require you to employ multiple.
 <Box>
@@ -29,6 +29,6 @@ Should you encounter a situation where scrubbers aren't cleaning a room fast eno
 </Box>
 ## Reference Sheet
 - Standard atmospheric mix is [color=#a4885c]78% N2 and 22% O2 at 101.24kPa.[/color]
-- Gas obeys real math. You can use the equation PV = nRT (Pressure kPa * Volume L = Moles * R * Temperature K) to derive information you might need to know about a gas. R is approximately 8.31446
+- Gas obeys real math. You can use the equation PV = nRT (Pressure kPa * Volume L = Moles * R * Temperature K) to derive information you might need to know about a gas. R is approximately 8.31.
 
 </Document>

--- a/Resources/Server Info/Guidebook/Eng/Engineering.xml
+++ b/Resources/Server Info/Guidebook/Eng/Engineering.xml
@@ -1,7 +1,7 @@
 <Document>
 # Engineering
 
-Engineering is a combination of construction work, repair work, maintaining a death machine that happens to produce power, and making sure the station contains breathable air.
+Engineering is a combination of construction work, repair work, [color=#888084]maintaining a death machine that happens to produce power[/color], and making sure the station contains breathable air.
 
 ## Tools
 <Box>
@@ -14,8 +14,8 @@ Engineering is a combination of construction work, repair work, maintaining a de
 <GuideEntityEmbed Entity="Welder"/>
 <GuideEntityEmbed Entity="Multitool"/>
 </Box>
-Your core toolset is a small variety of tools. If you're an engineer, then you should have a belt on your waist containing one of each, if not you can likely find them in maintenance and tool storage within assorted toolboxes and vending machines.
+Your core toolset is a small variety of tools. If you're an engineer, then you should have a belt on your waist containing one of each, if not, you can likely find them in maintenance and tool storage within assorted toolboxes and vending machines.
 
-Most tasks will have explainers for how to perform them on examination, for example if you're constructing a wall, it'll tell you the next step if you look at it a bit closer.
+[color=#888084]Most tasks will have explainers for how to perform them on examination, for example if you're constructing a wall, it'll tell you the next step if you look at it a bit closer.[/color]
 
 </Document>

--- a/Resources/Server Info/Guidebook/Eng/Fires.xml
+++ b/Resources/Server Info/Guidebook/Eng/Fires.xml
@@ -6,10 +6,10 @@ Fires and spacings are an inevitability due to the highly flammable plasma gas a
 ## Spacing
 Space is arguably the easier of the two to handle.
 While it does render an area uninhabitable, it can be trivially solved by simply sealing the hole that resulted in the vacuum and introducing a small amount of air.
-By default, station vents automatically seal themselves upon exposure to space, in order to avoid wasting air, and will only resume cycling after pressure has been brought up high enough to reopen them.
+By default, station vents automatically seal themselves upon exposure to space in order to avoid wasting air, and will only resume cycling after pressure has been brought up high enough to reopen them.
 
 ## Fires
-Fires can be delt with through a multitude of ways, but some of the most effective methods include:
-  - Spacing the enflamed area if possible. This will destroy all of the gasses in the room, which may be a problem if you're already straining life support.
+Fires can be dealt with through a multitude of ways, but some of the most effective methods include:
+  - Spacing the enflamed area. [color=#fcdf03]This will destroy all of the gasses in the room, which may be a problem if you're already straining life support.[/color]
   - Dumping a Frezon canister into the enflamed area. This will ice over the flames and halt any ongoing reaction, provided you use enough Frezon. Additionally does not result in destruction of material, so you can simply scrub the rooms afterward.
 </Document>

--- a/Resources/Server Info/Guidebook/Eng/MachineUpgrading.xml
+++ b/Resources/Server Info/Guidebook/Eng/MachineUpgrading.xml
@@ -37,6 +37,6 @@ You can use any rating part for any part requirement. Using higher rated parts w
 
 If you want to upgrade an existing machine, simply deconstruct it with a screwdriver and crowbar, and replace the existing parts with parts of a higher level.
 
-You can also quickly upgrade machines by using an RPED, loading it with machine parts, and then clicking on a machine. It will quickly be upgraded with whatever parts were inserted.
+You can also quickly upgrade machines by using an [color=#a4885c]RPED[/color], loading it with machine parts, and then clicking on a machine. It will quickly be upgraded with whatever parts were inserted.
 <GuideEntityEmbed Entity="RPED"/>
 </Document>

--- a/Resources/Server Info/Guidebook/Eng/Power.xml
+++ b/Resources/Server Info/Guidebook/Eng/Power.xml
@@ -1,23 +1,18 @@
 <Document>
 # Power
 
-SS14 has a fairly in-depth power system through which all devices on the station receive electricity. It's divided into three main powernets; HV, LV, and MV.
+SS14 has a fairly in-depth power system through which all devices on the station receive electricity. It's divided into three main powernets by voltage; [color=#cb761a]High Voltage[/color], [color=#cbcb1a]Medium Voltage[/color] and [color=#3c9434]Low Voltage[/color].
+
+## Cabling
+The three major cable types (HV, MV, and LV) can be used to form independent powernets. Examine them for a description of their uses.
 <Box>
 <GuideEntityEmbed Entity="CableHVStack"/>
 <GuideEntityEmbed Entity="CableMVStack"/>
 <GuideEntityEmbed Entity="CableApcStack"/>
 </Box>
 
-## Cabling
-The three major cable types (HV, MV, and LV) can be used to form independent powernets. Examine them for a description of their uses.
-<Box>
-<GuideEntityEmbed Entity="CableHV"/>
-<GuideEntityEmbed Entity="CableMV"/>
-<GuideEntityEmbed Entity="CableApcExtension"/>
-</Box>
-
 ## Power storage
-Each power storage device presented functions as the transformer for its respective power level (HV, MV, and LV) and also provides a fairly sizable backup battery to help flatten out spikes and dips in power usage.
+Each power storage device presented functions as the transformer for its respective power level (HV, MV, and LV) and also provides a battery to help flatten out spikes and dips in power usage.
 <Box>
 <GuideEntityEmbed Entity="SMESBasic"/>
 <GuideEntityEmbed Entity="SubstationBasic"/>
@@ -28,10 +23,10 @@ Each power storage device presented functions as the transformer for its respect
 Contrary to what one might expect from a video game electrical simulation, power is not instantly provided upon request. Generators and batteries take time to ramp up to match the draw imposed on them, which leads to brownouts when there are large changes in current draw all at once, for example when batteries run out.
 
 ## Installing power storage
-Substations are the most self-explanatory. Simply install the machine on top of an MV and HV cable, it will draw power from the HV cable to provide to MV.
+[color=#a4885c]Substations[/color] are the most self-explanatory. Simply install the machine on top of an MV and HV cable, it will draw power from the HV cable to provide to MV.
 
-Installing APCs is similarly simple, except APCs are exclusively wallmounted machinery and cannot be installed on the floor. Make sure it has both MV and LV connections.
+Installing [color=#a4885c]APCs[/color] is similarly simple, except APCs are exclusively wallmounted machinery and cannot be installed on the floor. Make sure it has both MV and LV connections underneath the wall that will have the APC on it.
 
-Installing a SMES requires you construct a cable terminal to use as the input. The SMES will draw power from the terminal and send power out from underneath. The terminal will ensure that the HV input and HV output do not connect. Avoid connecting a SMES to itself, this will result in a short circuit which can result in power flickering or outages depending on severity.
+Installing a [color=#a4885c]SMES[/color] requires you construct a cable terminal to use as the input. The SMES will draw power from the terminal and send power out from underneath. The terminal will ensure that the HV input and HV output do not connect. [color=#fcdf03]Avoid connecting a SMES to itself, this will result in a short circuit which can result in power flickering or outages.[/color]
 
 </Document>

--- a/Resources/Server Info/Guidebook/Eng/ReverseEngineering.xml
+++ b/Resources/Server Info/Guidebook/Eng/ReverseEngineering.xml
@@ -13,24 +13,24 @@ The scanning module increases its analysis power and the manipulator decreases t
 
 ## Operation
 
-The machine will only accept items it can reverse engineer. Currently this is most circuitboards and machine parts, but it accepts quite a variety of objects.
+The machine will only accept items it can reverse engineer. Currently this is most circuit boards and machine parts, but it accepts quite a variety of objects.
 
-It does not and will never accept firearms.
+It does not accept firearms and never will.
 
-To use the machine, insert an item, and use the buttons on the left.
+To use the machine, insert an item and use the buttons on the left.
 
-[color=#0000FF] Analyze [/color]
+[color=#a4885c] Analyze [/color]
 This starts a new reverse engineering attempt.
 
-[color=#0000FF] Safety [/color]
-With safety off, you have more analysis power but there is a chance to destroy the item.
+[color=#a4885c] Safety [/color]
+With safety off, you have more analysis power, but there is a chance to destroy the item.
 
-[color=#0000FF] AutoProbe [/color]
+[color=#a4885c] AutoProbe [/color]
 This will automatically start a new attempt when the last one ends.
 
-[color=#0000FF] Stop [/color]
+[color=#a4885c] Stop [/color]
 Stops the current attempt.
 
-[color=#0000FF] Item [/color]
+[color=#a4885c] Item [/color]
 Ejects the item.
 </Document>

--- a/Resources/Server Info/Guidebook/Eng/ReverseEngineering.xml
+++ b/Resources/Server Info/Guidebook/Eng/ReverseEngineering.xml
@@ -19,18 +19,18 @@ It does not accept firearms and never will.
 
 To use the machine, insert an item and use the buttons on the left.
 
-[color=#a4885c] Analyze [/color]
+- [color=#a4885c]Analyze:[/color]
 This starts a new reverse engineering attempt.
 
-[color=#a4885c] Safety [/color]
+- [color=#a4885c]Safety:[/color]
 With safety off, you have more analysis power, but there is a chance to destroy the item.
 
-[color=#a4885c] AutoProbe [/color]
+- [color=#a4885c]AutoProbe:[/color]
 This will automatically start a new attempt when the last one ends.
 
-[color=#a4885c] Stop [/color]
+- [color=#a4885c]Stop:[/color]
 Stops the current attempt.
 
-[color=#a4885c] Item [/color]
+- [color=#a4885c]Item:[/color]
 Ejects the item.
 </Document>

--- a/Resources/Server Info/Guidebook/Epi/APE.xml
+++ b/Resources/Server Info/Guidebook/Epi/APE.xml
@@ -1,7 +1,7 @@
 <Document>
 # A.P.E.
 
-The Anomalous Particle Emitter is a machine used to interface with anomalies. It is the primary way of manipulating the stats of an anomaly.
+The [color=#a4885c]Anomalous Particle Emitter[/color] is a machine used to interface with anomalies. It is the primary way of manipulating the stats of an anomaly.
 
 <Box>
 <GuideEntityEmbed Entity="MachineAPE"/>
@@ -9,12 +9,12 @@ The Anomalous Particle Emitter is a machine used to interface with anomalies. It
 
 The A.P.E. can shoot three different kinds of anomalous particles: Delta, Epsilon, and Zeta. Each particle types has certain effects:
 
-- [color=#a4885c]Danger:[/color] Increases the severity of an anomaly.
-- [color=#a4885c]Unstable:[/color] Increases the instability of an anomaly.
-- [color=#a4885c]Containment:[/color] Increases the stability at the cost of health.
+- [color=#DC143C]Danger:[/color] Increases the severity of an anomaly.
+- [color=#D299D2]Unstable:[/color] Increases the instability of an anomaly.
+- [color=#CC9B21]Containment:[/color] Increases the stability at the cost of health.
 
 Which particle type corresponds to each effect is unique and can be learned by scanning the anomaly.
 
-The A.P.E. can also be locked by anyone with science access, which prevents it from being deconstructed, turned on or off, or having the particle type switched.
+[color=#888084]The A.P.E. can also be locked by anyone with science access, which prevents it from being deconstructed, turned on or off, or having the particle type switched.[/color]
 
 </Document>

--- a/Resources/Server Info/Guidebook/Epi/Altar.xml
+++ b/Resources/Server Info/Guidebook/Epi/Altar.xml
@@ -2,21 +2,21 @@
 # Altars and Golemancy
 ## Altars
 <GuideEntityEmbed Entity="AltarNanotrasen" />
-The chapel has a sacrificial altar. To use it, a psionic humanoid must be placed on it, and someone with either psionics or clerical training must initiate the sacrifice.
+The chapel has a [color=#a4885c]sacrificial altar[/color]. To use it, a psionic humanoid must be placed on it, and someone with either psionics or clerical training must initiate the sacrifice.
 It appears in the context menu on the altar, which can be opened with the right mouse button by default.
 
 <GuideEntityEmbed Entity="CrystalSoul" />
-Once sacrificed, the psionic humanoid's soul is trapped inside a soul crystal. This is not the end for them; they can still talk both locally and telepathically, and this form is much harder to destroy.
+Once sacrificed, the psionic humanoid's soul is trapped inside a [color=#a4885c]soul crystal[/color]. This is not the end for them; they can still talk both vocally and telepathically, and this form is much harder to destroy.
 
 <GuideEntityEmbed Entity="PonderingOrbTelepathic" />
-10% of the time, the altar will spawn a powerful psionic item along with the soul crystal. This chance increases to 50% if the sacrifice was performed by someone with clerical training, such as the golemancer or mystagogue.
+10% of the time, the altar will spawn a powerful psionic item along with the soul crystal. This chance increases to 50% if the sacrifice was performed by someone with clerical training, such as the [color=#a4885c]golemancer[/color] or [color=#a4885c]mystagogue[/color].
 
 ## Golemancy
 <Box>
 <GuideEntityEmbed Entity="MobGolemCult"/>
 <GuideEntityEmbed Entity="MobGolemWood"/>
 </Box>
-Soul crystals can be installed into golems to give the soul a new body. Golems are bound to serve their master. As constructs, they do not need to eat, drink, or breathe.
-Note that for wood golems, if plants are planted on top of their head the plants will still need those things.
+Soul crystals can be installed into [color=#a4885c]golems[/color] to give the soul a new body. Golems are bound to serve their master. As constructs, they do not need to eat, drink, or breathe.
+Note that for wood golems, if plants are planted on top of their head, the plants will still need those things.
 
 </Document>

--- a/Resources/Server Info/Guidebook/Epi/AnomalousResearch.xml
+++ b/Resources/Server Info/Guidebook/Epi/AnomalousResearch.xml
@@ -10,16 +10,16 @@ Anomalous Research is a subdepartment of Science focused around the containment 
 <GuideEntityEmbed Entity="MachineAPE"/>
 </Box>
 
-Scanners, vessels, and A.P.E.s are all used in the containment and observation of anomalies.
+[color=#a4885c]Scanners[/color], [color=#a4885c]vessels[/color], and [color=#a4885c]A.P.Es[/color] are all used in the containment and observation of anomalies.
 
 <Box>
 <GuideEntityEmbed Entity="MachineAnomalyGenerator"/>
 </Box>
 
-The anomaly generator can produce a random anomaly somewhere on the station at the cost of plasma.
+The [color=#a4885c]anomaly generator[/color] can produce a random anomaly somewhere on the station at the cost of plasma.
 
 ## Anomalies
-Anomalies are static objects that appear on the station. They cannot be moved, and must be worked around, no matter their location.
+[color=#a4885c]Anomalies[/color] are static objects that appear on the station. They cannot be moved and must be worked around, no matter their location.
 
 <Box>
 <GuideEntityEmbed Entity="AnomalyPyroclastic"/>
@@ -27,8 +27,8 @@ Anomalies are static objects that appear on the station. They cannot be moved, a
 
 Each anomaly has three main stats, two of which can be seen in anomaly scans:
 
-- [color=#a4885c]Severity:[/color] This is a numerical value corresponding to the danger of an anomaly.
-- [color=#a4885c]Stability:[/color] Shown as either decaying, stable, or growing; this is how frequently and widespread the effects will be.
+- [color=#a4885c]Severity:[/color] This is a percentagew value corresponding to the danger of an anomaly.
+- [color=#a4885c]Stability:[/color] Shown as either [color=#FFD700]Decaying[/color], [color=#228B22]Stable[/color], or [color=#DB143C]Growing[/color]; this is how frequent and widespread the effects will be.
 - [color=#a4885c]Health:[/color] Health is a hidden stat. It decreases when you use [color=#a4885c]containment particles[/color] on an anomaly. If you use too many, the anomaly will disappear.
 
 ## Pulses and Supercritical Events

--- a/Resources/Server Info/Guidebook/Epi/ArtifactReports.xml
+++ b/Resources/Server Info/Guidebook/Epi/ArtifactReports.xml
@@ -1,8 +1,8 @@
 <Document>
 # Artifact Reports
-A large portion of Xenoarchaeology gameplay revolves around the interpretation of artifact reports, which are created at the [color=#a4885c]analysis console[/color] after an artifact is scanned. Reports contain the following information:
+A large portion of Xenoarchaeology gameplay revolves around the interpretation of [color=#a4885c]artifact reports[/color], which are created at the [color=#a4885c]analysis console[/color] after an artifact is scanned. Reports contain the following information:
 
-- [color=#a4885c]Node ID:[/color] a unique numeric ID corresponding to this artifact's node. Useful in conjunction with a [color=#a4885c]node scanner[/color] for quickly identifying recurring nodes.
+- [color=#a4885c]Node ID:[/color] a unique numeric ID corresponding to this artifact's node. Useful in conjunction with a [color=#a4885c]node scanner[/color] for quickly identifying the current node.
 
 - [color=#a4885c]Depth:[/color] a distance from the starting node (depth 0). This is a good shorthand for the value and danger of a node.
 
@@ -14,12 +14,12 @@ A large portion of Xenoarchaeology gameplay revolves around the interpretation o
 
 - [color=#a4885c]Edges:[/color] the amount of nodes that are connected to the current node. Using this, you can calculate the total number of nodes as well as organize a map of their connections.
 
-- [color=#a4885c]Current value:[/color] the amount of research points an artifact is currently worth. This is an important factor in choosing when to stop research and destroy the artifact in exchange for points.
+- [color=#a4885c]Current value:[/color] the amount of research points an artifact is currently worth. This is an important factor in choosing when to stop research and destroy the artifact in exchange for points. It is increased with every activated node.
 
 Reports are a helpful tool in manipulating an artifact, especially in the later stages where you are traversing nodes that have already been activated.
 <Box>
 <GuideEntityEmbed Entity="PaperArtifactAnalyzer"/>
 </Box>
-To help with this process, consider printing out reports, writing down details uncovered during activation, or storing them in a folder nearby.
+To help with this process, consider printing out reports, writing down details uncovered during activation on them and storing them in a folder nearby.
 
 </Document>

--- a/Resources/Server Info/Guidebook/Epi/Epistemics.xml
+++ b/Resources/Server Info/Guidebook/Epi/Epistemics.xml
@@ -1,7 +1,7 @@
 <Document>
 # Epistemics
 
-Epistemics, or Research and Development for people who refuse to use such a self-aggrandizing name, is one of the main departments on NanoTrasen stations.
+Epistemics, [color=#888084]or Research and Development for people who refuse to use such a self-aggrandizing name[/color], is one of the main departments on NanoTrasen stations.
 They are tolerated despite their strange customs and tendency to attract all sorts of weirdness to the station.
 
 ## Technologies
@@ -9,9 +9,9 @@ They are tolerated despite their strange customs and tendency to attract all sor
 <GuideEntityEmbed Entity="ComputerResearchAndDevelopment"/>
 <GuideEntityEmbed Entity="ResearchAndDevelopmentServer"/>
 </Box>
-The most important thing inside your department is the R&D server, which stores unlocked technologies, and the R&D computer, which allows you to unlock technologies.
+The most important thing inside your department is the [color=#a4885c]R&D server[/color], which stores unlocked technologies, and the [color=#a4885c]R&D computer[/color], which allows you to unlock technologies.
 
-Each technology costs [color=#a4885c]Research Points[/color] and unlocks recipes at lathes. Some technologies will also have prerequesites you have to unlock before you can research them.
+Each technology costs [color=#a4885c]Research Points[/color] and unlocks recipes at [color=#a4885c]lathes[/color]. Some technologies will also have prerequesites you have to unlock before you can research them.
 
 ## Lathes
 <Box>
@@ -22,11 +22,11 @@ Each technology costs [color=#a4885c]Research Points[/color] and unlocks recipes
 <GuideEntityEmbed Entity="EngineeringTechFab"/>
 <GuideEntityEmbed Entity="MedicalTechFab"/>
 </Box>
-At a lathe, you can sync to a server to allow it print whatever recipes you have unlocked. Recipes require various materials (steel, glass, plastic, gold, plasma) which can be acquired at Cargo or Salvage.
+Syncing a lathe to a server allows it to print whatever recipes you have unlocked on that server. Recipes require various materials (steel, glass, plastic, gold, plasma), which can be acquired at Cargo or Salvage.
 
 ## Oracle
 <GuideEntityEmbed Entity="Oracle" />
 
-Oracle is your benefactor, dispensing lots of strange liquids and research points. Is she a statue, a goddess, some sort of devious trap? Everyone has their own approach to her, but she doesn't seem to mind any of them.
+[color=#a4885c]Oracle[/color] is your benefactor, dispensing lots of strange liquids and research points in exchange of items she demands. [color=#888084]Is she a statue, a goddess, some sort of devious trap? Everyone has their own approach to her, but she doesn't seem to care for any of them.[/color]
 
 </Document>

--- a/Resources/Server Info/Guidebook/Epi/Psionics.xml
+++ b/Resources/Server Info/Guidebook/Epi/Psionics.xml
@@ -1,21 +1,21 @@
 <Document>
 # Psionics
-Psionics are mental abilities that interface with the noösphere. Humans have limited access to the noösphere's full potential, allowing some to find ways to command it.
+[color=#a4885c]Psionics[/color] are mental abilities that interface with the [color=#a4885c]noösphere[/color]. Humans have limited access to the noösphere's full potential, allowing some to find ways to command it.
 The abilities originate from distorting a noöspheric imprint into a specific shape, a bit like a lock and key. This means that humans can only have a single ability at a time.
 An imprint shaped for metapsionics will not work for invisibility, and vice versa.
 
 <GuideEntityEmbed Entity="MobIfritFamiliar" />
-Many other creatures are much more in tune with it than humans, allowing them to access more powerful psionics like kineses.
+Many other creatures are much more in tune with it than humans, allowing them to access more powerful psionics like [color=#a4885c]kineses[/color].
 
 ## Telepathy
 All psionic entities have a shared telepathic communication channel. It's anonymized, so you never know who you are talking to. Statistically, it probably is not human.
 
 ## Glimmer
-Glimmer is a more colloquial term for noöspheric pressure. The noösphere can be considered analogous to an atmosphere. In a localized area, everything will equalize towards a certain pressure that's based off of the total energy in the system.
+[color=#a4885c]Glimmer[/color] is a more colloquial term for [color=#a4885c]noöspheric pressure[/color], measured in [color=#a4885c]milli-Psi (mΨ)[/color]. The noösphere can be considered analogous to an atmosphere. In a localized area, everything will equalize towards a certain pressure that's based off of the total energy in the system.
 Note that unlike atmospheres, areas of noopsheric pressure do not operate by physical contigiousness, but mental. This means that areas with intertwined destinies will experience the same latent glimmer regardless of physical separation.
 
 <GuideEntityEmbed Entity="SophicScribe" />
-The sophic scribe tracks glimmer.
+The [color=#a4885c]sophic scribe[/color] tracks glimmer.
 
 <Box>
 <GuideEntityEmbed Entity="GlimmerProber"/>
@@ -23,22 +23,22 @@ The sophic scribe tracks glimmer.
 </Box>
 
 Epistemics can build devices to interact with glimmer. These are usually the main determiners of where glimmer is going.
-Glimmer probers will increase glimmer, but directly generate research points without further input. Glimmer drains simply drain glimmer at the cost of electricity.
+[color=#a4885c]Glimmer probers[/color] will increase glimmer, but directly generate research points without further input. [color=#a4885c]Glimmer drains[/color] simply drain glimmer at the cost of electricity.
 
-Use of psionics will increase glimmer, as will noöspheric storms.
+Use of psionics will increase glimmer, as will [color=#a4885c]noöspheric storms[/color].
 
 ## Discharges
-Glimmer will occasionally discharge if it's above 100Ψ, causing a wide range of effects based on just how high it is. The most common is giving all entities with psionic potential a small seizure,
+Glimmer will occasionally discharge if it's above 100 mΨ, causing a wide range of effects based on just how high it is. The most common is giving all entities with psionic potential a small seizure,
 which is something most people working on stations with an Epistemics department have grown used to.
 
 ## Acquiring Psionics
 <GuideEntityEmbed Entity="Oracle" />
 
-Psionics can be acquired in a number of ways. The oracle will sometimes dispense a strange liquid called lotophagoi oil, which at high glimmer levels is guaranteed to give psionics.
+Psionics can be acquired in a number of ways. The oracle will sometimes dispense a strange liquid called [color=#a4885c]lotophagoi oil[/color], which at high glimmer levels is guaranteed to give psionics.
 
 Random discharges may give you psionics as the seizure knocks your noöspheric imprint into just the right shape.
 
-Space drugs are an easier to acquire but much weaker alternative to lotophagoi oil.
+[color=#a4885c]Space drugs[/color]are an easier to acquire but much weaker alternative to lotophagoi oil.
 
 ## Psionic Insulation
 <Box>
@@ -46,14 +46,14 @@ Space drugs are an easier to acquire but much weaker alternative to lotophagoi o
 <GuideEntityEmbed Entity="ClothingHeadHelmetInsulated"/>
 <GuideEntityEmbed Entity="PillCryptobiolin" />
 </Box>
-Insulative clothing and cryptobiolin will render you immune to psionics, but prevent you from using any you have.
+[color=#a4885c]Insulative clothing[/color] and [color=#a4885c]cryptobiolin[/color] will render you immune to psionics, but prevent you from using any you have.
 
 <GuideEntityEmbed Entity="ClothingHeadCage" />
 Security has a more forcible option for insulative clothing.
 
 ## Handling Glimmer Emergencies
 <GuideEntityEmbed Entity="GlimmerProber"/>
-Probers should be turned off if glimmer is still below 500Ψ.
+Probers should be turned off before glimmer exceeds 500 mΨ.
 
 <GuideEntityEmbed Entity="GlimmerDrain"/>
 Glimmer drains are quite effective at draining glimmer, taking it out as fast as a prober can put it in.
@@ -62,12 +62,12 @@ Glimmer drains are quite effective at draining glimmer, taking it out as fast as
 Sacrificing psychics will reduce glimmer instantly by a decent amount.
 
 <GuideEntityEmbed Entity="PillMindbreakerToxin" />
-Metabolizing 20u or more of mindbreaker will remove psionics from a person, meaning they will not generate any more glimmer.
+Metabolizing 20u or more of [color=#a4885c]mindbreaker[/color] will remove psionics from a person, meaning they will not generate any more glimmer.
 
 <GuideEntityEmbed Entity="ShellSoulbreaker" />
-Soulbreaker shells will remove psionics from psychics they hit.
+[color=#a4885c]Soulbreaker[/color] shells will remove psionics from psychics they hit.
 
 <GuideEntityEmbed Entity="Ectoplasm" />
-Ectoplasm, combined in a beaker with equal parts water, ash, blood, and plasma, will produce a normality crystal when heated enough. Use a hot plate for this.
+[color=#a4885c]Ectoplasm[/color], combined in a beaker with equal parts water, ash, blood, and plasma, will produce a normality crystal when heated enough. [color=#fcdf03]Use a hot plate for this.[/color]
 
 </Document>

--- a/Resources/Server Info/Guidebook/Epi/Psionics.xml
+++ b/Resources/Server Info/Guidebook/Epi/Psionics.xml
@@ -38,7 +38,7 @@ Psionics can be acquired in a number of ways. The oracle will sometimes dispense
 
 Random discharges may give you psionics as the seizure knocks your noöspheric imprint into just the right shape.
 
-[color=#a4885c]Space drugs[/color]are an easier to acquire but much weaker alternative to lotophagoi oil.
+[color=#a4885c]Space drugs[/color] are an easier to acquire but much weaker alternative to lotophagoi oil.
 
 ## Psionic Insulation
 <Box>

--- a/Resources/Server Info/Guidebook/Epi/ScannersAndVessels.xml
+++ b/Resources/Server Info/Guidebook/Epi/ScannersAndVessels.xml
@@ -1,7 +1,7 @@
 <Document>
 ## Anomaly Scanner
 
-The Anomaly Scanner is used to gather various information on anomalies. They can be found inside of the lockers in the science department.
+The [color=#a4885c]Anomaly Scanner[/color] is used to gather various information on anomalies. They can be found inside of the lockers in the science department.
 
 <Box>
 <GuideEntityEmbed Entity="AnomalyScanner"/>
@@ -11,7 +11,7 @@ Scanning an anomaly shows the severity, general stability, approximate point out
 
 ## Anomaly Vessel
 
-The anomaly vessel is a machine that generates points from anomalies. Use the anomaly scanner on an empty vessel, and the anomaly that was last scanned will be synced with the vessel.
+The [color=#a4885c]anomaly vessel[/color] is a machine that generates points from anomalies. Use the anomaly scanner on an empty vessel, and the anomaly that was last scanned will be synced with the vessel.
 
 <Box>
 <GuideEntityEmbed Entity="MachineAnomalyVessel"/>
@@ -19,6 +19,6 @@ The anomaly vessel is a machine that generates points from anomalies. Use the an
 
 The amount of points a vessel generates per second is based on the severity, stability, and health of an anomaly. The higher each of these values, the higher the point output will be.
 
-Be careful: if an anomaly goes [color=#a4885c]supercritical[/color], the vessel it is linked to will explode. This may damage the station and nearby equipment.
+[color=#fcdf03]Be careful: if an anomaly goes supercritical, the vessel it is linked to will explode. This may damage the station and nearby equipment.[/color]
 
 </Document>

--- a/Resources/Server Info/Guidebook/Epi/TraversalDistorter.xml
+++ b/Resources/Server Info/Guidebook/Epi/TraversalDistorter.xml
@@ -1,11 +1,11 @@
 <Document>
 # Traversal Distorter
 
-The traversal distorter is a late-game artifact machine that can aid in moving through the nodes of an artifact.
+The [color=#a4885c]traversal distorter[/color] is a late-game artifact machine that can aid in moving through the nodes of an artifact.
 <Box>
 <GuideEntityEmbed Entity="MachineTraversalDistorter"/>
 </Box>
-Artifacts placed on top of a powered traversal distorter are subjected to a bias which affects which node they will move to after being activated. The bias can be set by clicking on the distorter.
+Artifacts placed on top of a powered traversal distorter are subjected to a [color=#a4885c]bias[/color] which affects which node they will move to after being activated. The bias can be set by clicking on the distorter.
 
 There are two types of biases:
 - [color=#a4885c]In:[/color] favors nodes closer to the origin. Results in a decrease of depth.
@@ -14,5 +14,7 @@ There are two types of biases:
 Setting it to bias inwards allows you to return to the beginning of an artifact graph, if you've reached a dead end.
 
 Likewise, if you find yourself stuck at low depths, setting it to bias outward will help you find new nodes. In certain circumstances, toggling between the two allows you to repeatedly activate the same node.
+
+It is not guaranteed that the bias will take effect, and if a node only has one edge, it will always be used regardless of bias. The machine may be upgraded to increase the chance a bias will apply on activation.
 
 </Document>

--- a/Resources/Server Info/Guidebook/Epi/Xenoarchaeology.xml
+++ b/Resources/Server Info/Guidebook/Epi/Xenoarchaeology.xml
@@ -8,9 +8,9 @@ Xenoarchaeology is a science subdepartment focused on researching and experiment
 <GuideEntityEmbed Entity="SimpleXenoArtifact" Caption=""/>
 <GuideEntityEmbed Entity="SimpleXenoArtifactItem" Caption=""/>
 </Box>
-Artifacts consist of a randomly-generated graph structure. They consist of nodes connected to each other by edges, the traversal of which is the main goal of the scientists working on them.
+Artifacts consist of a randomly-generated graph structure. They consist of [color=#a4885c]nodes[/color] connected to each other by [color=#a4885c]edges[/color], the traversal of which is the main goal of the scientists working on them.
 
-Each node has two main components: a [color=#a4885c]stimulus[/color] and a [color=#a4885c]reaction[/color]. A stimulus is the external behavior that triggers the reaction. Some reactions are instantaneous effects while others are permanent changes. Triggering the reaction causes the artifact to move to one of the node's edges.
+Each node has two main components: a [color=#a4885c]stimulus[/color] and a [color=#a4885c]reaction[/color]. A stimulus is the external behavior that triggers the reaction. Some reactions are instantaneous effects while others are permanent changes. Triggering the reaction causes the artifact to move through one of the node's edges to an adjacent node.
 
 With these basic principles, you can begin to grasp how the different nodes of an artifact are interconnected, and how one can move between them by repeatedly activating nodes.
 
@@ -25,6 +25,6 @@ The main equipment that you'll be using for Xenoarchaeology is the [color=#a4885
 
 To set them up, simply link them with a multitool, set an artifact on top of the analyzer, and press the [color=#a4885c]Scan[/color] button.
 
-Using the console, you can permanently destroy and artifact in exchange for points. This is irreversible, so be sure to confirm with your department that all research on it has concluded.
+Using the console, you can permanently destroy an artifact in exchange for points. This is irreversible, so be sure to confirm with your department that all research on it has concluded. [color=#fcdf03]Sacrificing an artefact may result in a massive increase of glimmer.[/color]
 
 </Document>

--- a/Resources/Server Info/Guidebook/Jobs.xml
+++ b/Resources/Server Info/Guidebook/Jobs.xml
@@ -6,35 +6,35 @@ SS14 has a large number of jobs, divided into seven major departments:
 ## Service
 This department includes the janitor, passengers, clown, mime, musician, chef, bartender, the head of personnel, and other jobs who exist to serve the station.
 
-It primarily functions as folks who entertain, clean, and serve the rest of the crew, with the exception of passengers who have no particular job beyond getting lost in maintenance.
+It primarily functions as folks who entertain, clean, and serve the rest of the crew, with the exception of passengers who have no particular job [color=#888084]beyond getting lost in maintenance[/color].
 
 ## Cargo
-Cargo consists of the cargo technicians, salvage technicians, and the quartermaster. As a department, it responsible resource distribution and trade, capable of buying and selling things on the galactic market.
+Cargo consists of the cargo technicians, salvage technicians, and the quartermaster. As a department, it is responsible for resource distribution and trade, capable of buying and selling things on the galactic market.
 
 For the most part, this means they scrounge around the station and assorted wrecks to find materials to sell and redistribute, and purchase materials other departments request.
 
 ## Security
-Security consists of the security cadets, lawyers, detective, security officers, warden, and the head of security. As a department it is responsible for dealing with troublemakers and non-humanoid threats like giant rats and carp.
+Security consists of the security cadets, lawyers, security officers, warden, and the head of security. As a department, it is responsible for dealing with troublemakers and non-humanoid threats like giant rats and carp.
 
-As a result of this, and the need to walk a fine line, security sometimes is overwhelmed by angry crew (don't kill the clown), and it is important for members of it to try and stay on their best behavior.
+As a result of this, and the need to walk a fine line, security sometimes is overwhelmed by angry crew [color=#888084](don't kill the clown)[/color], and it is important for its members to try and stay on their best behavior.
 
 ## Medical
-Medical consists of the medical interns, chemists, medical doctors, and the chief medical officer. As a department it is responsible for taking care of the crew, treat and/or clone the wounded and dead, treat disease, and prevent everyone from dying a horrible, bloody death in a closet somewhere.
+Medical consists of the medical interns, chemists, medical doctors, and the chief medical officer. As a department, it is responsible for taking care of the crew, treat and/or clone the wounded and dead, treat disease, and [color=#888084]prevent anyone from dying a horrible, bloody death in a closet somewhere.[/color]
 
 Medical is one of the more well-equipped departments, with the ability to locate injured crew using the crew monitor, a nigh infinite supply of chems should chemistry be on-par, and the ability to rapidly diagnose and vaccinate contagious diseases.
 
-## Science
-Science consists of scientists, and the research director. As a department it is responsible for researching technologies and artifacts, upgrading machines, and printing new and useful dev ices.
+## Epistemics
+Epistemics consists of acolytes, golemancers, a forensic mantis and the Mystagogue. As a department, it is responsible for containing and investigating anomalies and artefacts and dealing with psionics and the paranormal.
 
-Scientists should seek out new artifacts to study, as well as solicit departments to help upgrade their machines.
+[color=#fcdf03]It is up to Epistemics to prevent the station from being torn into pieces by rampant psionic entities due to overwhelming psionic potential.[/color]
 
 ## Engineering
-Engineering consists of technical assistants, station engineers, atmospheric technicians, and the chief engineer. As a department it is responsible for keeping the station powered, its structure intact and its air supply working.
+Engineering consists of technical assistants, station engineers, atmospheric technicians, and the chief engineer. As a department, it is responsible for keeping the station powered, its structure intact and its air supply working.
 
 Engineering is readily equipped to go safely into space, and as such they should always attempt to repair uninhabitable parts of the station.
 
 ## Command
-Command consists of the captain, the head of personnel, the head of security, the chief engineer, the chief medical officer, the research director, and the quartermaster. As a department it is responsible for keeping the station and its departments running efficiently.
+Command consists of the captain, the head of personnel, the head of security, the chief engineer, the chief medical officer, and the research director. As a department, it is responsible for keeping the station and its departments running efficiently.
 
 Command members should always be relatively competent in their respective departments and attempt to delegate responsibility and direct work.
 

--- a/Resources/Server Info/Guidebook/Law/Charges.xml
+++ b/Resources/Server Info/Guidebook/Law/Charges.xml
@@ -61,7 +61,7 @@ The charges will list name, Primary Sentence and Compound Limit. A brig time of 
 [color=#a4885c]Rioting[/color] | 0-5 min | 2 min
 - To engage in a public disturbance which involves damage to property.
 
-[color=#a4885c]Conduct Unbecoming[/color] | 0-6 min | 3 min
+[color=#a4885c]Conduct Unbecoming[/color] | 0-6 min & Demotion | 3 min
 - To willfully abandon an obligation that is critical to the station’s continued operation, or to disrepute Nyanotrasen by grossly improper conduct.
 
 [color=#a4885c]Abuse of Power[/color] | 3-6 min & Demotion | 2.5 min

--- a/Resources/Server Info/Guidebook/Law/Juris.xml
+++ b/Resources/Server Info/Guidebook/Law/Juris.xml
@@ -5,10 +5,10 @@ This section outlines the most important points about the extent of Space Law an
 
 ##Security
 
-- There are [color=#a4885c]no legal grounds[/color] to resist an arrest or detainment by Security. [color=#a4885c]None.[/color]
+- There are [color=#fcdf03]no legal grounds[/color] to resist an arrest or detainment by Security. [color=#a00000]None.[/color]
 - If you are suspected of having commited a crime, Security may [color=#a4885c]detain[/color] you (which may involve restraints) and question you.
 - If Security, or another crew member, decide to press charges, you will be [color=#a4885c]arrested[/color]. This will involve processing and searching at Security.
-- Security holds an unrestricted weapon license. It is authorized to use lethal force in serious circumstances at any time.
+- Security holds an unrestricted weapon license. [color=#fcdf03]It is authorized to use lethal force in serious circumstances at any time.[/color]
 
 ##Psionic Powers
 
@@ -22,6 +22,6 @@ This section outlines the most important points about the extent of Space Law an
 
 - The Captain decides whether to welcome visitors, grant asylum, and where to give them or deny them access.
 - All visitors aboard your station are subject to Space Law. When you visit another vessel, you're subject to theirs.
-- [color=#a4885c]Hot Pursuit[/color] doctrine applies, but in all other cases, the sovereignty of a foreign vessel must be observed.
+- [color=#a4885c]Hot Pursuit[/color] doctrine applies, but in all other cases, [color=#fcdf03]the sovereignty of a foreign vessel must be observed.[/color]
 
 </Document>

--- a/Resources/Server Info/Guidebook/Law/SL.xml
+++ b/Resources/Server Info/Guidebook/Law/SL.xml
@@ -1,8 +1,7 @@
-﻿<Document>
+<Document>
 # Space Law
 
-Within Nyanotrasen, stations operate under [color=#a4885c]Space Law[/color]. All persons aboard the station are beholden to this law and expected to follow it. Common sense knowledge should be sufficient to not break the law, but for your convenience, a Quick Reference on a variety of topics is provided.
+Within Nyanotrasen, stations operate under [color=#a4885c]Space Law[/color]. [color=#fcdf03]All persons aboard the station are beholden to this law and expected to follow it.[/color] Common sense knowledge should be sufficient to not break the law, but for your convenience, a Quick Reference on a variety of topics is provided.
 
 Members of Security and the Captain will often require a far deeper understanding of the law. For the full edition of Space Law, see our Wiki.
-
 </Document>

--- a/Resources/Server Info/Guidebook/Law/Trials.xml
+++ b/Resources/Server Info/Guidebook/Law/Trials.xml
@@ -3,9 +3,9 @@
 
 On Nyanotrasen, trials are conducted in the form of an [color=#a4885c]arbitration.[/color] This means that:
 
-- You are [color=#a4885c]not required[/color] to have a [color=#a4885c]lawyer[/color].
+- You are [color=#fcdf03]not required[/color] to have a [color=#a4885c]lawyer[/color].
 - You need a trial only when you are accused of a [color=#a4885c]Capital Crime[/color].
-- There is [color=#a4885c]no jury[/color], the verdict is assessed and passed by the [color=#a4885c]judge.[/color]
+- There is [color=#fcdf03]no jury[/color], the verdict is assessed and passed by the [color=#a4885c]judge.[/color]
 - Prosecution is represented by the Security member best familiar with the case.
 - The [color=#a4885c]Head of Security[/color] will often be the judge, or the [color=#a4885c]Captain[/color]. There are criteria for Conflict of Interest, but just holding these titles - or having been involved in one's prosecution - does not disqualify them.
 - The trial is intended to be done fast, within 15 minutes. The judge will typically simply ask both sides their case of why their verdict should pass, then decide.

--- a/Resources/Server Info/Guidebook/Space Station 14.xml
+++ b/Resources/Server Info/Guidebook/Space Station 14.xml
@@ -1,14 +1,14 @@
 ﻿<Document>
 # Space Station 14
 
-Welcome to the pre-alpha of Space Station 14! We hope you enjoy the game, and this entry will serve to guide you on how to learn to play. There's quite a bit to read, but SS14 is in itself a very large and in-depth game, and hopefully these guides help you enjoy it to it's fullest.
+Welcome to the pre-alpha of Space Station 14! We hope you enjoy the game, and this entry will serve to guide you on how to learn to play. There's quite a bit to read, but SS14 is in itself a very large and in-depth game, and hopefully these guides help you enjoy it to its fullest.
 
-## What this is
-Space Station 14 is a free (forever) open source remake of the infamous Space Station 13, hoping to provide a improved experience for both newcomers and old players alike. Space Station 14 is designed as a fully moddable experience that you can modify to your liking with custom servers, adding entire swaths of new content for people to explore.
+## What this game is
+Space Station 14 is a free (forever) open source remake of the infamous Space Station 13, hoping to provide an improved experience for newcomers and old players alike. Space Station 14 is designed as a fully moddable experience that you can modify to your liking with custom servers, adding entire swaths of new content for people to explore.
 
-If you're just here to play, that's great! The [color=#a4885c]Where to start[/color] section of this entry will help you out, if you're looking to do a bit more with the game, you can join our discord and find our github page in the lobby.
+If you're just here to play, that's great! The [color=#a4885c]Where to start[/color] section of this entry will help you out. If you're looking to do a bit more with the game, you can join our discord and find our GitHub page in the lobby.
 
 ## Where to start
-It's recommended to start with the [color=#a4885c]Controls[/color] guide, and then read the [color=#a4885c]Character Creation[/color], [color=#a4885c]Roleplaying[/color], and [color=#a4885c]Jobs[/color] guides. Not all jobs or concepts will have guides yet, and it's strongly encouraged to help us write them if you're an experienced player!
+It's recommended to start with the [color=#a4885c]Controls[/color] guide, and then read the [color=#a4885c]Survival[/color] and [color=#a4885c]Jobs[/color] guides. Not all jobs or concepts will have guides yet, so we'd be happy for you to help us write them if you're an experienced player!
 
 </Document>

--- a/Resources/Server Info/Guidebook/Survival.xml
+++ b/Resources/Server Info/Guidebook/Survival.xml
@@ -25,8 +25,8 @@ In the event of a serious emergency, there's a few things you can do to help ens
 <GuideEntityEmbed Entity="MaterialCloth"/>
 </Box>
 - In lieu of an actual health analyzer, simply examining yourself and using the detailed examine is a good way to figure out what wounds you have.
-- If going blind, carrots are another way to treat the issue (as they contain Oculine, the chemistry drug used to treat blindness) should they be available.
-- Well-made meals (cooked food not from a vending machine) is generally much better for your overall health and can help heal smaller wounds more quickly.
+- If going blind, carrots are another way to treat the issue [color=#888084](as they contain Oculine, the chemistry drug used to treat blindness)[/color] should they be available.
+- Well-made meals (cooked food not from a vending machine) are generally much better for your overall health and can help heal smaller wounds quicker.
 - Simple bed rest cures the majority of diseases and also allows wounds to close up on their own. Medical beds are best for this, providing a sterile surface and support for all damaged body parts, but any bed works. Even sitting down helps, if only a little.
 
 </Document>


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I gave the entire current Guidebook a proofing pass to spellcheck them and remove inaccuracies and outdated info. Implemented a basic colour palette: The current beige for in-game terms, yellow for cautions, grey for misc notes. Some things like depictions of HV, MV, LV and anomaly particle types are coloured in in the same way as they are in-game.

**Media**
![image](https://user-images.githubusercontent.com/117641290/218278059-58ca7e27-3db7-4341-85a1-8f85619483a6.png)
![image](https://user-images.githubusercontent.com/117641290/218278125-79ca9e56-9181-4d40-9a96-61f219ee9034.png)


**Changelog**

:cl: Torun
- tweak: Proofread Guidebook and made the text a bit more colourful.
