### PR TITLE
temporarily disable mass mind swap

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/GameRules/events.yml
+++ b/Resources/Prototypes/Nyanotrasen/GameRules/events.yml
@@ -54,14 +54,14 @@
     glimmerBurnLower: 8
     glimmerBurnUpper: 30
 
-- type: gameRule
-  id: MassMindSwap
-  config:
-    !type:GlimmerEventRuleConfiguration
-    id: MassMindSwap
-    minimumGlimmer: 900
-    glimmerBurnLower: 50
-    glimmerBurnUpper: 110
+# - type: gameRule
+#   id: MassMindSwap
+#   config:
+#     !type:GlimmerEventRuleConfiguration
+#     id: MassMindSwap
+#     minimumGlimmer: 900
+#     glimmerBurnLower: 50
+#     glimmerBurnUpper: 110
 
 - type: gameRule
   id: GlimmerWispSpawn


### PR DESCRIPTION
:cl: Rane
- remove: Mass mind swap is temporarily disabled while the recent batch of mind-related bugs is ironed out.

