### PR TITLE
Hats for crabs, penguins, skellys and slimes

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -438,6 +438,9 @@
       layer:
       - MobLayer
   - type: Appearance
+  - type: Inventory
+    templateId: crab
+  - type: Strippable    
   - type: DamageStateVisuals
     states:
       Alive:
@@ -1071,6 +1074,9 @@
       layer:
       - MobLayer
   - type: Appearance
+  - type: Inventory
+    templateId: penguin
+  - type: Strippable    
   - type: DamageStateVisuals
     states:
       Alive:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -13,7 +13,10 @@
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: ian
+    - map: [ "head" ] #temp????
   - type: Appearance
+  - type: Inventory
+    templateId: ian  
   - type: DamageStateVisuals
     states:
       Alive:
@@ -44,6 +47,8 @@
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: old_ian
   - type: Appearance
+  - type: Inventory
+    templateId: ian  
   - type: DamageStateVisuals
     states:
       Alive:

--- a/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
@@ -21,6 +21,8 @@
     damage:
       types:
         Blunt: 0
+  - type: Inventory
+    templateId: ian
   - type: Bloodstream
     maxBleedAmount: 0
     bloodReagent: Milk

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -19,6 +19,8 @@
   - type: Damageable
     damageContainer: Biological
     damageModifierSet: Slime
+  - type: Inventory
+    templateId: ian
   - type: Bloodstream
     bloodReagent: Slime # TODO Color slime blood based on their slime color or smth
     bloodlossDamage:

--- a/Resources/Prototypes/Nyanotrasen/InventoryTemplates/crab_inventory_template.yml
+++ b/Resources/Prototypes/Nyanotrasen/InventoryTemplates/crab_inventory_template.yml
@@ -1,0 +1,12 @@
+- type: inventoryTemplate
+  id: crab
+  slots:
+  - name: head
+    slotTexture: head
+    slotFlags: HEAD
+    slotGroup: MainHotbar
+    stripTime: 2
+    uiWindowPos: 0,0
+    strippingWindowPos: 0,0
+    displayName: Head
+    offset: 0.01, -0.2

--- a/Resources/Prototypes/Nyanotrasen/InventoryTemplates/ian_inventory_template.yml
+++ b/Resources/Prototypes/Nyanotrasen/InventoryTemplates/ian_inventory_template.yml
@@ -1,0 +1,11 @@
+- type: inventoryTemplate
+  id: ian
+  slots:   
+  - name: head
+    slotTexture: head
+    slotFlags: HEAD
+    slotGroup: MainHotbar
+    uiWindowPos: 0,0
+    strippingWindowPos: 0,0
+    displayName: Head
+    offset: 0, -0.03

--- a/Resources/Prototypes/Nyanotrasen/InventoryTemplates/penguin_inventory_template.yml
+++ b/Resources/Prototypes/Nyanotrasen/InventoryTemplates/penguin_inventory_template.yml
@@ -1,0 +1,11 @@
+- type: inventoryTemplate
+  id: penguin
+  slots:   
+  - name: head
+    slotTexture: head
+    slotFlags: HEAD
+    slotGroup: MainHotbar
+    uiWindowPos: 0,0
+    strippingWindowPos: 0,0
+    displayName: Head
+    offset: 0, -0.1


### PR DESCRIPTION


<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

The people have requested hats, so with the guidance of Old Dance Jacket, I've added hats to several spawnable species that lacks them.
I want to do Ian and Xenos, but Rane has cited engine issues preventing that.



**Changelog**

:cl:
-Hats added for penguins and crab AI's. These are strippable by players.
-Hats added for skeleton and slime people.

