### PR TITLE
Add 200 units of biomass to the medical supply crate.

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/medical.yml
@@ -23,6 +23,10 @@
         amount: 1
       - id: BoxMouthSwab
         amount: 1
+# > REVERT THIS COMMIT WHEN BIOMASS RECLAIMER DOAFTER WORKS AGAIN <
+      - id: MaterialBiomass
+        amount: 2
+# > <
 
 - type: entity
   id: CrateChemistrySupplies


### PR DESCRIPTION
This is a stopgap measure to make rounds better while we wait on a proper fix for the biomass reclaimer.

:cl:
- add: The medical supply crate now comes with 200 units of biomass, shipped out from CentCom to help stations with their malfunctioning biomass reclaimers.
