### PR TITLE
move hand teleporter from round start to teleportation tech

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -137,7 +137,6 @@
       - id: ClothingNeckCloakRd
       - id: ClothingHeadsetMedicalScience
       - id: ClothingOuterHardsuitRd
-      - id: HandTeleporter
       - id: PlushieSlime
         prob: 0.1
       - id: DoorRemoteResearch

--- a/Resources/Prototypes/Catalog/Research/technologies.yml
+++ b/Resources/Prototypes/Catalog/Research/technologies.yml
@@ -674,9 +674,10 @@
   icon:
     sprite: Nyanotrasen/Objects/Devices/QSI.rsi
     state: icon
-  requiredPoints: 10000
+  requiredPoints: 15000
   requiredTechnologies:
     - SuperPartsTechnology
     - AnomalyTechnology
   unlockedRecipes:
     - QSI
+    - HandTeleporter

--- a/Resources/Prototypes/Entities/Objects/Devices/hand_teleporter.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/hand_teleporter.yml
@@ -9,3 +9,7 @@
     layers:
     - state: icon
   - type: HandTeleporter
+  - type: ReverseEngineering
+    difficulty: 4
+    recipes:
+      - HandTeleporter

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Devices/qsi.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Devices/qsi.yml
@@ -8,3 +8,7 @@
   - type: Sprite
     sprite: Nyanotrasen/Objects/Devices/QSI.rsi
     state: icon
+  - type: ReverseEngineering
+    difficulty: 4
+    recipes:
+      - QSI

--- a/Resources/Prototypes/Nyanotrasen/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Structures/Machines/lathe.yml
@@ -25,6 +25,7 @@
     runningState: icon
     dynamicRecipes:
       - QSI
+      - HandTeleporter
       - BluespaceBeaker
       - Decloner
       - CryostasisBeaker

--- a/Resources/Prototypes/Nyanotrasen/Recipes/Lathes/bluespace.yml
+++ b/Resources/Prototypes/Nyanotrasen/Recipes/Lathes/bluespace.yml
@@ -11,6 +11,19 @@
     Plastic: 250
 
 - type: latheRecipe
+  id: HandTeleporter
+  icon:
+    sprite: /Textures/Objects/Devices/hand_teleporter.rsi
+    state: icon
+  result: HandTeleporter
+  completetime: 8
+  materials:
+    Bluespace: 600
+    Steel: 200
+    Plastic: 200
+    Gold: 200
+
+- type: latheRecipe
   id: BluespaceBeaker
   icon:
     sprite: Objects/Specific/Chemistry/beaker_bluespace.rsi

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -20,7 +20,6 @@
     MantisKnifeStealObjective: 1
     CaptainGunStealObjective: 0.5
     CaptainJetpackStealObjective: 0.5
-    HandTeleporterStealObjective: 0.5
 
 - type: weightedRandom
   id: TraitorObjectiveGroupKill

--- a/Resources/Prototypes/Objectives/traitorObjectives.yml
+++ b/Resources/Prototypes/Objectives/traitorObjectives.yml
@@ -109,20 +109,6 @@
       owner: job-name-mystagogue
 
 - type: objective
-  id: HandTeleporterStealObjective
-  issuer: syndicate
-  difficultyOverride: 2.75
-  requirements:
-  - !type:TraitorRequirement {}
-  - !type:IncompatibleConditionsRequirement
-    conditions:
-    - DieCondition
-  conditions:
-  - !type:StealCondition
-    prototype: HandTeleporter
-    owner: job-name-mystagogue
-
-- type: objective
   id: NukeDiskStealObjective
   issuer: syndicate
   requirements:


### PR DESCRIPTION
:cl: Rane
- remove: MG no longer starts with a hand teleporter.
- add: Hand teleporters can be research with teleportation technology, and can be reverse engineered.