### PR TITLE
Nerf Lightbulbs

### DIFF
--- a/Content.Server/Light/Components/PoweredLightComponent.cs
+++ b/Content.Server/Light/Components/PoweredLightComponent.cs
@@ -66,6 +66,9 @@ namespace Content.Server.Light.Components
 
         public CancellationTokenSource? CancelToken;
 
+        //Delay for the lights interactions
+        public TimeSpan cooldownEnd;
+
         /// <summary>
         /// How long it takes to eject a bulb from this
         /// </summary>

--- a/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
@@ -42,8 +42,11 @@ namespace Content.Server.Light.EntitySystems
         [Dependency] private readonly DoAfterSystem _doAfterSystem = default!;
         [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
 
-        private static readonly TimeSpan ThunkDelay = TimeSpan.FromSeconds(2);
+        private static readonly TimeSpan ThunkDelay = TimeSpan.FromSeconds(value: 2);
+
         public const string LightBulbContainer = "light_bulb";
+
+        public TimeSpan cooldownEnd = TimeSpan.FromSeconds(value: 0);
 
         public override void Initialize()
         {
@@ -102,6 +105,15 @@ namespace Content.Server.Light.EntitySystems
             var bulbUid = GetBulb(uid, light);
             if (bulbUid == null)
                 return;
+
+            // delay the interaction by 2 seconds
+            var curTime = _gameTiming.CurTime;
+            if (curTime < cooldownEnd)
+            {
+                return;
+            }
+
+            cooldownEnd = curTime + TimeSpan.FromSeconds(2);
 
             // check if it's possible to apply burn damage to user
             var userUid = args.User;

--- a/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
@@ -42,11 +42,11 @@ namespace Content.Server.Light.EntitySystems
         [Dependency] private readonly DoAfterSystem _doAfterSystem = default!;
         [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
 
-        private static readonly TimeSpan ThunkDelay = TimeSpan.FromSeconds(value: 2);
+        private static readonly TimeSpan ThunkDelay = TimeSpan.FromSeconds(2);
 
         public const string LightBulbContainer = "light_bulb";
 
-        public TimeSpan cooldownEnd = TimeSpan.FromSeconds(value: 0);
+        public TimeSpan cooldownEnd = TimeSpan.FromSeconds(0);
 
         public override void Initialize()
         {

--- a/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
@@ -46,8 +46,6 @@ namespace Content.Server.Light.EntitySystems
 
         public const string LightBulbContainer = "light_bulb";
 
-        public TimeSpan cooldownEnd = TimeSpan.FromSeconds(0);
-
         public override void Initialize()
         {
             base.Initialize();
@@ -108,12 +106,6 @@ namespace Content.Server.Light.EntitySystems
 
             // delay the interaction by 2 seconds
             var curTime = _gameTiming.CurTime;
-            if (curTime < cooldownEnd)
-            {
-                return;
-            }
-
-            cooldownEnd = curTime + TimeSpan.FromSeconds(2);
 
             // check if it's possible to apply burn damage to user
             var userUid = args.User;
@@ -125,6 +117,15 @@ namespace Content.Server.Light.EntitySystems
 
                 // check heat resistance against user
                 var burnedHand = light.CurrentLit && res < lightBulb.BurningTemperature;
+
+                // check for interaction delay
+                if (curTime < light.cooldownEnd)
+                {
+                    return;
+                }
+
+                light.cooldownEnd = curTime + TimeSpan.FromSeconds(2);
+
                 if (burnedHand)
                 {
                     // apply damage to users hands and show message with sound

--- a/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
@@ -79,7 +79,7 @@
     bulb: Tube
     damage:
       types:
-        Heat: 5
+        Heat: 0.2
   - type: ContainerContainer
     containers:
       light_bulb: !type:ContainerSlot
@@ -112,7 +112,7 @@
     hasLampOnSpawn: LightTube
     damage:
       types:
-        Heat: 5
+        Heat: 0.2
 
 #LED lights
 - type: entity
@@ -125,7 +125,7 @@
     hasLampOnSpawn: LedLightTube
     damage:
       types:
-        Heat: 5
+        Heat: 0.2
 
 - type: entity
   parent: AlwaysPoweredWallLight
@@ -149,7 +149,7 @@
     hasLampOnSpawn: ExteriorLightTube
     damage:
       types:
-        Heat: 5
+        Heat: 0.2
 
 - type: entity
   parent: AlwaysPoweredWallLight
@@ -173,7 +173,7 @@
     hasLampOnSpawn: SodiumLightTube
     damage:
       types:
-        Heat: 5
+        Heat: 0.2
 
 - type: entity
   parent: AlwaysPoweredWallLight
@@ -255,7 +255,7 @@
     bulb: Bulb
     damage:
       types:
-        Heat: 5
+        Heat: 0.2
   - type: ApcPowerReceiver
   - type: ExtensionCableReceiver
   - type: DeviceNetwork
@@ -284,7 +284,7 @@
     hasLampOnSpawn: LightBulb
     damage:
       types:
-        Heat: 5
+        Heat: 0.2
 
 #Emergency Lights
 - type: entity

--- a/Resources/Prototypes/Nyanotrasen/Entities/Structures/Lighting/base_lighting.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Structures/Lighting/base_lighting.yml
@@ -8,4 +8,4 @@
     hasLampOnSpawn: BlueLightTube
     damage:
       types:
-        Heat: 5
+        Heat: 0.2

--- a/Resources/Prototypes/Nyanotrasen/Entities/Structures/Lighting/colored_lighting.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Structures/Lighting/colored_lighting.yml
@@ -10,7 +10,7 @@
     hasLampOnSpawn: ColoredLightTubeRed
     damage:
       types:
-        Heat: 5
+        Heat: 0.2
 
 - type: entity
   id: PoweredlightColoredFrostyBlue
@@ -22,7 +22,7 @@
     hasLampOnSpawn: ColoredLightTubeFrostyBlue
     damage:
       types:
-        Heat: 5
+        Heat: 0.2
 
 - type: entity
   id: PoweredlightColoredBlack
@@ -34,7 +34,7 @@
     hasLampOnSpawn: ColoredLightTubeBlackLight
     damage:
       types:
-        Heat: 5
+        Heat: 0.2
 
 - type: entity
   id: PoweredLightPostSmallRed
@@ -51,4 +51,4 @@
     hasLampOnSpawn: ColoredLightTubeRed
     damage:
       types:
-        Heat: 20
+        Heat: 2


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

![sun](https://user-images.githubusercontent.com/80334192/221943280-56803071-eea7-425e-a4ff-ac6fb6bf5184.jpg)


Wallmounted Lightbulbs will no longer cause 3rd degree burns, heat value changed from 5 to 0.2, maybe the only "issue" is rounding errors at the moment of calculating the damage but hopefully it isn't that much big of a deal.

You will need 500 clicks to the lightbulb to get yourself into crit, at that point if you manage to crit yourself with that you honestly deserve it.

**Changelog**

:cl:
- tweak: people will be able to touch the glossy incandescence of the lightbulbs for longer periods of time, moths rejoice! 

