### PR TITLE
Nerf space ticks

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/spacetick.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/spacetick.yml
@@ -20,8 +20,8 @@
       scale: 0.8, 0.8
   - type: Physics
   - type: MovementSpeedModifier
-    baseWalkSpeed : 4
-    baseSprintSpeed : 6
+    baseWalkSpeed : 3.5
+    baseSprintSpeed : 5
   - type: Fixtures
     fixtures:
     - shape:
@@ -29,9 +29,9 @@
         radius: 0.20
       density: 20
       mask:
-      - SmallMobMask
+      - MobMask
       layer:
-      - SmallMobLayer
+      - MobLayer
   - type: MobState
     allowedStates:
       - Alive


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Space tick players take the role and abuse it by going to the station breaking all lights and by being incredibly fast they are hard to hit, considering we now have bleeding they are more stronger, so i made them a little bit slower and they cannot longer go under doors, so take this into consideration in new salvage map where you include ticks. 

this also means less Ahelps about ghost role abuse :^)

:cl:
- tweak: Salvage ticks are slower and cannot go under doors

