### PR TITLE
rats no longer have door bump opener

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -299,7 +299,6 @@
   - type: Tag
     tags:
       - CannotSuicide
-      - DoorBumpOpener
       - FootstepSound
   - type: NoSlip
   - type: MobPrice


### PR DESCRIPTION
:cl: Rane
- fix: Rats no longer play the denied sound when they move under doors.

