### PR TITLE
Disable harm mode on the arrivals terminal/shuttle

### DIFF
--- a/Content.Server/Shuttles/Systems/ArrivalsSystem.cs
+++ b/Content.Server/Shuttles/Systems/ArrivalsSystem.cs
@@ -11,6 +11,7 @@ using Content.Server.Station.Components;
 using Content.Server.Station.Systems;
 using Content.Shared.Administration;
 using Content.Shared.CCVar;
+using Content.Shared.CombatMode.Pacification;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Shuttles.Components;
 using Content.Shared.Spawners.Components;
@@ -139,6 +140,7 @@ public sealed class ArrivalsSystem : EntitySystem
                     }
 
                     RemCompDeferred<PendingClockInComponent>(uid);
+                    RemCompDeferred<PacifiedComponent>(uid);
                     shell.WriteLine(Loc.GetString("cmd-arrivals-forced", ("uid", ToPrettyString(uid))));
                 }
                 break;
@@ -176,6 +178,7 @@ public sealed class ArrivalsSystem : EntitySystem
                 continue;
 
             RemCompDeferred<PendingClockInComponent>(pUid);
+            RemCompDeferred<PacifiedComponent>(pUid);
         }
     }
 
@@ -238,6 +241,7 @@ public sealed class ArrivalsSystem : EntitySystem
                     ev.Station);
 
                 EnsureComp<PendingClockInComponent>(ev.SpawnResult.Value);
+                EnsureComp<PacifiedComponent>(ev.SpawnResult.Value);
                 return;
             }
         }
@@ -293,6 +297,7 @@ public sealed class ArrivalsSystem : EntitySystem
                 {
                     if (arrivals.IsValid())
                         _shuttles.FTLTravel(uid, shuttle, arrivals, dock: true);
+
                 }
                 // Go to station
                 else

--- a/Content.Server/Shuttles/Systems/ArrivalsSystem.cs
+++ b/Content.Server/Shuttles/Systems/ArrivalsSystem.cs
@@ -297,7 +297,6 @@ public sealed class ArrivalsSystem : EntitySystem
                 {
                     if (arrivals.IsValid())
                         _shuttles.FTLTravel(uid, shuttle, arrivals, dock: true);
-
                 }
                 // Go to station
                 else

--- a/Content.Server/Store/Systems/StoreSystem.Ui.cs
+++ b/Content.Server/Store/Systems/StoreSystem.Ui.cs
@@ -5,9 +5,11 @@ using Content.Shared.Actions.ActionTypes;
 using Content.Shared.FixedPoint;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Store;
+using Content.Shared.Popups;
 using Content.Shared.Database;
 using Robust.Server.GameObjects;
 using System.Linq;
+using Content.Server.Shuttles.Components;
 using Content.Server.Stack;
 using Content.Server.UserInterface;
 
@@ -124,6 +126,13 @@ public sealed partial class StoreSystem
 
             if (!conditionsMet)
                 return;
+        }
+
+        //check that we're not trying to buy before clocking in
+        if (HasComp<PendingClockInComponent>(buyer))
+        {
+            _popup.PopupEntity(Loc.GetString("store-error-arrivals"), uid, buyer);
+            return;
         }
 
         //check that we have enough money

--- a/Resources/Locale/en-US/store/store.ftl
+++ b/Resources/Locale/en-US/store/store.ftl
@@ -4,3 +4,5 @@ store-ui-balance-display = {$currency}: {$amount}
 store-ui-price-display = {$amount} {$currency}
 
 store-withdraw-button-ui = Withdraw {$currency}
+
+store-error-arrivals = Unable to complete purchase, out of range!


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This is a rather simple change, it just makes you a pacifist until you arrive at the station from the terminal. Makes it a lot harder to beat someone to death on the terminal. Idealy it would also prevent uplink usage so you cant buy bombs, but thats something I couldn't do in 4 lines.

**Media**

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl: Debug
- tweak: Disabled harm mode on the arrivals terminal