### PR TITLE
Walter spawner removal Pebble

### DIFF
--- a/Resources/Maps/pebble.yml
+++ b/Resources/Maps/pebble.yml
@@ -14037,8 +14037,8 @@ entities:
     - volume: 2500
       temperature: 293.15
       moles:
-      - 15.969111
-      - 60.07428
+      - 15.521976
+      - 58.3922
       - 0
       - 0
       - 0
@@ -14067,8 +14067,8 @@ entities:
     - volume: 2500
       temperature: 235
       moles:
-      - 15.969111
-      - 60.07428
+      - 15.521976
+      - 58.3922
       - 0
       - 0
       - 0
@@ -14082,8 +14082,8 @@ entities:
     - volume: 2500
       temperature: 293.15
       moles:
-      - 17.89022
-      - 67.30131
+      - 17.389294
+      - 65.41687
       - 0
       - 0
       - 0
@@ -53237,12 +53237,6 @@ entities:
     type: Transform
   - color: '#990000FF'
     type: AtmosPipeColor
-- uid: 5656
-  type: SpawnMobWalter
-  components:
-  - pos: -16.5,11.5
-    parent: 7
-    type: Transform
 - uid: 5657
   type: APCBasic
   components:


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Walter has been removed from chemistry since he loved eating machines.
