### PR TITLE
Fix things like suit sensors and handheld crew monitoring being broken when spawning via arrivals

### DIFF
--- a/Content.Server/Station/Systems/StationSystem.cs
+++ b/Content.Server/Station/Systems/StationSystem.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using Content.Server.Chat.Systems;
 using Content.Server.GameTicking;
+using Content.Server.Shuttles.Components;
 using Content.Server.Station.Components;
 using Content.Shared.CCVar;
 using Content.Shared.Station;
@@ -25,6 +26,7 @@ namespace Content.Server.Station.Systems;
 public sealed class StationSystem : EntitySystem
 {
     [Dependency] private readonly IConfigurationManager _configurationManager = default!;
+    [Dependency] private readonly IEntityManager _entityManager = default!;
     [Dependency] private readonly ILogManager _logManager = default!;
     [Dependency] private readonly IMapManager _mapManager = default!;
     [Dependency] private readonly IPlayerManager _player = default!;
@@ -492,6 +494,12 @@ public sealed class StationSystem : EntitySystem
         {
             // We are the station, just check ourselves.
             return CompOrNull<StationMemberComponent>(entity)?.Station;
+        }
+
+        if (TryComp<ArrivalsSourceComponent>(xform.GridUid, out _))
+        {
+            // We are an arrivals source, return an actual station
+            return Stations.ToList()[0]; // Is it hacky? Sure, but does it work? Yeah!
         }
 
         if (xform.GridUid == EntityUid.Invalid)

--- a/Content.Server/Station/Systems/StationSystem.cs
+++ b/Content.Server/Station/Systems/StationSystem.cs
@@ -496,7 +496,7 @@ public sealed class StationSystem : EntitySystem
             return CompOrNull<StationMemberComponent>(entity)?.Station;
         }
 
-        if (TryComp<ArrivalsSourceComponent>(xform.GridUid, out _))
+        if (TryComp<ArrivalsSourceComponent>(xform.GridUid, out _) && Stations.ToList()[0] != null)
         {
             // We are an arrivals source, return an actual station
             return Stations.ToList()[0]; // Is it hacky? Sure, but does it work? Yeah!

--- a/Content.Server/Station/Systems/StationSystem.cs
+++ b/Content.Server/Station/Systems/StationSystem.cs
@@ -496,10 +496,10 @@ public sealed class StationSystem : EntitySystem
             return CompOrNull<StationMemberComponent>(entity)?.Station;
         }
 
-        if (TryComp<ArrivalsSourceComponent>(xform.GridUid, out _) && Stations.ToList()[0] != null)
+        if (TryComp<ArrivalsSourceComponent>(xform.GridUid, out _) && Stations.Any())
         {
             // We are an arrivals source, return an actual station
-            return Stations.ToList()[0]; // Is it hacky? Sure, but does it work? Yeah!
+            return Stations.First();
         }
 
         if (xform.GridUid == EntityUid.Invalid)


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This fixes an issue where you'd get null returned when trying to get the owning station of something that spawned on the arrivals terminal. Normally this wouldn't be an issue but some systems like crew monitoring get _really_ upset when they have their station set as null. Since there is no easy way I could find to get the uid of the station you travel to, this just forces the first station that exists to be returned. It might cause issues when admemes create multiple stations, but that can easily be fixed by just disabling arrivals for that round.

**Media**
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl: Debug
- fix: Traveling via the arrivals terminal no longer breaks station linked devices

