### PR TITLE
Tweaked aberrant flesh

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/flesh.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/flesh.yml
@@ -1,5 +1,5 @@
 ﻿- type: entity
-  parent: SimpleMobBase
+  parent: SimpleFleshAnomalyBase
   id: BaseMobFlesh
   name: aberrant flesh
   description: A shambling mass of flesh, animated through anomalous energy.
@@ -51,7 +51,9 @@
     animation: WeaponArcClaw
     damage:
       types:
-        Slash: 3
+        Slash: 2
+        Blunt: 1
+    bluntStaminaDamageFactor: 3
   - type: ReplacementAccent
     accent: genericAggressive
 

--- a/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
@@ -227,3 +227,66 @@
   - type: Appearance
   - type: FloatingVisuals
 
+- type: entity
+  save: false
+  abstract: true
+  id: SimpleFleshAnomalyBase # for aberrant flesh, basically the same thing as SimpleMobBase sans barotrauma
+  parent: SimpleSpaceMobBase
+  suffix: AI
+  components:
+  - type: InputMover
+  - type: MobMover
+  - type: Hunger
+    thresholds:
+      Overfed: 100
+      Okay: 50
+      Peckish: 25
+      Starving: 10
+      Dead: 0
+    baseDecayRate: 0.00925925925926
+  - type: Thirst
+    thresholds:
+      OverHydrated: 200
+      Okay: 150
+      Thirsty: 100
+      Parched: 50
+      Dead: 0
+    baseDecayRate: 0.04
+  - type: StatusEffects
+    allowed:
+      - Stun
+      - KnockedDown
+      - SlowedDown
+      - Stutter
+      - Electrocution
+      - ForcedSleep
+      - TemporaryBlindness
+      - Pacified
+  - type: ThermalRegulator
+    metabolismHeat: 800
+    radiatedHeat: 100
+    implicitHeatRegulation: 250
+    sweatHeatRegulation: 500
+    shiveringHeatRegulation: 500
+    normalBodyTemperature: 310.15
+    thermalRegulationTemperatureThreshold: 25
+  - type: Temperature
+    heatDamageThreshold: 373
+    coldDamageThreshold: 100
+    currentTemperature: 310.15
+    specificHeat: 42
+    coldDamage:
+      types:
+        Cold : 1
+    heatDamage:
+      types:
+        Heat : 1
+  - type: Bloodstream
+    bloodMaxVolume: 150
+  - type: MobPrice
+    price: 150
+  - type: SentienceTarget
+    flavorKind: animal
+  - type: Appearance
+  - type: FloatingVisuals
+


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Made aberrant flesh not take damage from asphyxiation and barotrauma, as well as having a much wider safe temperature range (100 - 373 Kelvin) to avoid dying on Glacier.

Also changed their damage from 3 slash to 2 slash, 1 blunt, 3 stamina.