### PR TITLE
Felinids are inside your plants

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Furniture/potted_plants.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/potted_plants.yml
@@ -25,6 +25,11 @@
     noRot: true
   - type: PottedPlantHide
   - type: SecretStash
+  - type: Storage
+    capacity: 300
+    whitelist:
+      components:
+        - Felinid
     secretPartName: secret-stash-part-plant
   - type: ContainerContainer
     containers:


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Felinids will be able to hide inside potted plants, the only issue is that you cannot shoot at the potted plants due to layering and no direct targeting to objects, so for now you will be only able to destroy the plants for force felinids out via melee.

also the other issue of shell castings dropping inside the plant making it impossible to go back inside the plant if its full of castings.

**Media**

https://user-images.githubusercontent.com/80334192/229596284-b59ee863-7f62-4854-b5fa-4064a9750c44.mp4


:cl: Leander
- add: Felinids have learned the skill of hiding in plants to attack their prey by surprise.
