### PR TITLE
Fix Nyanotrasen Wiki update workflow

### DIFF
--- a/.github/workflows/update-wiki.yml
+++ b/.github/workflows/update-wiki.yml
@@ -56,7 +56,7 @@ jobs:
         wiki_text_file: ./bin/Content.Server/data/chem_prototypes.json
         edit_summary: Update chem_prototypes.json via GitHub Actions
         page_name: "${{ secrets.WIKI_PAGE_ROOT }}/chem_prototypes.json"
-        api_url: https://wiki.nyanotrasen.moe/api.php
+        api_url: https://wiki.nyanotrasen.moe/w/api.php
         username: ${{ secrets.WIKI_BOT_USER }}
         password: ${{ secrets.WIKI_BOT_PASS }}
 
@@ -66,7 +66,6 @@ jobs:
         wiki_text_file: ./bin/Content.Server/data/react_prototypes.json
         edit_summary: Update react_prototypes.json via GitHub Actions
         page_name: "${{ secrets.WIKI_PAGE_ROOT }}/react_prototypes.json"
-        api_url: https://wiki.nyanotrasen.moe/api.php
+        api_url: https://wiki.nyanotrasen.moe/w/api.php
         username: ${{ secrets.WIKI_BOT_USER }}
         password: ${{ secrets.WIKI_BOT_PASS }}
-

--- a/.github/workflows/update-wiki.yml
+++ b/.github/workflows/update-wiki.yml
@@ -3,7 +3,7 @@ name: Update Wiki
 on:
   workflow_dispatch:
   push:
-    branches: [ master, jsondump ]
+    branches: [ master ]
     paths:
       - '.github/workflows/update-wiki.yml'
       - 'Content.Shared/Chemistry/**.cs'

--- a/.github/workflows/update-wiki.yml
+++ b/.github/workflows/update-wiki.yml
@@ -18,6 +18,7 @@ jobs:
   update-wiki:
     name: Build and Publish JSON blobs to wiki
     runs-on: ubuntu-latest
+    environment: "update-wiki"
 
     steps:
     - name: Checkout Master


### PR DESCRIPTION
Fixed the API URL of the wiki, and robusted the workflow a bit.

Changes needed in the repository settings:
- Create a `update-wiki` environment
- Make it only run on master branch

I'll send the secrets after I've set up the bot account on the wiki.