### PR TITLE
Cleanbot rewrite + medibot/mouse minor fixes

### DIFF
--- a/Content.Server/NPC/HTN/PrimitiveTasks/Operators/PickAccessibleComponentOperator.cs
+++ b/Content.Server/NPC/HTN/PrimitiveTasks/Operators/PickAccessibleComponentOperator.cs
@@ -22,6 +22,9 @@ public sealed class PickAccessibleComponentOperator : HTNOperator
     [DataField("targetKey", required: true)]
     public string TargetKey = string.Empty;
 
+    [DataField("targetMoveKey", required: true)]
+    public string TargetMoveKey = string.Empty;
+
     [DataField("component", required: true)]
     public string Component = string.Empty;
 
@@ -96,7 +99,8 @@ public sealed class PickAccessibleComponentOperator : HTNOperator
 
             return (true, new Dictionary<string, object>()
             {
-                { TargetKey, targetCoords },
+                { TargetKey, target },
+                { TargetMoveKey, targetCoords },
                 { PathfindKey, path}
             });
         }

--- a/Content.Server/NPC/HTN/PrimitiveTasks/Operators/Specific/CleanBotCleanOperator.cs
+++ b/Content.Server/NPC/HTN/PrimitiveTasks/Operators/Specific/CleanBotCleanOperator.cs
@@ -2,43 +2,43 @@ using Content.Server.Silicons.Bots;
 
 namespace Content.Server.NPC.HTN.PrimitiveTasks.Operators.Specific;
 
-public sealed class MedibotInjectOperator : HTNOperator
+public sealed class CleanBotCleanOperator : HTNOperator
 {
     [Dependency] private readonly IEntityManager _entManager = default!;
-    private MedibotSystem _medibotSystem = default!;
+    private CleanBotSystem _cleanbotSystem = default!;
 
-    [DataField("injectKey")]
-    public string InjectKey = string.Empty;
+    [DataField("cleanKey")]
+    public string CleanKey = string.Empty;
 
     public override void Initialize(IEntitySystemManager sysManager)
     {
         base.Initialize(sysManager);
-        _medibotSystem = sysManager.GetEntitySystem<MedibotSystem>();
+        _cleanbotSystem = sysManager.GetEntitySystem<CleanBotSystem>();
     }
 
     public override HTNOperatorStatus Update(NPCBlackboard blackboard, float frameTime)
     {
         var owner = blackboard.GetValue<EntityUid>(NPCBlackboard.Owner);
-        var target = blackboard.GetValue<EntityUid>(InjectKey);
+        var target = blackboard.GetValue<EntityUid>(CleanKey);
 
         if (!target.IsValid() || _entManager.Deleted(target))
             return HTNOperatorStatus.Failed;
 
-        if (!_entManager.TryGetComponent<MedibotComponent>(owner, out var medibot))
+        if (!_entManager.TryGetComponent<CleanBotComponent>(owner, out var cleanbot))
             return HTNOperatorStatus.Failed;
 
-        if (medibot.CancelToken != null)
+        if (cleanbot.CancelToken != null)
             return HTNOperatorStatus.Continuing;
 
-        if (medibot.InjectTarget == null)
+        if (cleanbot.CleanTarget == null)
         {
-            if (_medibotSystem.NPCStartInject(owner, target, medibot))
+            if (_cleanbotSystem.TryStartClean(owner, cleanbot, target))
                 return HTNOperatorStatus.Continuing;
             else
                 return HTNOperatorStatus.Failed;
         }
 
-        medibot.InjectTarget = null;
+        cleanbot.CleanTarget = null;
 
         return HTNOperatorStatus.Finished;
     }

--- a/Content.Server/Silicons/Bots/CleanBotComponent.cs
+++ b/Content.Server/Silicons/Bots/CleanBotComponent.cs
@@ -1,0 +1,32 @@
+using System.Threading;
+using Robust.Shared.Audio;
+
+namespace Content.Server.Silicons.Bots
+{
+    [RegisterComponent]
+    public sealed class CleanBotComponent : Component
+    {
+        public CancellationTokenSource? CancelToken;
+
+        /// <summary>
+        /// Used in NPC logic.
+        /// </summary>
+        [ViewVariables]
+        public EntityUid? CleanTarget;
+
+        /// <summary>
+        /// How many units we can remove upon doafter completion.
+        /// </summary>
+        [DataField("UnitsToClean")]
+        public float UnitsToClean = 10f;
+
+        /// <summary>
+        /// Doafter length, in seconds.
+        /// </summary>
+        [DataField("cleanDelay")]
+        public float CleanDelay = 3.5f;
+
+        [DataField("cleanSound")]
+        public SoundSpecifier CleanSound = new SoundPathSpecifier("/Audio/Effects/Fluids/slosh.ogg");
+    }
+}

--- a/Content.Server/Silicons/Bots/CleanBotSystem.cs
+++ b/Content.Server/Silicons/Bots/CleanBotSystem.cs
@@ -1,0 +1,121 @@
+using System.Threading;
+using System.Diagnostics.CodeAnalysis;
+using Content.Shared.Mobs.Systems;
+using Content.Shared.Damage;
+using Content.Shared.Chemistry.Components;
+using Content.Shared.Popups;
+using Content.Shared.ActionBlocker;
+using Content.Shared.Interaction;
+using Content.Server.DoAfter;
+using Content.Server.Popups;
+using Content.Server.NPC.Components;
+using Content.Server.Fluids.Components;
+using Content.Server.Chemistry.EntitySystems;
+using Robust.Shared.Physics.Components;
+using Robust.Server.GameObjects;
+
+namespace Content.Server.Silicons.Bots
+{
+    public sealed class CleanBotSystem : EntitySystem
+    {
+        [Dependency] private readonly MobStateSystem _mobs = default!;
+        [Dependency] private readonly SolutionContainerSystem _solution = default!;
+        [Dependency] private readonly PopupSystem _popups = default!;
+        [Dependency] private readonly DoAfterSystem _doAfter = default!;
+        [Dependency] private readonly AudioSystem _audioSystem = default!;
+        [Dependency] private readonly ActionBlockerSystem _blocker = default!;
+        [Dependency] private readonly PhysicsSystem _physics = default!;
+        [Dependency] private readonly SharedInteractionSystem _interactionSystem = default!;
+
+        public override void Initialize()
+        {
+            base.Initialize();
+            SubscribeLocalEvent<CleanBotComponent, InteractNoHandEvent>(PlayerClean);
+            SubscribeLocalEvent<TargetCleanSuccessfulEvent>(OnCleanSuccessful);
+            SubscribeLocalEvent<CleanCancelledEvent>(OnCleanCancelled);
+        }
+
+        private void PlayerClean(EntityUid uid, CleanBotComponent component, InteractNoHandEvent args)
+        {
+            if (!HasComp<PuddleComponent>(args.Target))
+                return;
+
+            TryStartClean(uid, component, args.Target.Value);
+        }
+
+        public bool TryStartClean(EntityUid performer, CleanBotComponent component, EntityUid target)
+        {
+            if (component.CancelToken != null)
+                return false;
+
+            if (!_blocker.CanInteract(performer, target))
+                return false;
+
+            if (!_interactionSystem.InRangeUnobstructed(performer, target))
+                return false;
+
+            component.CancelToken = new CancellationTokenSource();
+            component.CleanTarget = target;
+
+            _doAfter.DoAfter(new DoAfterEventArgs(performer, component.CleanDelay, component.CancelToken.Token, target: target)
+            {
+                BroadcastFinishedEvent = new TargetCleanSuccessfulEvent(performer, target),
+                BroadcastCancelledEvent = new CleanCancelledEvent(performer),
+                BreakOnTargetMove = true,
+                BreakOnUserMove = true,
+                BreakOnStun = true,
+                NeedHand = false
+            });
+
+            return true;
+        }
+
+        private void OnCleanSuccessful(TargetCleanSuccessfulEvent ev)
+        {
+            if (!TryComp<CleanBotComponent>(ev.Cleaner, out var cleanbot))
+                return;
+
+            cleanbot.CancelToken = null;
+
+            if (!TryComp<PuddleComponent>(ev.Target, out var puddle))
+                return;
+
+            if (!_solution.TryGetSolution(ev.Target, puddle.SolutionName, out var solution))
+                return;
+
+            _audioSystem.PlayPvs(cleanbot.CleanSound, ev.Target);
+
+            solution.SplitSolution(cleanbot.UnitsToClean);
+
+            if (solution.Volume < 1f)
+                QueueDel(ev.Target);
+        }
+
+        private void OnCleanCancelled(CleanCancelledEvent ev)
+        {
+            if (!TryComp<CleanBotComponent>(ev.Cleaner, out var cleanbot))
+                return;
+
+            cleanbot.CancelToken = null;
+        }
+        private sealed class CleanCancelledEvent : EntityEventArgs
+        {
+            public EntityUid Cleaner;
+            public CleanCancelledEvent(EntityUid cleaner)
+            {
+                Cleaner = cleaner;
+            }
+        }
+
+        private sealed class TargetCleanSuccessfulEvent : EntityEventArgs
+        {
+            public EntityUid Cleaner;
+            public EntityUid Target;
+            public TargetCleanSuccessfulEvent(EntityUid cleaner, EntityUid target)
+            {
+                Cleaner = cleaner;
+                Target = target;
+            }
+        }
+    }
+}

--- a/Content.Server/Silicons/Bots/MedibotSystem.cs
+++ b/Content.Server/Silicons/Bots/MedibotSystem.cs
@@ -93,8 +93,7 @@ namespace Content.Server.Silicons.Bots
                 BroadcastFinishedEvent = new TargetInjectSuccessfulEvent(performer, target, injectable, drug, injectAmount),
                 BroadcastCancelledEvent = new InjectCancelledEvent(performer, target),
                 BreakOnTargetMove = true,
-                BreakOnUserMove = false,
-                DistanceThreshold = 2f,
+                BreakOnUserMove = true,
                 BreakOnStun = true,
                 NeedHand = false
             });
@@ -113,8 +112,6 @@ namespace Content.Server.Silicons.Bots
             _solution.TryAddReagent(ev.Target, ev.Injectable, ev.Drug, ev.Amount, out var acceptedQuantity);
             _popups.PopupEntity(Loc.GetString("hypospray-component-feel-prick-message"), ev.Target, ev.Target);
             EnsureComp<NPCRecentlyInjectedComponent>(ev.Target);
-
-            medibot.InjectTarget = null;
         }
 
         private void OnInjectCancelled(InjectCancelledEvent ev)
@@ -123,7 +120,6 @@ namespace Content.Server.Silicons.Bots
                 return;
 
             medibot.CancelToken = null;
-            medibot.InjectTarget = null;
         }
 
         private bool SharedInjectChecks(EntityUid uid, EntityUid target, [NotNullWhen(true)] out Solution? injectable)

--- a/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
@@ -25,3 +25,6 @@ ghost-role-information-cancer-mouse-description = Make off color comments, but n
 
 ghost-role-information-medibot-name = Medibot
 ghost-role-information-medibot-description = Click people to heal them. Heal anyone your autoinjector lets you.
+
+ghost-role-information-cleanbot-name = CleanBot
+ghost-role-information-cleanbot-description = Click puddles to mop them up.

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -708,7 +708,7 @@
     - shape:
         !type:PhysShapeCircle
         radius: 0.2
-      density: 100
+      density: 5
       mask:
       - SmallMobMask
       layer:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -152,26 +152,31 @@
   name: cleanbot
   description: The creep of automation now threatening space janitors.
   components:
+  - type: DoAfter
   - type: Sprite
     drawdepth: Mobs
     sprite: Mobs/Silicon/Bots/cleanbot.rsi
     state: cleanbot
-  - type: Drain
-    range: 1
-    unitsDestroyedPerSecond: 6
   - type: Construction
     graph: CleanBot
     node: bot
-  - type: SolutionContainerManager
-    solutions:
-      drainBuffer:
-        maxVol: 30
+  - type: CleanBot
   - type: MovementSpeedModifier
     baseWalkSpeed: 2
     baseSprintSpeed: 3
   - type: NoSlip
   - type: HTN
     rootTask: CleanbotCompound
+  - type: Fixtures
+    fixtures:
+    - shape:
+        !type:PhysShapeCircle
+        radius: 0.2
+      density: 40
+      mask:
+      - SmallMobMask
+      layer:
+      - SmallMobLayer
   - type: DrainableSolution
     solution: drainBuffer
   - type: InteractionPopup
@@ -179,6 +184,13 @@
     interactFailureString: petting-failure-cleanbot
     interactSuccessSound:
       path: /Audio/Ambience/Objects/periodic_beep.ogg
+  - type: GhostTakeoverAvailable
+    makeSentient: true
+    allowSpeech: true
+    allowMovement: true
+    whitelistRequired: false
+    name: ghost-role-information-cleanbot-name
+    description: ghost-role-information-cleanbot-description
 
 - type: entity
   parent: MobSiliconBase

--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -186,7 +186,7 @@
       path: /Audio/Ambience/Objects/periodic_beep.ogg
   - type: GhostTakeoverAvailable
     makeSentient: true
-    allowSpeech: true
+    allowSpeech: false
     allowMovement: true
     whitelistRequired: false
     name: ghost-role-information-cleanbot-name

--- a/Resources/Prototypes/NPCs/cleanbot.yml
+++ b/Resources/Prototypes/NPCs/cleanbot.yml
@@ -13,19 +13,17 @@
     - tasks:
         - id: PickPuddlePrimitive
         - id: MoveToAccessiblePrimitive
-        - id: SetIdleTimePrimitive
-        - id: WaitIdleTimePrimitive
-
+        - id: CleanPuddlePrimitive
 
 - type: htnPrimitive
   id: PickPuddlePrimitive
   operator: !type:PickAccessibleComponentOperator
     rangeKey: BufferRange
-    targetKey: MovementTarget
+    targetKey: CleanTarget
+    targetMoveKey: MovementTarget
     component: Puddle
 
 - type: htnPrimitive
-  id: SetIdleTimePrimitive
-  operator: !type:SetFloatOperator
-    targetKey: IdleTime
-    amount: 3
+  id: CleanPuddlePrimitive
+  operator: !type:CleanBotCleanOperator
+    cleanKey: CleanTarget


### PR DESCRIPTION
:cl: Rane
- fix: Cleanbots have been rewritten and work fine now.
- add: Cleanbots are now a ghost role option by default.
- add: Cleanbots can go under doors.
- fix: Fixed a few minor medibot issues.
- fix: Reverted the upstream decision to make mice weigh 20 kilograms.
