### PR TITLE
Improve salvage spawn loot

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/salvage.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/salvage.yml
@@ -64,7 +64,7 @@
         #  - Medical
       - id: MedkitFilled
         prob: 0.1
-      - id: MedkitToxicFilled
+      - id: MedkitToxinFilled
         prob: 0.05
       - id: MedkitBruteFilled
         prob: 0.05

--- a/Resources/Prototypes/Catalog/Fills/Crates/salvage.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/salvage.yml
@@ -32,27 +32,55 @@
         # Normal (10%)
       - id: ToolboxEmergencyFilled
         prob: 0.1
+      - id: ToolboxElectricalFilled
+        prob: 0.1
+      - id: ToolboxMechanicalFilled
+        prob: 0.1
       - id: ClothingMaskBreath
         prob: 0.1
       - id: OxygenTankFilled
         prob: 0.1
       - id: SheetPlasma
         prob: 0.1
+      - id: SheetUranium
+        prob: 0.01
       - id: WelderIndustrialAdvanced
         prob: 0.1
       - id: ResearchDisk
         prob: 0.1
       - id: ClothingBeltStorageWaistbag
         prob: 0.1
+      - id: ClothingBeltHolster
+        prob: 0.1
+      - id: ClothingUniformJumpsuitGalaxyRed
+        prob: 0.01
+      - id: ClothingUniformJumpsuitGalaxyBlue
+        prob: 0.01
         #  - Service
       - id: CrayonBox
+        prob: 0.1
+      - id: BoxMRE
         prob: 0.1
         #  - Medical
       - id: MedkitFilled
         prob: 0.1
+      - id: MedkitToxicFilled
+        prob: 0.05
+      - id: MedkitBruteFilled
+        prob: 0.05
+      - id: MedkitAdvancedFilled
+        prob: 0.05
+      - id: MedkitCombatFilled
+        prob: 0.05
+      - id: MedkitOxygenFilled
+        prob: 0.05
+      - id: MedkitBurnFilled
+        prob: 0.05
       - id: BoxSyringe
         prob: 0.1
       - id: BoxBeaker
+        prob: 0.1
+      - id: BoxPillCanister
         prob: 0.1
         #  - Scaf
       - id: ClothingHeadHelmetScaf
@@ -64,10 +92,17 @@
         prob: 0.1
       - id: LidSalami
         prob: 0.1
+      - id: LidOSaws
+        prob: 0.01
         # Interesting (1%)
         #  - Ammo
       - id: MagazineBoxMagnum
         prob: 0.01
+      - id: MagazineBoxRifle
+        prob: 0.01
+      - id: MagazineBoxPistol
+        prob: 0.01
+
       - id: ResearchDisk5000
         prob: 0.01
       - id: MaterialBluespace
@@ -89,29 +124,7 @@
         prob: 0.001
       - id: ClothingHeadHatCatEars
         prob: 0.01
-        #  - Pins
-      - id: ClothingNeckLGBTPin
-        prob: 0.025
-        orGroup: LGBTQIAPlusPins
-      - id: ClothingNeckAromanticPin
-        orGroup: LGBTQIAPlusPins
-      - id: ClothingNeckAsexualPin
-        orGroup: LGBTQIAPlusPins
-      - id: ClothingNeckBisexualPin
-        orGroup: LGBTQIAPlusPins
-      - id: ClothingNeckIntersexPin
-        orGroup: LGBTQIAPlusPins
-      - id: ClothingNeckLesbianPin
-        orGroup: LGBTQIAPlusPins
-      - id: ClothingNeckNonBinaryPin
-        orGroup: LGBTQIAPlusPins
-      - id: ClothingNeckPansexualPin
-        orGroup: LGBTQIAPlusPins
-      - id: ClothingNeckTransPin
-        orGroup: LGBTQIAPlusPins
         # TRAITOR EQUIPMENT (0.01%)
-      - id: Telecrystal10
-        prob: 0.0001
       - id: WeaponRevolverPython
         prob: 0.0001
       - id: WeaponRevolverMateba


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

The pins are cool and everything but honestly where put in the wrong place, salvage people are not interested in killing 2 bears and 3 carps just to open a crate full of fancy pins, it bloated the chances of better loot and its unnecessary because we have the Pride Vending Machine with all the pins available.

this PR essentially removes the pins from the loot and i added some extra stuff to compensate and to have a little more variety. 

![pins](https://user-images.githubusercontent.com/80334192/231517134-287a2c09-97e4-4f81-8f21-63a5a77ea3ef.png)


:cl: Leander
- tweak: Improve salvage spawn loot.
