### PR TITLE
Remove gatfruit seeds from salvage botanist loot locker.

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/service.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/service.yml
@@ -112,8 +112,6 @@
       - id: ClothingUniformOveralls
       - id: ClothingHeadHatTrucker
         prob: 0.3
-      - id: GatfruitSeeds
-        prob: 0.1
       - id: FlyAmanitaSeeds
         prob: 0.5
       - id: NettleSeeds


### PR DESCRIPTION
Missed one uplink item in the last PR regarding this.