### PR TITLE
Fix some door issues.

### DIFF
--- a/Content.Server/Doors/WireActions/DoorBoltWireAction.cs
+++ b/Content.Server/Doors/WireActions/DoorBoltWireAction.cs
@@ -28,7 +28,7 @@ public sealed class DoorBoltWireAction : ComponentWireAction<AirlockComponent>
 
     public override bool Mend(EntityUid user, Wire wire, AirlockComponent door)
     {
-        EntityManager.System<SharedAirlockSystem>().SetBoltWireCut(door, true);
+        EntityManager.System<SharedAirlockSystem>().SetBoltWireCut(door, false);
         return true;
     }
 

--- a/Content.Server/Remotes/DoorRemoteSystem.cs
+++ b/Content.Server/Remotes/DoorRemoteSystem.cs
@@ -91,12 +91,12 @@ namespace Content.Server.Remotes
                 case OperatingMode.ToggleBolts:
                     if (!airlockComp.BoltWireCut)
                     {
-                        _airlock.SetBoltsWithAudio(uid, airlockComp, !airlockComp.BoltsDown);
+                        _airlock.SetBoltsWithAudio(args.Target.Value, airlockComp, !airlockComp.BoltsDown);
                         _adminLogger.Add(LogType.Action, LogImpact.Medium, $"{ToPrettyString(args.User):player} used {ToPrettyString(args.Used)} on {ToPrettyString(args.Target.Value)} to {(airlockComp.BoltsDown ? "" : "un")}bolt it");
                     }
                     break;
                 case OperatingMode.ToggleEmergencyAccess:
-                    _airlock.ToggleEmergencyAccess(uid, airlockComp);
+                    _airlock.ToggleEmergencyAccess(args.Target.Value, airlockComp);
                     _adminLogger.Add(LogType.Action, LogImpact.Medium, $"{ToPrettyString(args.User):player} used {ToPrettyString(args.Used)} on {ToPrettyString(args.Target.Value)} to set emergency access {(airlockComp.EmergencyAccess ? "on" : "off")}");
                     break;
                 default:

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
@@ -116,5 +116,6 @@
     group: Standard
   - type: DynamicPrice
     price: 150
+  - type: AccessReader
   placement:
     mode: SnapgridCenter


### PR DESCRIPTION
Some simple door fixes. Mending a bolt wire wasn't actually setting it to mended. Door remotes were targetting themselves in 2/3 situations. Added a blank AccessReader component to Airlock so the AccessWireAction, which is a ComponentWireAction<AccessReader> can actually work. This means people can cut the access wire on any airlock now to deconstruct it.

To elaborate a little more on that last part: there were airlocks that did not have AccessReader components, thus open to all, and those airlocks in particular could not be deconstructed because the deconstruction of an airlock requires all wires to be cut, and the access wire could not be cut because it is dependent on that component. It's just how ComponentWireAction works apparently.

:cl:
- fix: Door remote bolting and emergency access toggle will work properly on airlocks again.
- fix: Doors that did not have access restrictions should be deconstructible again.
- fix: Doors that had their bolt wire cut will no longer immediately bolt when power is restored.

