### PR TITLE
Make ERT more interesting

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/backpack.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/backpack.yml
@@ -210,6 +210,7 @@
         - id: BoxLightMixed
         - id: BoxLightMixed
         - id: Soap
+        - id: MopItem
         - id: PillCryptobiolin
 
 - type: entity

--- a/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/backpack.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/backpack.yml
@@ -167,19 +167,17 @@
     - type: StorageFill
       contents:
         - id: BoxSurvivalMedical
-        - id: MedkitAdvancedFilled
+        - id: MedkitOxygenFilled
         - id: EpinephrineChemistryBottle
-        - id: OmnizineChemistryBottle
+        - id: AntiPoisonMedipen
+          amount: 2
         - id: Syringe
         - id: Gauze
-        - id: PillCryptobiolin
-        - id: PillDylovene
-          amount: 2
         - id: PillHyronalin
           amount: 2
-        - id: PillDexalin
-          amount: 2
         - id: PillIron
+          amount: 2
+        - id: PillCryptobiolin
 
 
 - type: entity

--- a/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/backpack.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/backpack.yml
@@ -140,10 +140,10 @@
       contents:
         - id: BoxSurvival
         - id: WeaponPulsePistol
-        - id: WeaponPistolMk58
-        - id: MagazinePistolHighCapacityRubber
-        - id: MagazinePistol
+        - id: WeaponDisabler
+        - id: Stunbaton
         - id: Handcuffs
+        - id: PillCryptobiolin
 
 
 - type: entity
@@ -153,12 +153,11 @@
   components:
     - type: StorageFill
       contents:
-        - id: BoxSurvival
+        - id: BoxSurvivalSecurity
         - id: WeaponDisabler
-        - id: WeaponPulsePistol
-        - id: WeaponPulseCarbine
         - id: BoxHandcuff
         - id: Handcuffs
+        - id: PillCryptobiolin
 
 - type: entity
   noSpawn: true
@@ -167,10 +166,20 @@
   components:
     - type: StorageFill
       contents:
-        - id: BoxSurvival
-        - id: WeaponPulseCarbine
-        - id: Hypospray
+        - id: BoxSurvivalMedical
         - id: MedkitAdvancedFilled
+        - id: EpinephrineChemistryBottle
+        - id: OmnizineChemistryBottle
+        - id: Syringe
+        - id: Gauze
+        - id: PillCryptobiolin
+        - id: PillDylovene
+          amount: 2
+        - id: PillHyronalin
+          amount: 2
+        - id: PillDexalin
+          amount: 2
+        - id: PillIron
 
 
 - type: entity
@@ -180,13 +189,17 @@
   components:
     - type: StorageFill
       contents:
-        - id: BoxSurvival
+        - id: BoxSurvivalEngineering
         - id: trayScanner
-        - id: WeaponPulseCarbine
-        - id: RCD
-        - id: RCDAmmo
-        - id: RCDAmmo
-        - id: RCDAmmo
+        - id: CableHVStack
+        - id: CableMVStack
+        - id: CableApcStack
+        - id: SheetSteel
+        - id: PartRodMetal
+        - id: InflatableWallStack
+        - id: InflatableDoorStack1
+          amount: 4
+        - id: PillCryptobiolin
 
 - type: entity
   noSpawn: true
@@ -196,11 +209,10 @@
     - type: StorageFill
       contents:
         - id: BoxSurvival
-        - id: WeaponPulsePistol
-        - id: MedkitFilled
         - id: BoxLightMixed
         - id: BoxLightMixed
         - id: Soap
+        - id: PillCryptobiolin
 
 - type: entity
   noSpawn: true

--- a/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
@@ -136,7 +136,7 @@
   - type: Sprite
     sprite: Clothing/Back/Backpacks/ertleader.rsi
   - type: Storage
-    capacity: 250
+    capacity: 120 #Nerf it to the size of a duffel bag.
 
 - type: entity
   parent: ClothingBackpackERTLeader

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -489,8 +489,8 @@
 - type: entity
   parent: BasePDA
   id: ERTLeaderPDA
-  name: ERT PDA
-  description: Red for firepower.
+  name: ERT Leader PDA
+  description: Red for the firepower.
   components:
   - type: PDA
     id: ERTLeaderIDCard

--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -292,12 +292,14 @@
 - type: entity
   parent: CentcomIDCard
   id: ERTLeaderIDCard
-  name: ERT ID card
+  name: ERT Leader ID card
   components:
   - type: Sprite
     layers:
     - state: gold
-    - state: ert_commander # we have the sprites but don't need individual ID entities for now.
+    - state: ert_commander
+  - type: IdCard
+    jobTitle: ert commander
   - type: Item
     heldPrefix: gold
 

--- a/Resources/Prototypes/Nyanotrasen/Entities/Clothing/Ears/headsets.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Clothing/Ears/headsets.yml
@@ -55,3 +55,78 @@
     sprite: Clothing/Ears/Headsets/science.rsi
   - type: Clothing
     sprite: Clothing/Ears/Headsets/science.rsi
+
+#ERT Special Headsets
+- type: entity
+  parent: ClothingHeadsetAlt
+  id: ClothingHeadsetAltERTJanitor
+  name: ERT janitor over-ear headset
+  components:
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - EncryptionKeyERT
+      - EncryptionKeyService
+  - type: Sprite
+    sprite: Clothing/Ears/Headsets/cargo.rsi
+  - type: Clothing
+    sprite: Clothing/Ears/Headsets/cargo.rsi
+
+- type: entity
+  parent: ClothingHeadsetAlt
+  id: ClothingHeadsetAltERTLeader
+  name: ERT leader over-ear headset
+  components:
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - EncryptionKeyCentCom
+  - type: Sprite
+    sprite: Clothing/Ears/Headsets/command.rsi
+  - type: Clothing
+    sprite: Clothing/Ears/Headsets/command.rsi
+
+- type: entity
+  parent: ClothingHeadsetAlt
+  id: ClothingHeadsetAltERTEngineer
+  name: ERT engineer over-ear headset
+  components:
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - EncryptionKeyERT
+      - EncryptionKeyEngineering
+  - type: Sprite
+    sprite: Clothing/Ears/Headsets/engineering.rsi
+  - type: Clothing
+    sprite: Clothing/Ears/Headsets/engineering.rsi
+
+- type: entity
+  parent: ClothingHeadsetAlt
+  id: ClothingHeadsetAltERTMedic
+  name: ERT medic over-ear headset
+  components:
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - EncryptionKeyERT
+      - EncryptionKeyMedical
+  - type: Sprite
+    sprite: Clothing/Ears/Headsets/medical.rsi
+  - type: Clothing
+    sprite: Clothing/Ears/Headsets/medical.rsi
+
+- type: entity
+  parent: ClothingHeadsetAlt
+  id: ClothingHeadsetAltERTSecurity
+  name: ERT security over-ear headset
+  components:
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - EncryptionKeyERT
+      - EncryptionKeySecurity
+  - type: Sprite
+    sprite: Clothing/Ears/Headsets/security.rsi
+  - type: Clothing
+    sprite: Clothing/Ears/Headsets/security.rsi

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Devices/encryption_keys.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Devices/encryption_keys.yml
@@ -13,3 +13,17 @@
   - type: Sprite
     sprite: Objects/Devices/encryption_keys.rsi
     state: sci_cypherkey
+
+- type: entity
+  parent: EncryptionKey
+  id: EncryptionKeyERT
+  name: ERT encryption key
+  description: An encryption key used by members of ERT squads to communicate.
+  components:
+  - type: EncryptionKey
+    channels:
+    - CentCom
+    defaultChannel: CentCom
+  - type: Sprite
+    sprite: Objects/Devices/encryption_keys.rsi
+    state: bin_cypherkey

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Devices/pda.yml
@@ -128,7 +128,7 @@
   parent: BasePDA
   id: ERTLeaderPDA
   name: ERT Leader PDA
-  description: Red for firepower.
+  description: Red for the firepower.
   components:
   - type: PDA
     id: ERTLeaderIDCard
@@ -143,7 +143,7 @@
   parent: BasePDA
   id: ERTJanitorPDA
   name: ERT Janitor PDA
-  description: Red for blood you have to mop.
+  description: Red for the mopped blood.
   components:
   - type: PDA
     id: ERTJanitorIDCard

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Devices/pda.yml
@@ -126,21 +126,6 @@
 
 - type: entity
   parent: BasePDA
-  id: ERTLeaderPDA
-  name: ERT Leader PDA
-  description: Red for the firepower.
-  components:
-  - type: PDA
-    id: ERTLeaderIDCard
-    state: pda-ert
-  - type: PDABorderColor
-    borderColor: "#A32D26"
-    accentHColor: "#447987"
-  - type: Icon
-    state: pda-ert
-
-- type: entity
-  parent: BasePDA
   id: ERTJanitorPDA
   name: ERT Janitor PDA
   description: Red for the mopped blood.

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Devices/pda.yml
@@ -123,3 +123,78 @@
     state: pda-security
   - type: Icon
     state: pda-guard
+
+- type: entity
+  parent: BasePDA
+  id: ERTLeaderPDA
+  name: ERT Leader PDA
+  description: Red for firepower.
+  components:
+  - type: PDA
+    id: ERTLeaderIDCard
+    state: pda-ert
+  - type: PDABorderColor
+    borderColor: "#A32D26"
+    accentHColor: "#447987"
+  - type: Icon
+    state: pda-ert
+
+- type: entity
+  parent: BasePDA
+  id: ERTJanitorPDA
+  name: ERT Janitor PDA
+  description: Red for blood you have to mop.
+  components:
+  - type: PDA
+    id: ERTJanitorIDCard
+    state: pda-ert
+  - type: PDABorderColor
+    borderColor: "#A32D26"
+    accentHColor: "#447987"
+  - type: Icon
+    state: pda-ert
+
+- type: entity
+  parent: BasePDA
+  id: ERTSecurityPDA
+  name: ERT Security PDA
+  description: Red for the law.
+  components:
+  - type: PDA
+    id: ERTSecurityIDCard
+    state: pda-ert
+  - type: PDABorderColor
+    borderColor: "#A32D26"
+    accentHColor: "#447987"
+  - type: Icon
+    state: pda-ert
+
+- type: entity
+  parent: BasePDA
+  id: ERTMedicPDA
+  name: ERT Medic PDA
+  description: Red for the blood of patients.
+  components:
+  - type: PDA
+    id: ERTMedicIDCard
+    state: pda-ert
+  - type: PDABorderColor
+    borderColor: "#A32D26"
+    accentHColor: "#447987"
+  - type: Icon
+    state: pda-ert
+
+- type: entity
+  parent: BasePDA
+  id: ERTEngineerPDA
+  name: ERT Engineer PDA
+  description: Red for the hard work.
+  components:
+  - type: PDA
+    id: ERTEngineerIDCard
+    state: pda-ert
+  - type: PDABorderColor
+    borderColor: "#A32D26"
+    accentHColor: "#447987"
+  - type: Icon
+    state: pda-ert

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Misc/identification_cards.yml
@@ -1,0 +1,108 @@
+- type: entity
+  parent: CentcomIDCard
+  id: ERTLeaderIDCard
+  name: ERT Leader ID card
+  components:
+  - type: Sprite
+    layers:
+    - state: gold
+    - state: ert_commander
+  - type: IdCard
+    jobTitle: ert commander
+  - type: Item
+    heldPrefix: gold
+
+- type: entity
+  parent: IDCardStandard
+  id: ERTJanitorIDCard
+  name: ERT Janitor ID card
+  components:
+  - type: Sprite
+    layers:
+    - state: ert_janitor
+  - type: IdCard
+    jobTitle: ert janitor
+  - type: Item
+    heldPrefix: blue
+  - type: Access
+    tags:
+    - Bar
+    - Kitchen
+    - Hydroponics
+    - Service
+    - Janitor
+    - Theatre
+    - Chapel
+    - Cargo
+    - Mail
+    - Maintenance
+    - External
+
+- type: entity
+  parent: IDCardStandard
+  id: ERTEngineerIDCard
+  name: ERT Engineer ID card
+  components:
+  - type: Sprite
+    layers:
+    - state: ert_engineer
+  - type: IdCard
+    jobTitle: ert engineer
+  - type: Item
+    heldPrefix: blue
+  - type: Access
+    tags:
+    - ChiefEngineer
+    - Engineering
+    - Salvage
+    - Atmospherics
+    - Cargo
+    - Mail
+    - Maintenance
+    - External
+
+- type: entity
+  parent: IDCardStandard
+  id: ERTMedicIDCard
+  name: ERT Medic ID card
+  components:
+  - type: Sprite
+    layers:
+    - state: ert_medic
+  - type: IdCard
+    jobTitle: ert medic
+  - type: Item
+    heldPrefix: blue
+  - type: Access
+    tags:
+    - ChiefMedicalOfficer
+    - Medical
+    - Chemistry
+    - Cargo
+    - Mail
+    - Maintenance
+    - External
+
+- type: entity
+  parent: IDCardStandard
+  id: ERTSecurityIDCard
+  name: ERT Security ID card
+  components:
+  - type: Sprite
+    layers:
+    - state: ert_security
+  - type: IdCard
+    jobTitle: ert security
+  - type: Item
+    heldPrefix: blue
+  - type: Access
+    tags:
+    - HeadOfSecurity
+    - Brig
+    - Security
+    - Armory
+    - Detective
+    - Cargo
+    - Mail
+    - Maintenance
+    - External

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Misc/identification_cards.yml
@@ -1,18 +1,4 @@
 - type: entity
-  parent: CentcomIDCard
-  id: ERTLeaderIDCard
-  name: ERT Leader ID card
-  components:
-  - type: Sprite
-    layers:
-    - state: gold
-    - state: ert_commander
-  - type: IdCard
-    jobTitle: ert commander
-  - type: Item
-    heldPrefix: gold
-
-- type: entity
   parent: IDCardStandard
   id: ERTJanitorIDCard
   name: ERT Janitor ID card

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Misc/identification_cards.yml
@@ -57,7 +57,6 @@
     - Salvage
     - Atmospherics
     - Cargo
-    - Mail
     - Maintenance
     - External
 
@@ -79,7 +78,6 @@
     - Medical
     - Chemistry
     - Cargo
-    - Mail
     - Maintenance
     - External
 
@@ -103,6 +101,5 @@
     - Armory
     - Detective
     - Cargo
-    - Mail
     - Maintenance
     - External

--- a/Resources/Prototypes/Roles/Jobs/Fun/emergencyresponseteam.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/emergencyresponseteam.yml
@@ -5,7 +5,7 @@
   description: job-description-ertleader
   playTimeTracker: JobERTLeader
   setPreference: false
-  startingGear: ERTLeaderGearEVA
+  startingGear: ERTLeaderGear
   icon: "Nanotrasen"
   supervisors: job-supervisors-centcom
   canBeAntag: false
@@ -19,11 +19,11 @@
     back: ClothingBackpackERTLeaderFilled
     shoes: ClothingShoesBootsJack
     head: ClothingHeadHelmetHelmet
-    eyes: ClothingEyesGlassesSecurity
+    eyes: ClothingEyesGlassesSunglasses
     gloves: ClothingHandsGlovesColorBlack
     outerclothing: ClothingOuterVestKevlar
     id: ERTLeaderPDA
-    ears: ClothingHeadsetAltCommand
+    ears: ClothingHeadsetAltERTLeader
     belt: ClothingBeltSecurityWebbing
     pocket1: Flare
 
@@ -34,12 +34,12 @@
     back: ClothingBackpackERTLeaderFilled
     shoes: ClothingShoesBootsMag
     mask: ClothingMaskBreath
-    eyes: ClothingEyesGlassesSecurity
+    eyes: ClothingEyesGlassesSunglasses
     gloves: ClothingHandsGlovesColorBlack
     outerClothing: ClothingOuterHardsuitERTLeader
     suitStorage: OxygenTankFilled
     id: ERTLeaderPDA
-    ears: ClothingHeadsetAltCommand
+    ears: ClothingHeadsetAltERTLeader
     belt: ClothingBeltSecurityFilled
     pocket1: Flare
 
@@ -50,7 +50,7 @@
   description: job-description-ertengineer
   playTimeTracker: JobERTEngineer
   setPreference: false
-  startingGear: ERTEngineerGearEVA
+  startingGear: ERTEngineerGear
   icon: "Nanotrasen"
   supervisors: job-supervisors-centcom
   canBeAntag: false
@@ -68,8 +68,8 @@
     gloves: ClothingHandsGlovesColorYellow
     outerClothing: ClothingOuterVestKevlar
     id: ERTLeaderPDA
-    ears: ClothingHeadsetAltCommand
-    belt: ClothingBeltChiefEngineerFilled
+    ears: ClothingHeadsetAltERTEngineer
+    belt: ClothingBeltUtilityFilled
     pocket1: Flare
 
 - type: startingGear
@@ -77,15 +77,15 @@
   equipment:
     jumpsuit: ClothingUniformJumpsuitERTEngineer
     back: ClothingBackpackERTEngineerFilled
-    shoes: ClothingShoesBootsMagAdv
+    shoes: ClothingShoesBootsMag
     mask: ClothingMaskBreath
     eyes: ClothingEyesGlassesMeson
     gloves: ClothingHandsGlovesColorYellow
     outerClothing: ClothingOuterHardsuitERTEngineer
     suitStorage: OxygenTankFilled
     id: ERTLeaderPDA
-    ears: ClothingHeadsetAltCommand
-    belt: ClothingBeltChiefEngineerFilled
+    ears: ClothingHeadsetAltERTEngineer
+    belt: ClothingBeltUtilityFilled
     pocket1: Flare
 
 # Security
@@ -95,7 +95,7 @@
   description: job-description-ertsecurity
   playTimeTracker: JobERTSecurity
   setPreference: false
-  startingGear: ERTEngineerGearEVA
+  startingGear: ERTSecurityGear
   icon: "Nanotrasen"
   supervisors: job-supervisors-centcom
   canBeAntag: false
@@ -113,8 +113,8 @@
     gloves: ClothingHandsGlovesColorBlack
     outerClothing: ClothingOuterVestKevlar
     id: ERTLeaderPDA
-    ears: ClothingHeadsetAltCommand
-    belt: ClothingBeltSecurityWebbing
+    ears: ClothingHeadsetAltERTSecurity
+    belt: ClothingBeltSecurityFilled
     pocket1: Flare
 
 - type: startingGear
@@ -129,8 +129,8 @@
     outerClothing: ClothingOuterHardsuitERTSecurity
     suitStorage: OxygenTankFilled
     id: ERTLeaderPDA
-    ears: ClothingHeadsetAltCommand
-    belt: ClothingBeltSecurityWebbing
+    ears: ClothingHeadsetAltERTSecurity
+    belt: ClothingBeltSecurityFilled
     pocket1: Flare
 
 # Medical
@@ -140,7 +140,7 @@
   description: job-description-ertmedic
   playTimeTracker: JobERTMedical
   setPreference: false
-  startingGear: ERTMedicalGearEVA
+  startingGear: ERTMedicalGear
   icon: "Nanotrasen"
   supervisors: job-supervisors-centcom
   canBeAntag: false
@@ -155,10 +155,10 @@
     shoes: ClothingShoesBootsJack
     head: ClothingHeadHelmetHelmet
     eyes: ClothingEyesHudMedical
-    gloves: ClothingHandsGlovesColorBlack
+    gloves: ClothingHandsGlovesNitrile
     outerClothing: ClothingOuterVestKevlar
     id: ERTLeaderPDA
-    ears: ClothingHeadsetAltCommand
+    ears: ClothingHeadsetAltERTMedic
     belt: ClothingBeltMedicalFilled
     pocket1: HandheldHealthAnalyzer
     pocket2: Flare
@@ -171,11 +171,11 @@
     shoes: ClothingShoesBootsMag
     mask: ClothingMaskBreath
     eyes: ClothingEyesHudMedical
-    gloves: ClothingHandsGlovesColorBlack
+    gloves: ClothingHandsGlovesNitrile
     outerClothing: ClothingOuterHardsuitERTMedical
     suitStorage: OxygenTankFilled
     id: ERTLeaderPDA
-    ears: ClothingHeadsetAltCommand
+    ears: ClothingHeadsetAltERTMedic
     belt: ClothingBeltMedicalFilled
     pocket1: HandheldHealthAnalyzer
     pocket2: Flare
@@ -187,7 +187,7 @@
   description: job-description-ertjanitor
   playTimeTracker: JobERTJanitor
   setPreference: false
-  startingGear: ERTJanitorGearEVA
+  startingGear: ERTJanitorGear
   icon: "Nanotrasen"
   supervisors: job-supervisors-centcom
   canBeAntag: false
@@ -201,12 +201,14 @@
     back: ClothingBackpackERTJanitorFilled
     shoes: ClothingShoesGaloshes
     head: ClothingHeadHelmetHelmet
-    gloves: ClothingHandsGlovesColorBlack
+    eyes: ClothingEyesGlassesSunglasses
+    gloves: ClothingHandsGlovesColorYellowBudget
     outerClothing: ClothingOuterVestKevlar
     id: ERTLeaderPDA
-    ears: ClothingHeadsetAltCommand
+    ears: ClothingHeadsetAltERTJanitor
     belt: ClothingBeltJanitorFilled
-    pocket1: Flare
+    pocket1: SprayBottleSpaceCleaner
+    pocket2: Flare
 
 - type: startingGear
   id: ERTJanitorGearEVA
@@ -215,10 +217,12 @@
     back: ClothingBackpackERTJanitorFilled
     shoes: ClothingShoesBootsMag
     mask: ClothingMaskBreath
-    gloves: ClothingHandsGlovesColorBlack
+    eyes: ClothingEyesGlassesSunglasses
+    gloves: ClothingHandsGlovesColorYellowBudget
     outerClothing: ClothingOuterHardsuitERTJanitor
     suitStorage: OxygenTankFilled
     id: ERTLeaderPDA
-    ears: ClothingHeadsetAltCommand
+    ears: ClothingHeadsetAltERTJanitor
     belt: ClothingBeltJanitorFilled
-    pocket1: Flare
+    pocket1: SprayBottleSpaceCleaner
+    pocket2: Flare

--- a/Resources/Prototypes/Roles/Jobs/Fun/emergencyresponseteam.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/emergencyresponseteam.yml
@@ -67,7 +67,7 @@
     eyes: ClothingEyesGlassesMeson
     gloves: ClothingHandsGlovesColorYellow
     outerClothing: ClothingOuterVestKevlar
-    id: ERTLeaderPDA
+    id: ERTEngineerPDA
     ears: ClothingHeadsetAltERTEngineer
     belt: ClothingBeltUtilityFilled
     pocket1: Flare
@@ -83,7 +83,7 @@
     gloves: ClothingHandsGlovesColorYellow
     outerClothing: ClothingOuterHardsuitERTEngineer
     suitStorage: OxygenTankFilled
-    id: ERTLeaderPDA
+    id: ERTEngineerPDA
     ears: ClothingHeadsetAltERTEngineer
     belt: ClothingBeltUtilityFilled
     pocket1: Flare
@@ -112,7 +112,7 @@
     eyes: ClothingEyesGlassesSecurity
     gloves: ClothingHandsGlovesColorBlack
     outerClothing: ClothingOuterVestKevlar
-    id: ERTLeaderPDA
+    id: ERTSecurityPDA
     ears: ClothingHeadsetAltERTSecurity
     belt: ClothingBeltSecurityFilled
     pocket1: Flare
@@ -128,7 +128,7 @@
     gloves: ClothingHandsGlovesColorBlack
     outerClothing: ClothingOuterHardsuitERTSecurity
     suitStorage: OxygenTankFilled
-    id: ERTLeaderPDA
+    id: ERTEngineerPDA
     ears: ClothingHeadsetAltERTSecurity
     belt: ClothingBeltSecurityFilled
     pocket1: Flare
@@ -157,7 +157,7 @@
     eyes: ClothingEyesHudMedical
     gloves: ClothingHandsGlovesNitrile
     outerClothing: ClothingOuterVestKevlar
-    id: ERTLeaderPDA
+    id: ERTMedicalPDA
     ears: ClothingHeadsetAltERTMedic
     belt: ClothingBeltMedicalFilled
     pocket1: HandheldHealthAnalyzer
@@ -174,7 +174,7 @@
     gloves: ClothingHandsGlovesNitrile
     outerClothing: ClothingOuterHardsuitERTMedical
     suitStorage: OxygenTankFilled
-    id: ERTLeaderPDA
+    id: ERTMedicalPDA
     ears: ClothingHeadsetAltERTMedic
     belt: ClothingBeltMedicalFilled
     pocket1: HandheldHealthAnalyzer
@@ -204,7 +204,7 @@
     eyes: ClothingEyesGlassesSunglasses
     gloves: ClothingHandsGlovesColorYellowBudget
     outerClothing: ClothingOuterVestKevlar
-    id: ERTLeaderPDA
+    id: ERTLJanitorPDA
     ears: ClothingHeadsetAltERTJanitor
     belt: ClothingBeltJanitorFilled
     pocket1: SprayBottleSpaceCleaner
@@ -221,7 +221,7 @@
     gloves: ClothingHandsGlovesColorYellowBudget
     outerClothing: ClothingOuterHardsuitERTJanitor
     suitStorage: OxygenTankFilled
-    id: ERTLeaderPDA
+    id: ERTLJanitorPDA
     ears: ClothingHeadsetAltERTJanitor
     belt: ClothingBeltJanitorFilled
     pocket1: SprayBottleSpaceCleaner


### PR DESCRIPTION
## About the PR
Somebody suggested ERT changes so I did it, plus some extra.
I don't expect this to be a thing because the original ERT concept is dumb but I had time to spare.

An attempt at making Emergency Response Team less a team of heavily armed individuals that are geared with weapons and Head of Department level items, and access, to a team of slightly more protected than your average joe with the tools that would fit their role.

Some would argue that this goes against the ERT logic of "Heavy weaponized emergency team to deal with any sort of problems" but if there's a need for heavy weaponized teams, there's already deathsquads or providing them a crate of pew pews.

This could make them more interesting to deploy in emergencies where they don't have to shoot everything that moves, as they can fix/clean/deal with prisoners/provide health care then extract without admins feeling like they deployed a walking loot box of weapons ripe for the stealing.

This overrides quite a bit of upstream stuff so also probably not a good idea.
This does the following:
- Give every ERT member a Cryptobiolin pill. They are aware of the glimmer effects.
- Nerf the ERT Backpack to the capacity of a duffel bag.
- Each ERT Member, except leader, now has a new headset that only has access to their department and the centcom channel.
- All ERT starting loadout is no longer the EVA one.
- Each ERT Member, except leader, have a new PDA and ID that only provide access to specific areas of the station related to their job.
  - This means that outside emergencies they are limited to their job's access, in emergencies they have to stay together.
- Modify the Leader's Loadout to the following:
  - Backpack now contains:
    - Pulse Pistol, they are still the commander after all
    - Disabler
    - Stunbaton
    - Handcuffs
  - Replaces their Security Glasses with Sunglasses
- Modify the Medic's Loadout to the following:
  - Backpack now contains:
    - Oxygen Deprivation Kit
    - Epinephrine bottle with an empty Syringe to use it
    - Gauze
    - 2 AntiPoison Medipen
    - 2 Hyronalin pills and 2 Iron pill.
  - Replaces their gloves with Nitrile Gloves
- Modify the Engineer's Loadout to the following:
  - Backpack now contains:
    - tray Scanner
    - HV, MV, LV Cable stacks
    - 30 Steel and 30 Metal Rods for quick repairs. You can scavenge more.
    - 10 Inflatable Walls and 4 Inflatable Doors
  - Replaces their CE Belt with a normal filled utility belt.
  - Their EVA variant no longer use the CE Mag Boots.
- Modify the Security's Loadout to the following:
  - Backpack now contains:
    - Disabler
    - A Box of Handcuffs
  - Replaces their empty webbing with a filled Security Belt.
- Modify the Janitor's Loadout to the following:
  - Backpack now contains:
    - A damn mop.
    - 2 Boxes of Mixed Lights
    - 1 Soap
  - Replaces their gloves with the yellow budget gloves
  - They get cool sunglasses because they deserve it

**Media**
![ss (2023-02-18 at 06 54 39)](https://user-images.githubusercontent.com/9823203/219881732-d3b594ea-287f-4527-ba00-c02e6c0ed317.png)
![ss (2023-02-18 at 06 54 43)](https://user-images.githubusercontent.com/9823203/219881746-0a19a810-cb12-49d7-8d36-f9f69fa69f16.png)
![ss (2023-02-18 at 06 52 41)](https://user-images.githubusercontent.com/9823203/219881759-fa31d5f7-8fd9-4f76-ba71-eeced850ed1f.png)


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Fixed fun.

