### PR TITLE
fix mind swap interacting with components that use MindAdded subscrip…

### DIFF
--- a/Content.Server/GameTicking/Rules/Components/NukeOperativeComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/NukeOperativeComponent.cs
@@ -6,5 +6,6 @@ namespace Content.Server.GameTicking.Rules.Components;
 [RegisterComponent]
 public sealed class NukeOperativeComponent : Component
 {
-
+    [DataField("firstMindAdded")]
+    public bool FirstMindAdded = false;
 }

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -588,6 +588,11 @@ public sealed class NukeopsRuleSystem : GameRuleSystem
         if (!TryComp<MindComponent>(uid, out var mindComponent) || mindComponent.Mind == null)
             return;
 
+        if (component.FirstMindAdded)
+            return;
+
+        component.FirstMindAdded = true;
+
         var mind = mindComponent.Mind;
 
         if (_operativeMindPendingData.TryGetValue(uid, out var role))

--- a/Content.Server/Nyanotrasen/EvilTwin/EvilTwinComponent.cs
+++ b/Content.Server/Nyanotrasen/EvilTwin/EvilTwinComponent.cs
@@ -6,5 +6,8 @@ namespace Content.Server.EvilTwin
     public sealed class EvilTwinComponent : Component
     {
         public Mind.Mind? TwinMind;
+
+        [DataField("firstMindAdded")]
+        public bool FirstMindAdded = false;
     }
 }

--- a/Content.Server/Nyanotrasen/EvilTwin/EvilTwinSystem.cs
+++ b/Content.Server/Nyanotrasen/EvilTwin/EvilTwinSystem.cs
@@ -64,6 +64,11 @@ namespace Content.Server.EvilTwin
             if (!TryComp<MindComponent>(uid, out var mindComponent) || mindComponent.Mind == null)
                 return;
 
+            if (component.FirstMindAdded)
+                return;
+
+            component.FirstMindAdded = true;
+
             var mind = mindComponent.Mind;
 
             mind.AddRole(new TraitorRole(mind, _prototypeManager.Index<AntagPrototype>(EvilTwinRole)));

--- a/Content.Server/Nyanotrasen/Fugitive/FugitiveComponent.cs
+++ b/Content.Server/Nyanotrasen/Fugitive/FugitiveComponent.cs
@@ -7,5 +7,8 @@ namespace Content.Server.Fugitive
     {
         [DataField("spawnSound")]
         public SoundSpecifier SpawnSoundPath = new SoundPathSpecifier("/Audio/Effects/clang.ogg");
+
+        [DataField("firstMindAdded")]
+        public bool FirstMindAdded = false;
     }
 }

--- a/Content.Server/Nyanotrasen/Fugitive/FugitiveSystem.cs
+++ b/Content.Server/Nyanotrasen/Fugitive/FugitiveSystem.cs
@@ -102,6 +102,11 @@ namespace Content.Server.Fugitive
             if (!TryComp<MindComponent>(uid, out var mindComponent) || mindComponent.Mind == null)
                 return;
 
+            if (component.FirstMindAdded)
+                return;
+
+            component.FirstMindAdded = true;
+
             var mind = mindComponent.Mind;
 
             mind.AddRole(new TraitorRole(mind, _prototypeManager.Index<AntagPrototype>(FugitiveRole)));


### PR DESCRIPTION
:cl: Rane
- fix: Mind swapping entities that do stuff when a mind is attached (nuke ops, fugi, etc.) should work again.

