### PR TITLE
Tweaked thrusters to allow large grid Shuttles/Spaceships proper movement

### DIFF
--- a/Content.Server/Physics/Controllers/MoverController.cs
+++ b/Content.Server/Physics/Controllers/MoverController.cs
@@ -363,7 +363,10 @@ namespace Content.Server.Physics.Controllers
                         var impulse = force * brakeInput;
                         var wishDir = impulse.Normalized;
                         // TODO: Adjust max possible speed based on total thrust in particular direction.
-                        var wishSpeed = 20f;
+                        //Calculates average thrust from cardinal directions. Then checks if its high enough where it's worth to increase potential linear velocity cap 
+                        //Grid size and mass have huge influence over how fast it can move. Which means that it will never reach linear velocity cap unless shuttle consists of only thrusters
+                        var avgLinearThrust = (shuttle.LinearThrust[0]+shuttle.LinearThrust[1]+shuttle.LinearThrust[2]+shuttle.LinearThrust[3])/4;
+                        var wishSpeed = MathF.Max(20f, (avgLinearThrust+17500)/1000);
 
                         var currentSpeed = Vector2.Dot(shuttleVelocity, wishDir);
                         var addSpeed = wishSpeed - currentSpeed;
@@ -504,7 +507,10 @@ namespace Content.Server.Physics.Controllers
 
                     var wishDir = totalForce.Normalized;
                     // TODO: Adjust max possible speed based on total thrust in particular direction.
-                    var wishSpeed = 20f;
+                    //Calculates average thrust from cardinal directions. Then checks if its high enough where it's worth to increase potential linear velocity cap 
+                    //Grid size and mass have huge influence over how fast it can move. Which means that it will never reach linear velocity cap unless shuttle consists of only thrusters
+                    var avgLinearThrust = (shuttle.LinearThrust[0]+shuttle.LinearThrust[1]+shuttle.LinearThrust[2]+shuttle.LinearThrust[3])/4;
+                    var wishSpeed = MathF.Max(20f, (avgLinearThrust+17500)/1000);
 
                     var currentSpeed = Vector2.Dot(shuttleVelocity, wishDir);
                     var addSpeed = wishSpeed - currentSpeed;


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
It influences shuttles with high amount of thrusters. As before the size (and mass) of grid had a massive impact on possible velocities while thrusters at certain point weren't able to accelerate the grid fast enough for velocity to not be reset into 0.

<!-- 
If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 
(adding clothing, items, new features, etc) must include ingame media or the PR will not be merged, in accordance with our PR guidelines.
This makes it much easier for us to merge PRs and find media for progress reports. If you include media in your pull request, we 
may potentially use it in the SS14 progress reports, with clear credit given.

Use screenshot software like Window's built in snipping tool, ShareX, Lightshot, or recording software like ShareX (gif), ScreenToGif, or Open Broadcaster Software (cross platform).
If you're unsure whether your PR will require media, ask a maintainer.

Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
**Media**
![obraz](https://user-images.githubusercontent.com/52052459/219260534-1bf33c4e-5bc3-4473-a969-4e9e72f31378.png)



**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Tweaked thrusters to allow Spaceships and large shuttles to function properly

