### PR TITLE
Fix survival round summary invalid end color tag.

### DIFF
--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-survival.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-survival.ftl
@@ -2,5 +2,5 @@ survival-title = Survival
 survival-description = No internal threats, but how long can the station survive increasingly chaotic and frequent events?
 
 survival-round-end-result = The crew had to survive for {$minutes} minutes.
-survival-success = [color=green]Success![/color=green]
+survival-success = [color=green]Success![/color]
 survival-failure = [color=red]Failure![/color] ({$progress}%)


### PR DESCRIPTION

:cl:
- fix: The survival round end summary should appear again when the crew is successful.
