### PR TITLE
Gives security winter coats protection

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -153,11 +153,19 @@
   parent: ClothingOuterWinterCoat
   id: ClothingOuterWinterHoS
   name: head of security's winter coat
+  description: A sturdy, red winter coat designed for the head of security. It is extra comfortable.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/WinterCoats/coathos.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/WinterCoats/coathos.rsi
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.7
+        Slash: 0.7
+        Piercing: 0.6 #slightly less bulletproof than hos normal coat
+        Heat: 0.7
 
 - type: entity
   parent: ClothingOuterWinterCoat
@@ -263,11 +271,21 @@
   parent: ClothingOuterWinterCoat
   id: ClothingOuterWinterSec
   name: security winter coat
+  description: A red, armour-padded winter coat. It glitters with a mild ablative coating and a robust air of authority.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/WinterCoats/coatsec.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/WinterCoats/coatsec.rsi
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.9
+        Slash: 0.9
+        Piercing: 0.6 #slightly less bulletproof than a normal kevlar vest
+        Heat: 0.85
+  - type: ExplosionResistance
+    damageCoefficient: 0.95
 
 - type: entity
   parent: ClothingOuterWinterCoat

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -165,7 +165,7 @@
         Blunt: 0.7
         Slash: 0.7
         Piercing: 0.6 #slightly less bulletproof than hos normal coat
-        Heat: 0.7
+        Heat: 0.75
 
 - type: entity
   parent: ClothingOuterWinterCoat
@@ -283,7 +283,7 @@
         Blunt: 0.9
         Slash: 0.9
         Piercing: 0.6 #slightly less bulletproof than a normal kevlar vest
-        Heat: 0.85
+        Heat: 0.75
   - type: ExplosionResistance
     damageCoefficient: 0.95
 

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -153,7 +153,7 @@
   parent: ClothingOuterWinterCoat
   id: ClothingOuterWinterHoS
   name: head of security's winter coat
-  description: A sturdy, red winter coat designed for the head of security. It is extra comfortable.
+  description: A sturdy, red winter coat designed for the head of security. It is meant to withstand the harshest of weathers.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/WinterCoats/coathos.rsi


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Because if the Warden can get a special protective winter coat, why not the rest of security.

This is purely so Security on Glacier can function slightly better than being completely unarmored.
This follows the base of the Warden's winter coat which is to give 20% less piercing protection compared to what it is supposed to "replace".

The HoS winter coat is just because it makes sense to do it too, their trenchcoat is by default able to withstand Glacier's temperature.

**Media**
<!-- 
If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 
(adding clothing, items, new features, etc) must include ingame media or the PR will not be merged, in accordance with our PR guidelines.
This makes it much easier for us to merge PRs and find media for progress reports. If you include media in your pull request, we 
may potentially use it in the SS14 progress reports, with clear credit given.

Use screenshot software like Window's built in snipping tool, ShareX, Lightshot, or recording software like ShareX (gif), ScreenToGif, or Open Broadcaster Software (cross platform).
If you're unsure whether your PR will require media, ask a maintainer.

Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![ss (2023-04-15 at 05 23 51)](https://user-images.githubusercontent.com/9823203/232234019-57cf3746-f615-427e-995f-f31396f8000c.png)
Compared to.
![ss (2023-04-15 at 05 23 56)](https://user-images.githubusercontent.com/9823203/232234023-742b6a07-a63e-450e-bcd4-adca19cc8b3e.png)



- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Tweaked Security winter coats to be slightly more protective.

