### PR TITLE
changes the damage type of the decloner gun due to being outdated also changed its name.

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -1,8 +1,8 @@
 - type: entity
   parent: BaseWeaponBattery
   id: Decloner
-  name: decloner
-  description: A weapon that damages the target's genome, making it very hard to heal from
+  name: experimental facilitate laser pistol
+  description: A weapon that has a series of lens to allacate a beam through.
   components:
   - type: Sprite
     netsync: false
@@ -16,5 +16,5 @@
     proto: BoltDecloner
     fireCost: 100
   - type: Battery
-    maxCharge: 600
-    startingCharge: 600
+    maxCharge: 1000
+    startingCharge: 0

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -13,4 +13,4 @@
   - type: Projectile
     damage:
       types:
-        Cellular: 15
+        heat: 20


### PR DESCRIPTION
also increased the mag size and now it starts off empty

<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

**Media**
<!-- 
If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 
(adding clothing, items, new features, etc) must include ingame media or the PR will not be merged, in accordance with our PR guidelines.
This makes it much easier for us to merge PRs and find media for progress reports. If you include media in your pull request, we 
may potentially use it in the SS14 progress reports, with clear credit given.

Use screenshot software like Window's built in snipping tool, ShareX, Lightshot, or recording software like ShareX (gif), ScreenToGif, or Open Broadcaster Software (cross platform).
If you're unsure whether your PR will require media, ask a maintainer.

Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Added fun!
- remove: Removed fun!

