### PR TITLE
Remove spacetime

### DIFF
--- a/Content.Server/Nyanotrasen/Psionics/Glimmer/GlimmerEventRuleConfiguration.cs
+++ b/Content.Server/Nyanotrasen/Psionics/Glimmer/GlimmerEventRuleConfiguration.cs
@@ -40,14 +40,14 @@ public sealed class GlimmerEventRuleConfiguration : GameRuleConfiguration
     ///     Lower bound.
     /// </summary>
     [DataField("glimmerBurnLower")]
-    public int GlimmerBurnLower = 15;
+    public int GlimmerBurnLower = 25;
 
     /// <summary>
     ///     Will be used for _random.Next and subtracted from glimmer.
     ///     Upper bound.
     /// </summary>
     [DataField("glimmerBurnUpper")]
-    public int GlimmerBurnUpper = 60;
+    public int GlimmerBurnUpper = 70;
 
     /// <summary>
     ///     When in the lifetime to start the event.

--- a/Content.Server/Nyanotrasen/Psionics/Glimmer/GlimmerSystem.cs
+++ b/Content.Server/Nyanotrasen/Psionics/Glimmer/GlimmerSystem.cs
@@ -29,7 +29,7 @@ namespace Content.Server.Psionics.Glimmer
 
             if (DecayAccumulator > SecondsToLoseOneGlimmer)
             {
-                if (_robustRandom.Prob(0.5f))
+                if (_robustRandom.Prob(0.75f))
                     _sharedGlimmerSystem.Glimmer--;
                 DecayAccumulator -= SecondsToLoseOneGlimmer;
             }

--- a/Content.Server/Revenant/EntitySystems/RevenantSystem.Abilities.cs
+++ b/Content.Server/Revenant/EntitySystems/RevenantSystem.Abilities.cs
@@ -199,7 +199,7 @@ public sealed partial class RevenantSystem
         dspec.DamageDict.Add("Poison", damage.Value);
         _damage.TryChangeDamage(args.Target, dspec, true, origin: uid);
 
-        _psionics.LogPowerUsed(uid, "a soul draining power", 4, 8);
+        _psionics.LogPowerUsed(uid, "a soul draining power", 2, 6);
     }
 
     private void OnHarvestCancelled(EntityUid uid, RevenantComponent component, HarvestDoAfterCancelled args)
@@ -268,7 +268,7 @@ public sealed partial class RevenantSystem
             if (lights.HasComponent(ent))
                 _ghost.DoGhostBooEvent(ent);
         }
-        _psionics.LogPowerUsed(uid, "a spirit power");
+        _psionics.LogPowerUsed(uid, Loc.GetString("revenant-psionic-power"));
     }
 
     private void OnOverloadLightsAction(EntityUid uid, RevenantComponent component, RevenantOverloadLightsActionEvent args)
@@ -305,7 +305,7 @@ public sealed partial class RevenantSystem
             comp.Target = ent; //who they gon fire at?
         }
 
-        _psionics.LogPowerUsed(uid, "a spirit power");
+        _psionics.LogPowerUsed(uid, Loc.GetString("revenant-psionic-power"));
     }
 
     private void OnBlightAction(EntityUid uid, RevenantComponent component, RevenantBlightActionEvent args)
@@ -324,7 +324,7 @@ public sealed partial class RevenantSystem
             if (emo.TryGetComponent(ent, out var comp))
                 _disease.TryAddDisease(ent, component.BlightDiseasePrototypeId, comp);
         }
-        _psionics.LogPowerUsed(uid, "a spirit power");
+        _psionics.LogPowerUsed(uid, Loc.GetString("revenant-psionic-power"), 6, 10);
     }
 
     private void OnMalfunctionAction(EntityUid uid, RevenantComponent component, RevenantMalfunctionActionEvent args)
@@ -341,6 +341,6 @@ public sealed partial class RevenantSystem
         {
             _emag.DoEmagEffect(ent, ent); //it emags itself. spooky.
         }
-        _psionics.LogPowerUsed(uid, "a spirit power");
+        _psionics.LogPowerUsed(uid, Loc.GetString("revenant-psionic-power"), 6, 10);
     }
 }

--- a/Content.Server/Revenant/EntitySystems/RevenantSystem.cs
+++ b/Content.Server/Revenant/EntitySystems/RevenantSystem.cs
@@ -209,6 +209,7 @@ public sealed partial class RevenantSystem : EntitySystem
 
             if (rev.Accumulator <= 1)
                 continue;
+
             rev.Accumulator -= 1;
 
             if (rev.Essence < rev.EssenceRegenCap)

--- a/Resources/Changelog/NyanotrasenChangelog.yml
+++ b/Resources/Changelog/NyanotrasenChangelog.yml
@@ -2694,3 +2694,10 @@ Entries:
   - {message: Revenant's essence loss now is in line with its new resistances., type: Tweak}
   id: 423
   time: '2023-02-16T00:15:08.0000000+00:00'
+- author: Rane
+  changes:
+  - {message: You can no longer print normality crystals., type: Remove}
+  - {message: Passive glimmer values have been changed so the average round will have 2000 less glimmer., type: Tweak}
+  - {message: 'Spacetime technology has been split into one for teleportation, and one for bluespace.', type: Tweak}
+  id: 423
+  time: '2023-02-17T00:15:08.0000000+00:00'

--- a/Resources/Locale/en-US/prototypes/catalog/research/technologies.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/research/technologies.ftl
@@ -100,8 +100,11 @@ technologies-direct-energy-technology-description = Leverage our advances in pow
 technologies-non-lethal-technology = Non-lethal technology
 technologies-non-lethal-technology-description = Less lethal options for security.
 
-technologies-space-time-technology = Spacetime technology
-technologies-space-time-technology-description = Pushing the limits of the universe.
-
 technologies-ripley-technology = Exosuit: Ripley
 technologies-ripley-technology-description = The latest and greatest in mechanized cargo construction.
+
+technologies-bluespace-technology = Bluespace technology
+technologies-bluespace-technology-description = Extradimensional storage.
+
+technologies-teleportation-technology = Teleportation technology
+technologies-teleportation-technology-description = The ability to move matter instantly from one place to another.

--- a/Resources/Locale/en-US/revenant/revenant.ftl
+++ b/Resources/Locale/en-US/revenant/revenant.ftl
@@ -16,6 +16,8 @@ revenant-soul-yield-low = {CAPITALIZE(THE($target))} has a below average soul.
 revenant-soul-begin-harvest = {CAPITALIZE(THE($target))} suddenly rises slightly into the air, {POSS-ADJ($target)} skin turning an ashy gray.
 revenant-soul-finish-harvest = {CAPITALIZE(THE($target))} slumps onto the ground!
 
+revenant-psionic-power = a spirit power
+
 #UI
 revenant-user-interface-title = Ability Shop
 revenant-user-interface-essence-amount = [color=plum]{$amount}[/color] Stolen Essence

--- a/Resources/Prototypes/Catalog/Research/technologies.yml
+++ b/Resources/Prototypes/Catalog/Research/technologies.yml
@@ -552,6 +552,24 @@
   - ReverseEngineeringMachineCircuitboard
 
 - type: technology
+  name: technologies-super-parts-technology
+  id: SuperPartsTechnology
+  description: technologies-super-parts-technology-description
+  icon:
+    sprite: Objects/Misc/stock_parts.rsi
+    state: super_capacitor
+  requiredPoints: 20000
+  requiredTechnologies:
+  - AdvancedPartsTechnology
+  - CompactPowerTechnology
+  unlockedRecipes:
+  - SuperCapacitorStockPart
+  - SuperMatterBinStockPart
+  - UltraHighPowerMicroLaserStockPart
+  - PicoManipulatorStockPart
+  - PhasicScanningModuleStockPart
+
+- type: technology
   name: technologies-robotics-technology
   id: RoboticsTechnology
   description: technologies-robotics-technology-description
@@ -632,41 +650,33 @@
   - TraversalDistorterMachineCircuitboard
 
 - type: technology
-  name: technologies-space-time-technology
-  id: SpaceTimeTechnology
-  description: technologies-space-time-technology-description
+  name: technologies-bluespace-technology
+  id: BluespaceTechnology
+  description: technologies-bluespace-technology-description
   icon:
-    sprite: Nyanotrasen/Objects/Devices/QSI.rsi
-    state: icon
-  requiredPoints: 20000
+    sprite: Nyanotrasen/Objects/Materials/materials.rsi
+    state: bluespace
+  requiredPoints: 15000
   requiredTechnologies:
-    - CompactPowerTechnology
-    - AdvancedPartsTechnology
-    - ArchaeologicalEquipment
+    - SuperPartsTechnology
     - AnomalyTechnology
   unlockedRecipes:
-    - QSI
     - BluespaceBeaker
     - BackpackOfHolding
     - SatchelOfHolding
     - DuffelbagOfHolding
     - TrashBagOfHolding
-    - NormalityCrystal
 
 - type: technology
-  name: technologies-super-parts-technology
-  id: SuperPartsTechnology
-  description: technologies-super-parts-technology-description
+  name: technologies-teleportation-technology
+  id: TeleportationTechnology
+  description: technologies-teleporation-technology-description
   icon:
-    sprite: Objects/Misc/stock_parts.rsi
-    state: super_capacitor
-  requiredPoints: 20000
+    sprite: Nyanotrasen/Objects/Devices/QSI.rsi
+    state: icon
+  requiredPoints: 10000
   requiredTechnologies:
-  - AdvancedPartsTechnology
-  - CompactPowerTechnology
+    - SuperPartsTechnology
+    - AnomalyTechnology
   unlockedRecipes:
-  - SuperCapacitorStockPart
-  - SuperMatterBinStockPart
-  - UltraHighPowerMicroLaserStockPart
-  - PicoManipulatorStockPart
-  - PhasicScanningModuleStockPart
+    - QSI

--- a/Resources/Prototypes/Nyanotrasen/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Structures/Machines/lathe.yml
@@ -33,7 +33,6 @@
       - BackpackOfHolding
       - SatchelOfHolding
       - DuffelbagOfHolding
-      - NormalityCrystal
       - AnomalyScanner
       - ChemicalPayload #Below = shared
       - FlashlightLantern

--- a/Resources/Prototypes/Nyanotrasen/GameRules/events.yml
+++ b/Resources/Prototypes/Nyanotrasen/GameRules/events.yml
@@ -27,8 +27,8 @@
     !type:GlimmerEventRuleConfiguration
     id: MundaneDischarge
     maximumGlimmer: 300
-    glimmerBurnLower: 8
-    glimmerBurnUpper: 30
+    glimmerBurnLower: 18
+    glimmerBurnUpper: 40
 
 - type: gameRule
   id: NoosphericZap
@@ -51,8 +51,8 @@
     id: PsionicCatGotYourTongue
     minimumGlimmer: 200
     maximumGlimmer: 500
-    glimmerBurnLower: 8
-    glimmerBurnUpper: 30
+    glimmerBurnLower: 18
+    glimmerBurnUpper: 40
 
 # - type: gameRule
 #   id: MassMindSwap

--- a/Resources/Prototypes/Nyanotrasen/Recipes/Lathes/bluespace.yml
+++ b/Resources/Prototypes/Nyanotrasen/Recipes/Lathes/bluespace.yml
@@ -80,15 +80,3 @@
   completetime: 4
   materials:
     Bluespace: 100
-
-- type: latheRecipe
-  id: NormalityCrystal
-  icon:
-    sprite: Nyanotrasen/Objects/Materials/materials.rsi
-    state: bluespace
-  result: CrystalNormality
-  completetime: 4
-  materials:
-    Bluespace: 100
-    Plasma: 100
-    Gold: 25


### PR DESCRIPTION
:cl: Rane
- tweak: Changes to current glimmer generation/reduction values should lead to about 2000 psi less glimmer in an average round.
- remove: Removed the ability to print normality crystals.
- tweak: Spacetime technology has been split into bluespace technology and teleportation technology.

