### PR TITLE
Make pinguin able to withstand Glacier's cold air

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1063,9 +1063,6 @@
   - type: HTN
     rootTask: IdleEvadeCompound
 
-
-
-
 - type: entity
   name: penguin
   id: MobPenguin
@@ -1097,12 +1094,12 @@
       state: penguin
       sprite: Mobs/Animals/penguin.rsi
   - type: Hands
-  - type: Body #this is a filthy, FILTHY hack to make crab hands work
+  - type: Body #this is a filthy, FILTHY hack to make penguin hands work
     prototype: Primate
   - type: DamageStateVisuals
     states:
       Alive:
-        Base: crab
+        Base: penguin
       Critical:
         Base: penguin_dead
       Dead:
@@ -1120,11 +1117,10 @@
     interactSuccessString: petting-success-bird
     interactFailureString: petting-failure-generic
   - type: Temperature
-    coldDamageThreshold: 235
+    coldDamageThreshold: 210
     coldDamage:
       types:
         Cold: 0.1 #per second, scales with temperature & other constants
-
 
 - type: entity
   name: grenade penguin


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This makes them immune to glacier air by reducing their coldDamageThreshold to 210.
The downside is that player penguin still see the "Too Cold" indicator.

I misspelled penguin.

**Media**
<!-- 
If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 
(adding clothing, items, new features, etc) must include ingame media or the PR will not be merged, in accordance with our PR guidelines.
This makes it much easier for us to merge PRs and find media for progress reports. If you include media in your pull request, we 
may potentially use it in the SS14 progress reports, with clear credit given.

Use screenshot software like Window's built in snipping tool, ShareX, Lightshot, or recording software like ShareX (gif), ScreenToGif, or Open Broadcaster Software (cross platform).
If you're unsure whether your PR will require media, ask a maintainer.

Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

