### PR TITLE
Fix IndexOutOfRangeException preventing appearance of ban messages on connect.

### DIFF
--- a/Content.Client/Launcher/LauncherConnecting.cs
+++ b/Content.Client/Launcher/LauncherConnecting.cs
@@ -93,7 +93,7 @@ namespace Content.Client.Launcher
 
             string? newAddress = null;
 
-            if (reason[1] != null)
+            if (reason.Length > 1 && reason[1] != null)
             {
                 var address = reason[1];
 


### PR DESCRIPTION
:cl:
- fix: Ban messages should appear again when you connect. Report any further issues.