### PR TITLE
rev changes

### DIFF
--- a/Content.Server/Revenant/EntitySystems/RevenantSystem.Abilities.cs
+++ b/Content.Server/Revenant/EntitySystems/RevenantSystem.Abilities.cs
@@ -188,7 +188,7 @@ public sealed partial class RevenantSystem
         if (_mobState.IsAlive(args.Target) || _mobState.IsCritical(args.Target))
         {
             _popup.PopupEntity(Loc.GetString("revenant-max-essence-increased"), uid, uid);
-            component.EssenceRegenCap += component.MaxEssenceUpgradeAmount;
+            component.EssenceRegenCap = Math.Min((float) component.EssenceCeiling, (float) component.EssenceRegenCap + component.MaxEssenceUpgradeAmount);
         }
 
         //KILL THEMMMM

--- a/Content.Server/Revenant/EntitySystems/RevenantSystem.cs
+++ b/Content.Server/Revenant/EntitySystems/RevenantSystem.cs
@@ -124,7 +124,7 @@ public sealed partial class RevenantSystem : EntitySystem
         if (!allowDeath && component.Essence + amount <= 0)
             return false;
 
-        component.Essence += amount;
+        component.Essence = Math.Min((float) component.EssenceCeiling, (float) (component.Essence + amount));
 
         if (regenCap)
             FixedPoint2.Min(component.Essence, component.EssenceRegenCap);
@@ -140,7 +140,7 @@ public sealed partial class RevenantSystem : EntitySystem
             int i = 0;
             while (i < amt)
             {
-                Spawn("Ectoplasm", Transform(uid).Coordinates);
+                Spawn("EctoplasmRevenant", Transform(uid).Coordinates);
                 i++;
             }
             QueueDel(uid);

--- a/Content.Shared/Revenant/Components/RevenantComponent.cs
+++ b/Content.Shared/Revenant/Components/RevenantComponent.cs
@@ -28,10 +28,16 @@ public sealed class RevenantComponent : Component
     public FixedPoint2 EssenceRegenCap = 75;
 
     /// <summary>
+    /// Maximum essence, rather than infinite scaling.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite), DataField("essenceCeiling")]
+    public FixedPoint2 EssenceCeiling = 150;
+
+    /// <summary>
     /// The coefficient of damage taken to actual health lost.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField("damageToEssenceCoefficient")]
-    public float DamageToEssenceCoefficient = 0.75f;
+    public float DamageToEssenceCoefficient = 1f;
 
     /// <summary>
     /// The amount of essence passively generated per second.

--- a/Resources/Changelog/NyanotrasenChangelog.yml
+++ b/Resources/Changelog/NyanotrasenChangelog.yml
@@ -2686,3 +2686,11 @@ Entries:
   - {message: Added a round-end report for survival mode., type: Add}
   id: 422
   time: '2023-02-16T00:15:08.0000000+00:00'
+- author: Rane
+  changes:
+  - {message: Holy water now works against wisps and revenants when sprayed., type: Add}
+  - {message: Holy water spray damage increased., type: Tweak}
+  - {message: 'Revenant no longer scales infinitely, but has a reasonable essence cap.', type: Tweak}
+  - {message: Revenant's essence loss now is in line with its new resistances., type: Tweak}
+  id: 423
+  time: '2023-02-16T00:15:08.0000000+00:00'

--- a/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
@@ -18,6 +18,9 @@
     sprite: Mobs/Ghosts/revenant.rsi
     layers:
     - state: active
+  - type: Reactive
+    groups:
+      Acidic: [Touch] #Holy water
   - type: Clickable
   - type: StatusEffects
     allowed:

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/spray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/spray.yml
@@ -100,5 +100,7 @@
       mask:
       - FullTileMask
       - Opaque
+      layer:
+      - FullTileLayer
   - type: Appearance
   - type: VaporVisuals

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/NPCs/glimmer_monsters.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/NPCs/glimmer_monsters.yml
@@ -39,6 +39,9 @@
   - type: MovementIgnoreGravity
   - type: Stealth
     lastVisibility: 0.66
+  - type: Reactive
+    groups:
+      Acidic: [Touch] #Holy water
   - type: MobState
     allowedStates:
     - Alive

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Chapel/ectoplasm.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Chapel/ectoplasm.yml
@@ -9,7 +9,19 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 50
+        maxVol: 100
         reagents:
         - ReagentId: Ectoplasm
           Quantity: 25
+
+- type: entity
+  parent: Ectoplasm
+  id: EctoplasmRevenant
+  components:
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 100
+        reagents:
+        - ReagentId: Ectoplasm
+          Quantity: 60

--- a/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
@@ -286,7 +286,7 @@
         ignoreResistances: false
         damage:
           types:
-            Holy: 0.1
+            Holy: 0.5
   metabolisms: #Could nullify debuffs of feeding.
     Drink:
       effects:


### PR DESCRIPTION
:cl: Rane
- tweak: Revenants no longer scale infinitely. They have an essence cap.
- tweak: Revenants convert 100% of damage into essence damage. I forgot to take this into account when last changing their damage multiplier.
- tweak: Revenants drop way more ectoplasm.