### PR TITLE
Fix typo in holy water tip

### DIFF
--- a/Resources/Prototypes/Datasets/tips.yml
+++ b/Resources/Prototypes/Datasets/tips.yml
@@ -71,5 +71,5 @@
   - "You can perform CPR by using an empty hand on someone in critical condition."
   - "The metempsychotic machine's chance to reincarnate you into a humanoid is guaranteed for a number of times equal to its scanning module tier."
   - "Glimmer wisps will only attack you if they detect you are psionic, or you aggravate them by damaging them or dragging away a body they are trying to drain."
-  - "Bibles, holy water, and the anti-psychic knife can deal holy damage, which has strong effects some creatures."
+  - "Bibles, holy water, and the anti-psychic knife can deal holy damage, which has strong effects against some creatures."
   - "Ectoplasm is used in the recipe for normality crystals."


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Just adds "against" in the tip text.

"Bibles, holy water, and the anti-psychic knife can deal holy damage, which has strong effects against some creatures."

**Changelog**
Irrelevant.

