### PR TITLE
Temporarily patch Discord changelog action

### DIFF
--- a/Tools/actions_changelogs_since_last_run.py
+++ b/Tools/actions_changelogs_since_last_run.py
@@ -19,6 +19,7 @@ GITHUB_TOKEN      = os.environ["GITHUB_TOKEN"]
 
 DISCORD_WEBHOOK_URL = os.environ.get("DISCORD_WEBHOOK_URL")
 
+CHANGELOG_FILE_OLD = "Resources/Changelog/NyanotrasenChangelog.yml"
 CHANGELOG_FILE = "Resources/Changelog/Changelog.yml"
 
 TYPES_TO_EMOJI = {
@@ -91,7 +92,7 @@ def get_last_changelog(sess: requests.Session, sha: str) -> str:
         "Accept": "application/vnd.github.raw"
     }
 
-    resp = sess.get(f"{GITHUB_API_URL}/repos/{GITHUB_REPOSITORY}/contents/{CHANGELOG_FILE}", headers=headers, params=params)
+    resp = sess.get(f"{GITHUB_API_URL}/repos/{GITHUB_REPOSITORY}/contents/{CHANGELOG_FILE_OLD}", headers=headers, params=params)
     resp.raise_for_status()
     return resp.text
 


### PR DESCRIPTION
There was a small hiccup with the publish workflow when changing changelog filenames. This will be reverted after I run the next publish action which should result in a successful run that the future (reverted) action will be able to work with.