### PR TITLE
Stop people from eating the whole PSB

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Consumable/Food/ration.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Consumable/Food/ration.yml
@@ -12,7 +12,7 @@
 
 - type: entity
   name: prepacked sustenance bar
-  parent: FoodSnackBase
+  parent: BaseItem
   id: FoodPSB
   description: The PSB is a densely packed, nutrient rich, artificially flavored and colored food bar specifically made to accomodate all morphotypes during food shortages.
   components:
@@ -20,6 +20,11 @@
     sprite: Nyanotrasen/Objects/Consumable/Food/ration.rsi
     state: psb
   - type: Item
+    size: 3
+  - type: Recyclable
+  - type: SpaceGarbage
+  - type: DynamicPrice
+    price: 0
   - type: SpawnItemsOnUse
     items:
       - id: FoodPSBTrash
@@ -65,7 +70,7 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15 # Too compacted for anything more
+        maxVol: 15
         reagents:
         - ReagentId: Nutriment
           Quantity: 15


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

Because a certain moth thought about eating the Prepacked Sustenance Bar *whole*.
In response to this barbaric act against food, NanoTrasen is shipping the PSB with non-edible protective wrapper.

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes the PSB no longer inherit from the FoodSnackBase and instead use BaseItem as a parent so it acts like a normal item and not Food.

**Media**
<!-- 
If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 
(adding clothing, items, new features, etc) must include ingame media or the PR will not be merged, in accordance with our PR guidelines.
This makes it much easier for us to merge PRs and find media for progress reports. If you include media in your pull request, we 
may potentially use it in the SS14 progress reports, with clear credit given.

Use screenshot software like Window's built in snipping tool, ShareX, Lightshot, or recording software like ShareX (gif), ScreenToGif, or Open Broadcaster Software (cross platform).
If you're unsure whether your PR will require media, ask a maintainer.

Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Fixed the PSB being edible with the wrapper.