### PR TITLE
Adds defibrillator to cargo catalog

### DIFF
--- a/Resources/Locale/en-US/prototypes/catalog/fills/crates/medical-crates.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/fills/crates/medical-crates.ftl
@@ -1,4 +1,5 @@
 ent-CrateMedicalDefib = Defibrillator crate
+    .desc = A defibrillator and a spare power cell.
 
 ent-CrateMedicalSupplies = Medical supplies crate
     .desc = Basic medical supplies.

--- a/Resources/Prototypes/Catalog/Cargo/cargo_medical.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_medical.yml
@@ -86,3 +86,13 @@
   cost: 800
   category: Medical
   group: market
+
+- type: cargoProduct
+  id: MedicalDefib
+  icon:
+    sprite: Objects/Specific/Medical/defib.rsi
+    state: icon
+  product: CrateMedicalDefib
+  cost: 5000
+  category: Medical
+  group: market

--- a/Resources/Prototypes/Catalog/Fills/Crates/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/medical.yml
@@ -3,9 +3,11 @@
   parent: CrateMedical
   components:
   - type: StorageFill
-#    contents:
-#      - id: Defibrillator
-#        amount: 1
+    contents:
+      - id: Defibrillator
+        amount: 1
+      - id: PowerCellMedium
+        amount: 1
 
 - type: entity
   id: CrateMedicalSupplies


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Touched the defibrillator crate to put a defib + a spare medium cell in (the defib prototype spawns with a medium cell inside it too). Set the cost in cargo for $5000. Defibs appraise for $100 without cell, $208 with cell, and the cell itself is $108. Thoughts on the price?
Upstream push from https://github.com/DeltaV-Station/Delta-v/pull/22
**Media**
![image](https://github.com/DeltaV-Station/Delta-v/assets/42394661/b7706d25-f5aa-4c50-89b3-4fe4bbeaa5a9)

**Changelog**

:cl: Pooch
- tweak: Defibrillators can be ordered from Cargo.