### PR TITLE
Make the mind swap event permanent.

### DIFF
--- a/Content.Server/Nyanotrasen/Abilities/Psionics/Abilities/MindSwapPowerSystem.cs
+++ b/Content.Server/Nyanotrasen/Abilities/Psionics/Abilities/MindSwapPowerSystem.cs
@@ -184,7 +184,7 @@ namespace Content.Server.Abilities.Psionics
             targetComp.OriginalEntity = performer;
         }
 
-        private void GetTrapped(EntityUid uid)
+        public void GetTrapped(EntityUid uid)
         {
             if (!_prototypeManager.TryIndex<InstantActionPrototype>("MindSwapReturn", out var action))
                 return;

--- a/Content.Server/Nyanotrasen/Psionics/Glimmer/Events/MassMindSwap.cs
+++ b/Content.Server/Nyanotrasen/Psionics/Glimmer/Events/MassMindSwap.cs
@@ -36,7 +36,12 @@ public sealed class MassMindSwap : GlimmerEventSystem
 
         for (int i = 0; i < psionicList.Count; i += 2)
         {
-            _mindSwap.Swap(psionicList[i].Owner, psionicList[i+1].Owner);
+            var performer = psionicList[i].Owner;
+            var target = psionicList[i+1].Owner;
+
+            _mindSwap.Swap(performer, target);
+            _mindSwap.GetTrapped(performer);
+            _mindSwap.GetTrapped(target);
         }
     }
 }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

why the change? mind swap event is something incredibly rare that happens when epistemics or the traitors have made the noosphere go out of control, this change was made to reflect that basically the mind field is breaking from that much glimmer, it being only a 30s thing is just a slap on the wrist compared to the absolute fuck up of the glimmer at 900.

plus by the way its coded now if you want to go back to your original body you just need another mind swap event!  ;^)

**Changelog**

:cl:
- tweak: Mind swap event is more punishing.
