### PR TITLE
Restore crew's clothing on spawn

### DIFF
--- a/Content.Shared/Inventory/InventorySystem.Equip.cs
+++ b/Content.Shared/Inventory/InventorySystem.Equip.cs
@@ -80,9 +80,6 @@ public abstract partial class InventorySystem
         if(!TryGetSlot(uid, args.Container.ID, out var slotDef, inventory: component))
             return;
 
-        if (!_gameTiming.IsFirstTimePredicted && !_gameTiming.ApplyingState)
-            return;
-
         var unequippedEvent = new DidUnequipEvent(uid, args.Entity, slotDef);
         RaiseLocalEvent(uid, unequippedEvent, true);
 
@@ -93,9 +90,6 @@ public abstract partial class InventorySystem
     private void OnEntInserted(EntityUid uid, InventoryComponent component, EntInsertedIntoContainerMessage args)
     {
         if(!TryGetSlot(uid, args.Container.ID, out var slotDef, inventory: component))
-            return;
-
-        if (!_gameTiming.IsFirstTimePredicted && !_gameTiming.ApplyingState)
             return;
 
         var equippedEvent = new DidEquipEvent(uid, args.Entity, slotDef);

--- a/Content.Shared/Inventory/InventorySystem.Equip.cs
+++ b/Content.Shared/Inventory/InventorySystem.Equip.cs
@@ -80,7 +80,7 @@ public abstract partial class InventorySystem
         if(!TryGetSlot(uid, args.Container.ID, out var slotDef, inventory: component))
             return;
 
-        if (!_gameTiming.IsFirstTimePredicted)
+        if (!_gameTiming.IsFirstTimePredicted && !_gameTiming.ApplyingState)
             return;
 
         var unequippedEvent = new DidUnequipEvent(uid, args.Entity, slotDef);
@@ -95,8 +95,8 @@ public abstract partial class InventorySystem
         if(!TryGetSlot(uid, args.Container.ID, out var slotDef, inventory: component))
             return;
 
-        if (!_gameTiming.IsFirstTimePredicted)
-            return;
+        if (!_gameTiming.IsFirstTimePredicted && !_gameTiming.ApplyingState)
+             return;
 
         var equippedEvent = new DidEquipEvent(uid, args.Entity, slotDef);
         RaiseLocalEvent(uid, equippedEvent, true);

--- a/Content.Shared/Inventory/InventorySystem.Equip.cs
+++ b/Content.Shared/Inventory/InventorySystem.Equip.cs
@@ -96,7 +96,7 @@ public abstract partial class InventorySystem
             return;
 
         if (!_gameTiming.IsFirstTimePredicted && !_gameTiming.ApplyingState)
-             return;
+            return;
 
         var equippedEvent = new DidEquipEvent(uid, args.Entity, slotDef);
         RaiseLocalEvent(uid, equippedEvent, true);


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
A change in the engine, and a Nyano specific change caused players to spawn without their clothes being applied (nude).

Change in the engine: https://github.com/space-wizards/RobustToolbox/pull/3866
Nyano commit: https://github.com/Nyanotrasen/Nyanotrasen/pull/1103

I have no idea what I'm doing; I haven't looked at game state or event flow before. But this change seems to fix it. No idea how to test the desync errors or whatever the original change was meant to fix.


**Media**
<!-- 
If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 
(adding clothing, items, new features, etc) must include ingame media or the PR will not be merged, in accordance with our PR guidelines.
This makes it much easier for us to merge PRs and find media for progress reports. If you include media in your pull request, we 
may potentially use it in the SS14 progress reports, with clear credit given.

Use screenshot software like Window's built in snipping tool, ShareX, Lightshot, or recording software like ShareX (gif), ScreenToGif, or Open Broadcaster Software (cross platform).
If you're unsure whether your PR will require media, ask a maintainer.

Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: jick
- fix: Crew board with their clothes on

