### PR TITLE
Add Defibrillators and Cell Chargers to Medbays

### DIFF
--- a/Resources/Maps/arena.yml
+++ b/Resources/Maps/arena.yml
@@ -55055,6 +55055,20 @@ entities:
     - pos: -27.5,-80.5
       parent: 6747
       type: Transform
+- proto: DefibrillatorCabinetFilled
+  entities:
+  - uid: 8794
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 17.5,-34.5
+      parent: 6747
+      type: Transform
+  - uid: 8815
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 20.5,-30.5
+      parent: 6747
+      type: Transform
 - proto: DeployableBarrier
   entities:
   - uid: 3168
@@ -127221,6 +127235,12 @@ entities:
   - uid: 8527
     components:
     - pos: 58.5,-22.5
+      parent: 6747
+      type: Transform
+  - uid: 8816
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 17.5,-23.5
       parent: 6747
       type: Transform
   - uid: 9135

--- a/Resources/Maps/arena.yml
+++ b/Resources/Maps/arena.yml
@@ -55055,20 +55055,6 @@ entities:
     - pos: -27.5,-80.5
       parent: 6747
       type: Transform
-- proto: DefibrillatorCabinetFilled
-  entities:
-  - uid: 8794
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 17.5,-34.5
-      parent: 6747
-      type: Transform
-  - uid: 8815
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 20.5,-30.5
-      parent: 6747
-      type: Transform
 - proto: DeployableBarrier
   entities:
   - uid: 3168
@@ -127235,12 +127221,6 @@ entities:
   - uid: 8527
     components:
     - pos: 58.5,-22.5
-      parent: 6747
-      type: Transform
-  - uid: 8816
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: 17.5,-23.5
       parent: 6747
       type: Transform
   - uid: 9135

--- a/Resources/Maps/glacier.yml
+++ b/Resources/Maps/glacier.yml
@@ -39898,6 +39898,19 @@ entities:
     - pos: 11.384118,52.69154
       parent: 1781
       type: Transform
+- proto: DefibrillatorCabinetFilled
+  entities:
+  - uid: 11625
+    components:
+    - pos: 0.5,3.5
+      parent: 1781
+      type: Transform
+  - uid: 11626
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -4.5,-5.5
+      parent: 1781
+      type: Transform
 - proto: DeployableBarrier
   entities:
   - uid: 275
@@ -76158,6 +76171,12 @@ entities:
   - uid: 9388
     components:
     - pos: -7.5,42.5
+      parent: 1781
+      type: Transform
+  - uid: 11624
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -0.5,0.5
       parent: 1781
       type: Transform
 - proto: Poweredlight

--- a/Resources/Maps/glacier.yml
+++ b/Resources/Maps/glacier.yml
@@ -39898,19 +39898,6 @@ entities:
     - pos: 11.384118,52.69154
       parent: 1781
       type: Transform
-- proto: DefibrillatorCabinetFilled
-  entities:
-  - uid: 11625
-    components:
-    - pos: 0.5,3.5
-      parent: 1781
-      type: Transform
-  - uid: 11626
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -4.5,-5.5
-      parent: 1781
-      type: Transform
 - proto: DeployableBarrier
   entities:
   - uid: 275
@@ -76171,12 +76158,6 @@ entities:
   - uid: 9388
     components:
     - pos: -7.5,42.5
-      parent: 1781
-      type: Transform
-  - uid: 11624
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -0.5,0.5
       parent: 1781
       type: Transform
 - proto: Poweredlight

--- a/Resources/Maps/lighthouse.yml
+++ b/Resources/Maps/lighthouse.yml
@@ -47504,7 +47504,7 @@ entities:
       type: Transform
   - uid: 19163
     components:
-    - pos: -9.477411,40.882256
+    - pos: -9.528376,40.921482
       parent: 100
       type: Transform
   - uid: 19696
@@ -50165,6 +50165,20 @@ entities:
   - uid: 13743
     components:
     - pos: 13.673946,-52.319447
+      parent: 100
+      type: Transform
+- proto: DefibrillatorCabinetFilled
+  entities:
+  - uid: 12998
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -10.5,43.5
+      parent: 100
+      type: Transform
+  - uid: 19825
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -15.5,41.5
       parent: 100
       type: Transform
 - proto: DeployableBarrier
@@ -99628,12 +99642,12 @@ entities:
       type: Transform
   - uid: 19164
     components:
-    - pos: -9.741274,41.381287
+    - pos: -9.543883,40.441753
       parent: 100
       type: Transform
   - uid: 19165
     components:
-    - pos: -9.256899,41.662537
+    - pos: -9.601502,40.499382
       parent: 100
       type: Transform
   - uid: 19166
@@ -99648,7 +99662,7 @@ entities:
       type: Transform
   - uid: 19168
     components:
-    - pos: -9.6306715,40.543194
+    - pos: -9.6591215,40.557007
       parent: 100
       type: Transform
   - uid: 19220
@@ -101083,6 +101097,11 @@ entities:
   - uid: 14696
     components:
     - pos: 4.5,-32.5
+      parent: 100
+      type: Transform
+  - uid: 19826
+    components:
+    - pos: -9.5,41.5
       parent: 100
       type: Transform
 - proto: Poweredlight

--- a/Resources/Maps/lighthouse.yml
+++ b/Resources/Maps/lighthouse.yml
@@ -47504,7 +47504,7 @@ entities:
       type: Transform
   - uid: 19163
     components:
-    - pos: -9.528376,40.921482
+    - pos: -9.477411,40.882256
       parent: 100
       type: Transform
   - uid: 19696
@@ -50165,20 +50165,6 @@ entities:
   - uid: 13743
     components:
     - pos: 13.673946,-52.319447
-      parent: 100
-      type: Transform
-- proto: DefibrillatorCabinetFilled
-  entities:
-  - uid: 12998
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -10.5,43.5
-      parent: 100
-      type: Transform
-  - uid: 19825
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -15.5,41.5
       parent: 100
       type: Transform
 - proto: DeployableBarrier
@@ -99642,12 +99628,12 @@ entities:
       type: Transform
   - uid: 19164
     components:
-    - pos: -9.543883,40.441753
+    - pos: -9.741274,41.381287
       parent: 100
       type: Transform
   - uid: 19165
     components:
-    - pos: -9.601502,40.499382
+    - pos: -9.256899,41.662537
       parent: 100
       type: Transform
   - uid: 19166
@@ -99662,7 +99648,7 @@ entities:
       type: Transform
   - uid: 19168
     components:
-    - pos: -9.6591215,40.557007
+    - pos: -9.6306715,40.543194
       parent: 100
       type: Transform
   - uid: 19220
@@ -101097,11 +101083,6 @@ entities:
   - uid: 14696
     components:
     - pos: 4.5,-32.5
-      parent: 100
-      type: Transform
-  - uid: 19826
-    components:
-    - pos: -9.5,41.5
       parent: 100
       type: Transform
 - proto: Poweredlight

--- a/Resources/Maps/ovni.yml
+++ b/Resources/Maps/ovni.yml
@@ -27019,6 +27019,20 @@ entities:
       pos: 39.37888,-20.383318
       parent: 8
       type: Transform
+- proto: DefibrillatorCabinetFilled
+  entities:
+  - uid: 11226
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -5.5,21.5
+      parent: 8
+      type: Transform
+  - uid: 11227
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 5.5,16.5
+      parent: 8
+      type: Transform
 - proto: DeployableBarrier
   entities:
   - uid: 11123
@@ -56853,6 +56867,11 @@ entities:
   - uid: 11136
     components:
     - pos: -3.5,-24.5
+      parent: 8
+      type: Transform
+  - uid: 11224
+    components:
+    - pos: -1.5,24.5
       parent: 8
       type: Transform
 - proto: Poweredlight

--- a/Resources/Maps/ovni.yml
+++ b/Resources/Maps/ovni.yml
@@ -27019,20 +27019,6 @@ entities:
       pos: 39.37888,-20.383318
       parent: 8
       type: Transform
-- proto: DefibrillatorCabinetFilled
-  entities:
-  - uid: 11226
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -5.5,21.5
-      parent: 8
-      type: Transform
-  - uid: 11227
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 5.5,16.5
-      parent: 8
-      type: Transform
 - proto: DeployableBarrier
   entities:
   - uid: 11123
@@ -56867,11 +56853,6 @@ entities:
   - uid: 11136
     components:
     - pos: -3.5,-24.5
-      parent: 8
-      type: Transform
-  - uid: 11224
-    components:
-    - pos: -1.5,24.5
       parent: 8
       type: Transform
 - proto: Poweredlight

--- a/Resources/Maps/pebble.yml
+++ b/Resources/Maps/pebble.yml
@@ -28801,6 +28801,20 @@ entities:
     - pos: 23.913591,4.2355914
       parent: 7
       type: Transform
+- proto: DefibrillatorCabinetFilled
+  entities:
+  - uid: 9963
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -20.5,7.5
+      parent: 7
+      type: Transform
+  - uid: 9964
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -20.5,16.5
+      parent: 7
+      type: Transform
 - proto: DeployableBarrier
   entities:
   - uid: 535
@@ -53245,6 +53259,12 @@ entities:
     components:
     - rot: -1.5707963267948966 rad
       pos: 19.5,5.5
+      parent: 7
+      type: Transform
+  - uid: 9965
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -17.5,4.5
       parent: 7
       type: Transform
 - proto: Poweredlight

--- a/Resources/Maps/pebble.yml
+++ b/Resources/Maps/pebble.yml
@@ -28801,20 +28801,6 @@ entities:
     - pos: 23.913591,4.2355914
       parent: 7
       type: Transform
-- proto: DefibrillatorCabinetFilled
-  entities:
-  - uid: 9963
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -20.5,7.5
-      parent: 7
-      type: Transform
-  - uid: 9964
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -20.5,16.5
-      parent: 7
-      type: Transform
 - proto: DeployableBarrier
   entities:
   - uid: 535
@@ -53259,12 +53245,6 @@ entities:
     components:
     - rot: -1.5707963267948966 rad
       pos: 19.5,5.5
-      parent: 7
-      type: Transform
-  - uid: 9965
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -17.5,4.5
       parent: 7
       type: Transform
 - proto: Poweredlight


### PR DESCRIPTION
## About the PR
Two Defibrillator Cabinets have been added to each of the maps currently in rotation, ideally one in the Trauma Ward behind a locked Medbay door and another in the Surgery room in case folks milling about snatch the one up front. I've also added Power Cell Rechargers to Medbay for those maps that did not already have one.

**Media**
![image](https://github.com/Nyanotrasen/Nyanotrasen/assets/20689511/3dba067e-a061-4a9c-be1c-5b38ec86b7f3)

**Changelog**
:cl: Fireheart
- add: Mapped Defibrillators and missing Medbay Power Cell Rechargers

