### PR TITLE
Arachne Barotrauma Blunt Reduction.

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/arachne.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/arachne.yml
@@ -133,19 +133,15 @@
       - "enum.HumanoidVisualLayers.RArm"
   - type: MovedByPressure
     pressureResistance: 4
+  - type: Barotrauma
+    damage:
+      types:
+        Blunt: 0.05 #per second, scales with pressure and other constants. Reduced Damage. This allows medicine to heal faster than damage.
   - type: MovementAlwaysTouching
   - type: MovementSpeedModifier
-    baseWalkSpeed : 2.7
-    baseSprintSpeed : 4.5
+    baseWalkSpeed : 3.0
+    baseSprintSpeed : 5.0
   - type: Perishable
-  - type: ThermalRegulator
-    metabolismHeat: 800
-    radiatedHeat: 100
-    implicitHeatRegulation: 500
-    sweatHeatRegulation: 500
-    shiveringHeatRegulation: 500
-    normalBodyTemperature: 310.15
-    thermalRegulationTemperatureThreshold: 25
   - type: FireVisuals
     sprite: Mobs/Effects/onfire.rsi
     normalState: Generic_mob_burning


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This change is to allow some more survivability for the Arachne Morphotype due to spacing. This PR reduces the damage of the Blunt portion of the Barotrauma to a healable level with Bicar and Derma and still allow the Arachne to take on roles in Space like Salvage and Engi Roles. 

I have given the Arachne a small movement increase as well since I noticed that their pulling speed and lack of shoes. They have eight legs, should be able to move a bit faster.

Currently I have set only the Blunt Barotrauma damaged reduced, so no changes to the Blunt from weapons. Even without Hardsuits, the Arachne WILL DIE if they stay out too long. Winter Coats can help some of the Cold damage. 

I have also removed an old entry of ThermalRegulator in the arachne yaml file that seemed to be an old entry and the parent seems to have an updated version.

Here is some of the damage testing I did for determining the reduction:
BaroTramua till crit
naked	base			
Arachne - 41 secs		
Oni     - 39 secs		
Felinid - 39 secs		
Moth	  - 48 secs		

air+winter coat + mask
Arachne -  1 min 6 secs
Oni     -  1 min 4 secs
Felinid - 1 min 10 secs
Moth	  - 1 min 8 secs

Arachne Testing with reduced Barotramua Blunt damage

	Blunt, Cold, and Oxygen Loss
0.05 naked					1 min 15 sec
0.10 naked					1 min 16 sec
0.15 naked					57 secs

	Blunt and Cold Damage
0.05 winter coat + mask			4 mins 9 secs
0.10 winter coat + mask			2 mins 41 secs
0.15 winter coat + mask			2 mins 43 secs	Blunt caused crit way before Cold

	Only blunt, No cold damage/ Oxygen Loss
0.05, scarf+ winter coat + mask		8 mins 15 secs
0.10, scarf+ winter coat + mask		4 mins 9 sec
0.15, scarf+ winter coat + mask		3 mins 25 secs
**Media**
<!-- 
If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 
(adding clothing, items, new features, etc) must include ingame media or the PR will not be merged, in accordance with our PR guidelines.
This makes it much easier for us to merge PRs and find media for progress reports. If you include media in your pull request, we 
may potentially use it in the SS14 progress reports, with clear credit given.

Use screenshot software like Window's built in snipping tool, ShareX, Lightshot, or recording software like ShareX (gif), ScreenToGif, or Open Broadcaster Software (cross platform).
If you're unsure whether your PR will require media, ask a maintainer.

Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Arachne now have resistance to the Blunt damage from Barotrauma. 
- remove: Removes old Yaml entries in Arachne file

