### PR TITLE
Damage Adjustments

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -20,10 +20,10 @@
   - type: Clothing
     sprite: Clothing/Eyes/Glasses/gar.rsi
   - type: MeleeWeapon
-    attackRate: 1.5
+    attackRate: 1.1
     damage:
       types:
-        Blunt: 7
+        Blunt: 5
 
 - type: entity
   parent: ClothingEyesBase
@@ -42,7 +42,7 @@
   - type: MeleeWeapon
     damage:
       types:
-        Blunt: 10
+        Blunt: 5
 
 - type: entity
   parent: ClothingEyesBase
@@ -61,7 +61,7 @@
   - type: MeleeWeapon
     damage:
       types:
-        Blunt: 10
+        Blunt: 6
 
 - type: entity
   parent: ClothingEyesBase

--- a/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/tools.yml
@@ -53,6 +53,7 @@
     netsync: false
   - type: ItemCooldown
   - type: MeleeWeapon
+    range: 1.85
     damage:
       types:
         Slash: 7
@@ -85,8 +86,8 @@
     range: 1.4
     damage:
       types:
-        Slash: 8
-        Piercing: 3.5
+        Slash: 9
+        Piercing: 2.5
   - type: MeleeBloodletter
     bloodReduction:
       types:
@@ -111,8 +112,8 @@
   - type: MeleeWeapon
     damage:
       types:
-        Blunt: 8
-        Piercing: 3.5 # I guess you can stab it into them?
+        Blunt: 9
+        Slash: 2.5 # I guess you can stab it into them?
   - type: StaminaDamageOnHit
     damage: 5
   - type: Item

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
@@ -254,9 +254,8 @@
     bluntStaminaDamageFactor: 3.0
     damage:
       types:
-        Blunt: 3.5
-        Slash: 4.5
-        Piercing: 2
+        Blunt: 4.5
+        Slash: 5.5
     soundHit:
       path: /Audio/Items/drill_hit.ogg
   - type: MeleeBloodletter
@@ -287,9 +286,8 @@
     bluntStaminaDamageFactor: 5.0
     damage:
       types:
-        Blunt: 3.5
-        Slash: 6.5
-        Piercing: 2
+        Blunt: 4.5
+        Slash: 7.5
     soundHit:
       path: /Audio/Items/drill_hit.ogg
   - type: MeleeBloodletter

--- a/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
@@ -19,8 +19,8 @@
     bluntStaminaDamageFactor: 4.0
     damage:
       types:
-        Blunt: 6
-        Piercing: 10
+        Blunt: 11
+        Slash: 5
   - type: MeleeStaminaCost
     swing: 10
   - type: Clothing
@@ -65,8 +65,8 @@
     attackRate: 0.85
     damage:
       types:
-        Blunt: 8.5
-        Piercing: 10
+        Blunt: 13.5
+        Slash: 5
   - type: MultipleTool
     entries:
       - behavior: Prying

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -24,7 +24,7 @@
     range: 1.6
     damage:
       types:
-        Slash: 6.5
+        Blunt: 6.5
   - type: Tool
     qualities:
       - Cutting
@@ -66,7 +66,8 @@
     attackRate: 1.5
     damage:
       types:
-        Piercing: 7
+        Blunt: 5
+        Slash: 2
   - type: Tool
     qualities:
       - Screwing

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
@@ -25,7 +25,7 @@
   - type: MeleeBloodletter
     bloodReduction:
       types:
-        Slash: 20.0
+        Slash: 15.0
   - type: Wieldable
   - type: IncreaseDamageOnWield
     damage:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -22,7 +22,7 @@
   - type: MeleeBloodletter
     bloodReduction:
       types:
-        Slash: 15.0
+        Slash: 10.0
   - type: Sprite
     netsync: false
   - type: Item
@@ -71,7 +71,7 @@
   - type: MeleeBloodletter
     bloodReduction:
       types:
-        Slash: 19.0
+        Slash: 12.0
   - type: Item
     size: 10
     sprite: Objects/Weapons/Melee/cleaver.rsi
@@ -91,14 +91,15 @@
     size: 2
     state: icon
   - type: MeleeWeapon
-    attackRate: 1.5
+    attackRate: 1.35
+    range: 1.4
     damage:
       types:
-        Slash: 10
+        Slash: 9
   - type: MeleeBloodletter
     bloodReduction:
       types:
-        Slash: 23.0
+        Slash: 10.0
   - type: Item
     size: 10
     sprite: Objects/Weapons/Melee/combat_knife.rsi
@@ -112,12 +113,15 @@
   description: Weapon of first and last resort for combatting space carp.
   components:
   - type: MeleeWeapon
-    attackRate: 1.25
+    attackRate: 1
     range: 1.65
+    damage:
+      types:
+        Slash: 8
   - type: MeleeBloodletter
     bloodReduction:
       types:
-        Slash: 27.0
+        Slash: 17.0
   - type: Sprite
     sprite: Objects/Weapons/Melee/survival_knife.rsi
     size: 2

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/pickaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/pickaxe.yml
@@ -62,14 +62,14 @@
     bluntStaminaDamageFactor: 4.0
     damage:
       types:
-        Piercing: 7.5
-        Blunt: 7.5
+        Slash: 6
+        Blunt: 9
     soundHit:
       path: /Audio/Items/drill_hit.ogg
   - type: MeleeBloodletter
     bloodReduction:
       types:
-        Slash: 70.0
+        Slash: 65.0
   - type: MeleeStaminaCost
     swing: 15
   - type: StaminaDamageOnHit

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
@@ -16,13 +16,15 @@
     range: 2.0
     damage:
       types:
-        Piercing: 7
+        Slash: 6
+        Blunt: 3
     angle: 0
     animation: WeaponArcThrust
   - type: DamageOtherOnHit
     damage:
       types:
-        Piercing: 15
+        Slash: 11
+        Blunt: 3
   - type: Item
     size: 40
   - type: Clothing
@@ -49,7 +51,8 @@
   - type: IncreaseDamageOnWield
     damage:
       types:
-        Piercing: 7
+        Slash: 4
+        Blunt: 2
   - type: Damageable
     damageContainer: Inorganic
   - type: Destructible

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -17,7 +17,7 @@
   - type: MeleeBloodletter
     bloodReduction:
       types:
-        Slash: 25.0
+        Slash: 15.0
   - type: Item
     size: 15
     sprite: Objects/Weapons/Melee/captain_sabre.rsi
@@ -25,6 +25,7 @@
     tags:
     - CaptainSabre
   - type: DisarmMalus
+    malus: 0.25
 
 - type: entity
   name: katana
@@ -47,7 +48,7 @@
   - type: MeleeBloodletter
     bloodReduction:
       types:
-        Slash: 22.0
+        Slash: 12.0
   - type: Item
     size: 15
     sprite: Objects/Weapons/Melee/katana.rsi
@@ -74,7 +75,7 @@
   - type: MeleeBloodletter
     bloodReduction:
       types:
-        Slash: 30.0
+        Slash: 20.0
   - type: StaminaDamageOnHit
     damage: 15
   - type: MeleeStaminaCost
@@ -103,7 +104,7 @@
   - type: MeleeBloodletter
     bloodReduction:
       types:
-        Slash: 40.0
+        Slash: 30.0
   - type: MeleeStaminaCost
     swing: 10
     hit: 10


### PR DESCRIPTION
## About the PR 
Minor damage table adjustments

**Changelog**

:cl: Faye
- tweak: Reduced bloodletter values on most slashing weapons
- tweak: Removed Pierce damage type from several melee weapons due to upcoming gun+armor rebalances
- add: Added .25 disarm malice to captain's sabre
- tweak: Increased scythe range from 1.5 to 1.85

