### PR TITLE
medibot update 3

### DIFF
--- a/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
@@ -22,3 +22,6 @@ ghost-role-information-hamlet-description = Lives in the station bridge, has a b
 
 ghost-role-information-cancer-mouse-name = Cancer Mouse
 ghost-role-information-cancer-mouse-description = Make off color comments, but not so edgy that they break the rules of the server.
+
+ghost-role-information-medibot-name = Medibot
+ghost-role-information-medibot-description = Click people to heal them. Heal anyone your autoinjector lets you.

--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -95,6 +95,8 @@
   - type: Body
     prototype: Bot
   - type: Examiner
+  - type: Actions
+  - type: Alerts
 
 - type: entity
   parent: MobSiliconBase
@@ -203,3 +205,10 @@
       path: /Audio/Ambience/Objects/periodic_beep.ogg
   - type: ShowHealthBars
     damageContainer: Biological
+  - type: GhostTakeoverAvailable
+    makeSentient: true
+    allowSpeech: true
+    allowMovement: true
+    whitelistRequired: false
+    name: ghost-role-information-medibot-name
+    description: ghost-role-information-medibot-description

--- a/Resources/Prototypes/NPCs/medibot.yml
+++ b/Resources/Prototypes/NPCs/medibot.yml
@@ -12,13 +12,19 @@
     - tasks:
         - id: PickNearbyInjectablePrimitive
         - id: MoveToAccessiblePrimitive
-        - id: MedibotSpeakPrimitive
+        # - id: MedibotSpeakPrimitive // TODO: some sort of CD?
         - id: MedibotInjectPrimitive
+        # - id: MedibotSpeakFinishPrimitive
 
 - type: htnPrimitive
   id: MedibotSpeakPrimitive
   operator: !type:SpeakOperator
     speech: medibot-start-inject
+
+- type: htnPrimitive
+  id: MedibotSpeakFinishPrimitive
+  operator: !type:SpeakOperator
+    speech: medibot-finish-inject
 
 - type: htnPrimitive
   id: PickNearbyInjectablePrimitive


### PR DESCRIPTION
:cl: Rane
- add: Medibots are available as a ghost role. No whitelist required.
- tweak: Disabled medibot NPC speech for now.
- tweak: Player controlled medibots are easier to use.
- fix: Fixed a few more medibot AI problems.

