### PR TITLE
Add discord round announcements

### DIFF
--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -236,6 +236,7 @@ namespace Content.Server.GameTicking
             UpdateLateJoinStatus();
             AnnounceRound();
             UpdateInfoText();
+            RaiseLocalEvent(new RoundStartedEvent(RoundId));
 
 #if EXCEPTION_TOLERANCE
             }
@@ -359,6 +360,7 @@ namespace Content.Server.GameTicking
             RaiseNetworkEvent(new RoundEndMessageEvent(gamemodeTitle, roundEndText, roundDuration, RoundId,
                 listOfPlayerInfoFinal.Length, listOfPlayerInfoFinal, LobbySong,
                 new SoundCollectionSpecifier("RoundEnd").GetSound()));
+            RaiseLocalEvent(new RoundEndedEvent(RoundId, roundDuration));
         }
 
         public void RestartRound()

--- a/Content.Server/Nyanotrasen/GameTicking/RoundEndedEvent.cs
+++ b/Content.Server/Nyanotrasen/GameTicking/RoundEndedEvent.cs
@@ -1,0 +1,13 @@
+﻿namespace Content.Shared.GameTicking;
+
+public sealed class RoundEndedEvent : EntityEventArgs
+{
+    public int RoundId { get; }
+    public TimeSpan RoundDuration { get; }
+
+    public RoundEndedEvent(int roundId, TimeSpan roundDuration)
+    {
+        RoundId = roundId;
+        RoundDuration = roundDuration;
+    }
+}

--- a/Content.Server/Nyanotrasen/RoundNotifications/RoundNotificationsSystem.cs
+++ b/Content.Server/Nyanotrasen/RoundNotifications/RoundNotificationsSystem.cs
@@ -1,0 +1,180 @@
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Content.Shared.CCVar;
+using Content.Server.Maps;
+using Content.Shared.GameTicking;
+using Robust.Shared;
+using Robust.Shared.Configuration;
+
+namespace Content.Server.Nyanotrasen.RoundNotifications;
+
+/// <summary>
+/// Listen game events and send notifications to Discord
+/// </summary>
+public sealed class RoundNotificationsSystem : EntitySystem
+{
+    [Dependency] private readonly IConfigurationManager _config = default!;
+    [Dependency] private readonly IGameMapManager _gameMapManager = default!;
+
+    private ISawmill _sawmill = default!;
+    private readonly HttpClient _httpClient = new();
+
+    private string _webhookUrl = String.Empty;
+    private string _roleId = String.Empty;
+    private bool _roundStartOnly;
+    private string _serverName = string.Empty;
+
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundRestart);
+        SubscribeLocalEvent<RoundStartedEvent>(OnRoundStarted);
+        SubscribeLocalEvent<RoundEndedEvent>(OnRoundEnded);
+
+        _config.OnValueChanged(CCVars.DiscordRoundWebhook, value => _webhookUrl = value, true);
+        _config.OnValueChanged(CCVars.DiscordRoundRoleId, value => _roleId = value, true);
+        _config.OnValueChanged(CCVars.DiscordRoundStartOnly, value => _roundStartOnly = value, true);
+
+        _sawmill = IoCManager.Resolve<ILogManager>().GetSawmill("notifications");
+    }
+
+    private void OnServerNameChanged(string obj)
+    {
+        _serverName = obj;
+    }
+
+    private void OnRoundRestart(RoundRestartCleanupEvent e)
+    {
+        if (String.IsNullOrEmpty(_webhookUrl))
+            return;
+
+        var text = Loc.GetString("discord-round-new");
+
+        SendDiscordMessage(text);
+    }
+
+    private void OnRoundStarted(RoundStartedEvent e)
+    {
+        if (String.IsNullOrEmpty(_webhookUrl))
+            return;
+
+        var map = _gameMapManager.GetSelectedMap();
+        var mapName = map?.MapName ?? Loc.GetString("discord-round-unknown-map");
+        var text = Loc.GetString("discord-round-start",
+            ("id", e.RoundId),
+            ("map", mapName));
+
+        SendDiscordMessage(text);
+    }
+
+    private void OnRoundEnded(RoundEndedEvent e)
+    {
+        if (String.IsNullOrEmpty(_webhookUrl) || _roundStartOnly)
+            return;
+
+        var text = Loc.GetString("discord-round-end",
+            ("id", e.RoundId),
+            ("hours", e.RoundDuration.Hours),
+            ("minutes", e.RoundDuration.Minutes),
+            ("seconds", e.RoundDuration.Seconds));
+
+        SendDiscordMessage(text);
+    }
+
+    private async void SendDiscordMessage(string text)
+    {
+        var allowedMentions = new Dictionary<string, string[]>
+        {
+            { "roles", new[] { _roleId } }
+        };
+
+        // Limit server name to 1500 characters, in case someone tries to be a little funny
+        var serverName = _serverName[..Math.Min(_serverName.Length, 1500)];
+        var message = "";
+        if (!String.IsNullOrEmpty(_roleId))
+            message = $"<@&{_roleId}>";
+
+        // Build the embed
+        var payload = new WebhookPayload
+        {
+            Message = message,
+            Embeds = new List<Embed>
+            {
+                new()
+                {
+                    Description = text,
+                    Color = 0x41F097,
+                    Footer = new EmbedFooter
+                    {
+                        Text = $"{serverName}"
+                    },
+                },
+            },
+            AllowedMentions = allowedMentions,
+        };
+
+        var request = await _httpClient.PostAsync($"{_webhookUrl}?wait=true",
+            new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json"));
+
+        var content = await request.Content.ReadAsStringAsync();
+        if (!request.IsSuccessStatusCode)
+        {
+            _sawmill.Log(LogLevel.Error,
+                $"Discord returned bad status code when posting message: {request.StatusCode}\nResponse: {content}");
+            return;
+        }
+    }
+
+// https://discord.com/developers/docs/resources/channel#message-object-message-structure
+    private struct WebhookPayload
+    {
+        [JsonPropertyName("username")] public string? Username { get; set; } = null;
+
+        [JsonPropertyName("avatar_url")] public string? AvatarUrl { get; set; } = null;
+
+        [JsonPropertyName("content")] public string Message { get; set; } = "";
+
+        [JsonPropertyName("embeds")] public List<Embed>? Embeds { get; set; } = null;
+
+        [JsonPropertyName("allowed_mentions")]
+        public Dictionary<string, string[]> AllowedMentions { get; set; } =
+            new()
+            {
+                { "parse", Array.Empty<string>() },
+            };
+
+        public WebhookPayload()
+        {
+        }
+    }
+
+// https://discord.com/developers/docs/resources/channel#embed-object-embed-structure
+    private struct Embed
+    {
+        [JsonPropertyName("title")] public string Title { get; set; } = "Round Notification";
+
+        [JsonPropertyName("description")] public string Description { get; set; } = "";
+
+        [JsonPropertyName("color")] public int Color { get; set; } = 0;
+
+        [JsonPropertyName("footer")] public EmbedFooter? Footer { get; set; } = null;
+
+        public Embed()
+        {
+        }
+    }
+
+// https://discord.com/developers/docs/resources/channel#embed-object-embed-footer-structure
+    private struct EmbedFooter
+    {
+        [JsonPropertyName("text")] public string Text { get; set; } = "";
+
+        [JsonPropertyName("icon_url")] public string? IconUrl { get; set; }
+
+        public EmbedFooter()
+        {
+        }
+    }
+}

--- a/Content.Server/Nyanotrasen/RoundNotifications/RoundNotificationsSystem.cs
+++ b/Content.Server/Nyanotrasen/RoundNotifications/RoundNotificationsSystem.cs
@@ -36,6 +36,7 @@ public sealed class RoundNotificationsSystem : EntitySystem
         _config.OnValueChanged(CCVars.DiscordRoundWebhook, value => _webhookUrl = value, true);
         _config.OnValueChanged(CCVars.DiscordRoundRoleId, value => _roleId = value, true);
         _config.OnValueChanged(CCVars.DiscordRoundStartOnly, value => _roundStartOnly = value, true);
+        _config.OnValueChanged(CVars.GameHostName, OnServerNameChanged, true);
 
         _sawmill = IoCManager.Resolve<ILogManager>().GetSawmill("notifications");
     }

--- a/Content.Server/Nyanotrasen/RoundNotifications/RoundNotificationsSystem.cs
+++ b/Content.Server/Nyanotrasen/RoundNotifications/RoundNotificationsSystem.cs
@@ -85,10 +85,6 @@ public sealed class RoundNotificationsSystem : EntitySystem
 
     private async void SendDiscordMessage(string text)
     {
-        var allowedMentions = new Dictionary<string, string[]>
-        {
-            { "roles", new[] { _roleId } }
-        };
 
         // Limit server name to 1500 characters, in case someone tries to be a little funny
         var serverName = _serverName[..Math.Min(_serverName.Length, 1500)];
@@ -112,8 +108,9 @@ public sealed class RoundNotificationsSystem : EntitySystem
                     },
                 },
             },
-            AllowedMentions = allowedMentions,
         };
+        if (!String.IsNullOrEmpty(_roleId))
+            payload.AllowedMentions = new Dictionary<string, string[]> {{ "roles", new []{ _roleId } }};
 
         var request = await _httpClient.PostAsync($"{_webhookUrl}?wait=true",
             new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json"));

--- a/Content.Server/Nyanotrasen/RoundNotifications/RoundNotificationsSystem.cs
+++ b/Content.Server/Nyanotrasen/RoundNotifications/RoundNotificationsSystem.cs
@@ -76,7 +76,7 @@ public sealed class RoundNotificationsSystem : EntitySystem
 
         var text = Loc.GetString("discord-round-end",
             ("id", e.RoundId),
-            ("hours", e.RoundDuration.Hours),
+            ("hours", Math.Truncate(e.RoundDuration.TotalHours)),
             ("minutes", e.RoundDuration.Minutes),
             ("seconds", e.RoundDuration.Seconds));
 

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -315,6 +315,24 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<string> DiscordAHelpAvatar =
             CVarDef.Create("discord.ahelp_avatar", string.Empty, CVar.SERVERONLY);
 
+        /// <summary>
+        ///     URL of the Discord webhook which will send round status notifications.
+        /// </summary>
+        public static readonly CVarDef<string> DiscordRoundWebhook =
+            CVarDef.Create("discord.round_webhook", string.Empty, CVar.SERVERONLY);
+
+        /// <summary>
+        ///     Discord ID of role which will be pinged on new round start message.
+        /// </summary>
+        public static readonly CVarDef<string> DiscordRoundRoleId =
+            CVarDef.Create("discord.round_roleid", string.Empty, CVar.SERVERONLY);
+
+        /// <summary>
+        ///     Send notifications only about a new round begins.
+        /// </summary>
+        public static readonly CVarDef<bool> DiscordRoundStartOnly =
+            CVarDef.Create("discord.round_start_only", false, CVar.SERVERONLY);
+
         /*
          * Suspicion
          */

--- a/Content.Shared/GameTicking/RoundRestartedEvent.cs
+++ b/Content.Shared/GameTicking/RoundRestartedEvent.cs
@@ -1,0 +1,15 @@
+﻿using Robust.Shared.Serialization;
+
+namespace Content.Shared.GameTicking
+{
+    [Serializable, NetSerializable]
+    public sealed class RoundStartedEvent : EntityEventArgs
+    {
+        public int RoundId { get; }
+
+        public RoundStartedEvent(int roundId)
+        {
+            RoundId = roundId;
+        }
+    }
+}

--- a/Resources/Locale/en-US/round-notifications/notifications.ftl
+++ b/Resources/Locale/en-US/round-notifications/notifications.ftl
@@ -1,0 +1,3 @@
+﻿discord-round-new = New round started!
+discord-round-start = Round #{ $id } on map "{ $map }" has started.
+discord-round-end = Round #{ $id } has ended. It lasted for {$hours} hours, {$minutes} minutes, and {$seconds} seconds.

--- a/Resources/Locale/en-US/round-notifications/notifications.ftl
+++ b/Resources/Locale/en-US/round-notifications/notifications.ftl
@@ -1,3 +1,3 @@
-﻿discord-round-new = New round started!
+﻿discord-round-new = A new round started!
 discord-round-start = Round #{ $id } on map "{ $map }" has started.
 discord-round-end = Round #{ $id } has ended. It lasted for {$hours} hours, {$minutes} minutes, and {$seconds} seconds.


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

This PR adds a system that allows the server to send notifications for rounds starting and ending via a webhook, along with the ability to set a role to ping when a new round starts. I am by no means a pro C# writer, and I did my best to make sure this follows what the rest of the code looks like, but please let me know if I made any formatting mistakes or whatever, I'm still trying to learn.

I wasn't fully sure how to properly provided credit, but I have taken a majority of the code from a [Russian fork]( https://github.com/space-syndicate/space-station-14)

**Media**
![Discord_AYKfXG5wcp](https://user-images.githubusercontent.com/49997488/227354343-fb8892cc-b9fc-4dc8-ab7c-4deb34e14606.png)



- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

