### PR TITLE
Traitor Deathmatch gamemode timer

### DIFF
--- a/Content.Server/GameTicking/Rules/TraitorDeathMatchRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/TraitorDeathMatchRuleSystem.cs
@@ -202,7 +202,7 @@ public sealed class TraitorDeathMatchRuleSystem : GameRuleSystem
 
     public override void Started()
     {
-        _restarter.RoundMaxTime = TimeSpan.FromMinutes(30);
+        _restarter.RoundMaxTime = TimeSpan.FromMinutes(120);
         _restarter.RestartTimer();
         _safeToEndRound = true;
     }


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Extend the traitor deathmatch timer from 30 minutes to 2 hours, for admin events only so no need for changelog.

