### PR TITLE
Fix robot crew monitor running out of charges

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/robots.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/robots.yml
@@ -227,7 +227,7 @@
     slots:
       analyzer_slot:
         name: HealthAnalyzer
-        startingItem: BorgHealthAnalyzer
+        startingItem: HandheldHealthAnalyzerBorg
         locked: true
       hypospray_slot:
         name: Hypospray
@@ -269,7 +269,7 @@
     tools:
       - id: HyposprayBorgMedical
       - id: Syringe
-      - id: BorgHealthAnalyzer
+      - id: HandheldHealthAnalyzerBorg
       - id: HandheldCrewMonitor
       - id: FireExtinguisher
       - id: StackHolderHealingItem

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/robots.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/robots.yml
@@ -270,7 +270,7 @@
       - id: HyposprayBorgMedical
       - id: Syringe
       - id: HandheldHealthAnalyzerBorg
-      - id: HandheldCrewMonitor
+      - id: HandheldCrewMonitorBorg
       - id: FireExtinguisher
       - id: StackHolderHealingItem
   - type: ItemSlots

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Borgs/borgs_tools.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Borgs/borgs_tools.yml
@@ -64,7 +64,7 @@
   parent: BaseItem
   id: HandheldHealthAnalyzerBorg
   name: health analyzer
-  description: A hand-held body scanner, that runs off of your own power cells, capable of distinguishing vital signs of the subject.
+  description: A hand-held body scanner that runs off of your own power cells, capable of distinguishing vital signs of the subject.
   noSpawn: true
   components:
   - type: Sprite
@@ -89,7 +89,7 @@
   parent: BaseItem
   id: HandheldCrewMonitorBorg
   name: handheld crew monitor
-  description: A hand-held crew monitor, that runs off of your own power cells, which displays the status of the crew suit sensors.
+  description: A hand-held crew monitor that runs off of your own power cells, which displays the status of the crew suit sensors.
   noSpawn: true
   components:
   - type: Sprite
@@ -108,13 +108,7 @@
     receiveFrequencyId: CrewMonitor
   - type: WirelessNetworkConnection
     range: 500
-  - type: DynamicPrice
-    price: 500
   - type: StationLimitedNetwork
-  - type: ReverseEngineering
-    difficulty: 2
-    recipes:
-      - HandheldCrewMonitor
 
 - type: entity
   parent: BaseItem

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Borgs/borgs_tools.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Borgs/borgs_tools.yml
@@ -2,7 +2,7 @@
   parent: BaseItem
   id: HyposprayBorgStandard
   name: epinephrine hypospray
-  description: A sterile injector for rapid administration of drugs to patients.
+  description: A sterile injector for rapid administration of drugs to patients. It slowly regenerates epinephrine.
   noSpawn: true
   components:
   - type: Sprite

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Borgs/borgs_tools.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Borgs/borgs_tools.yml
@@ -59,7 +59,7 @@
           Quantity: 1
 
 - type: entity
-  name: medical robot health analyzer
+  name: robot health analyzer
   parent: BaseItem
   id: HandheldHealthAnalyzerBorg
   description: A hand-held body scanner capable of distinguishing vital signs of the subject.
@@ -81,6 +81,36 @@
   - type: Tag
     tags:
     - DiscreteHealthAnalyzer
+
+- type: entity
+  name: robot handheld crew monitor
+  parent: BaseItem
+  id: HandheldCrewMonitorBorg
+  description: A hand-held crew monitor displaying the status of suit sensors.
+  components:
+  - type: Sprite
+    sprite: Objects/Specific/Medical/handheldcrewmonitor.rsi
+    state: scanner
+  - type: ActivatableUI
+    key: enum.CrewMonitoringUIKey.Key
+    closeOnHandDeselect: false
+  - type: UserInterface
+    interfaces:
+      - key: enum.CrewMonitoringUIKey.Key
+        type: CrewMonitoringBoundUserInterface
+  - type: CrewMonitoringConsole
+  - type: DeviceNetwork
+    deviceNetId: Wireless
+    receiveFrequencyId: CrewMonitor
+  - type: WirelessNetworkConnection
+    range: 500
+  - type: DynamicPrice
+    price: 500
+  - type: StationLimitedNetwork
+  - type: ReverseEngineering
+    difficulty: 2
+    recipes:
+      - HandheldCrewMonitor
 
 - type: entity
   parent: BaseItem

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Borgs/borgs_tools.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Borgs/borgs_tools.yml
@@ -1,8 +1,9 @@
 - type: entity
-  name: epinephrine hypospray
   parent: BaseItem
-  description: A borg version of hypospray that automatically regenerates epinephrine.
   id: HyposprayBorgStandard
+  name: epinephrine hypospray
+  suffix: Robot, No Map
+  description: A borg version of hypospray that automatically regenerates epinephrine.
   components:
   - type: Sprite
     sprite: Objects/Specific/Medical/hypospray.rsi
@@ -28,6 +29,7 @@
   parent: HyposprayBorgStandard
   id: HyposprayBorgMedical
   name: medical robot hypospray
+  suffix: Robot, No Map
   description: A hypospray that can switch through several reagents.
   components:
   - type: SolutionContainerManager
@@ -59,9 +61,10 @@
           Quantity: 1
 
 - type: entity
-  name: robot health analyzer
   parent: BaseItem
   id: HandheldHealthAnalyzerBorg
+  name: robot health analyzer
+  suffix: Robot, No Map
   description: A hand-held body scanner capable of distinguishing vital signs of the subject.
   components:
   - type: Sprite
@@ -83,9 +86,10 @@
     - DiscreteHealthAnalyzer
 
 - type: entity
-  name: robot handheld crew monitor
   parent: BaseItem
   id: HandheldCrewMonitorBorg
+  name: robot handheld crew monitor
+  suffix: Robot, No Map
   description: A hand-held crew monitor displaying the status of suit sensors.
   components:
   - type: Sprite

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Borgs/borgs_tools.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Borgs/borgs_tools.yml
@@ -65,7 +65,7 @@
   id: HandheldHealthAnalyzerBorg
   name: health analyzer
   suffix: Robot, No Map
-  description: A batteryless hand-held body scanner capable of distinguishing vital signs of the subject meant for medical robots.
+  description: A batteryless hand-held body scanner meant for medical robots capable of distinguishing vital signs of the subject.
   components:
   - type: Sprite
     sprite: Objects/Specific/Medical/healthanalyzer.rsi
@@ -90,7 +90,7 @@
   id: HandheldCrewMonitorBorg
   name: handheld crew monitor
   suffix: Robot, No Map
-  description: A batteryless hand-held crew monitor displaying the status of suit sensors designed for robots.
+  description: A batteryless hand-held crew monitor designed for robots which displays the status of the crew suit sensors.
   components:
   - type: Sprite
     sprite: Objects/Specific/Medical/handheldcrewmonitor.rsi

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Borgs/borgs_tools.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Borgs/borgs_tools.yml
@@ -2,8 +2,8 @@
   parent: BaseItem
   id: HyposprayBorgStandard
   name: epinephrine hypospray
-  suffix: Robot, No Map
-  description: A borg version of hypospray that automatically regenerates epinephrine.
+  description: A sterile injector for rapid administration of drugs to patients.
+  noSpawn: true
   components:
   - type: Sprite
     sprite: Objects/Specific/Medical/hypospray.rsi
@@ -29,8 +29,8 @@
   parent: HyposprayBorgStandard
   id: HyposprayBorgMedical
   name: medical robot hypospray
-  suffix: Robot, No Map
-  description: A hypospray that can switch through several reagents.
+  description: A sterile injector for rapid administration of drugs to patients. This one can switch through several reagents.
+  noSpawn: true
   components:
   - type: SolutionContainerManager
     solutions:
@@ -64,8 +64,8 @@
   parent: BaseItem
   id: HandheldHealthAnalyzerBorg
   name: health analyzer
-  suffix: Robot, No Map
-  description: A batteryless hand-held body scanner meant for medical robots capable of distinguishing vital signs of the subject.
+  description: A hand-held body scanner, that runs off of your own power cells, capable of distinguishing vital signs of the subject.
+  noSpawn: true
   components:
   - type: Sprite
     sprite: Objects/Specific/Medical/healthanalyzer.rsi
@@ -89,8 +89,8 @@
   parent: BaseItem
   id: HandheldCrewMonitorBorg
   name: handheld crew monitor
-  suffix: Robot, No Map
-  description: A batteryless hand-held crew monitor designed for robots which displays the status of the crew suit sensors.
+  description: A hand-held crew monitor, that runs off of your own power cells, which displays the status of the crew suit sensors.
+  noSpawn: true
   components:
   - type: Sprite
     sprite: Objects/Specific/Medical/handheldcrewmonitor.rsi

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Borgs/borgs_tools.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Borgs/borgs_tools.yml
@@ -61,7 +61,7 @@
 - type: entity
   name: medical robot health analyzer
   parent: BaseItem
-  id: BorgHealthAnalyzer
+  id: HandheldHealthAnalyzerBorg
   description: A hand-held body scanner capable of distinguishing vital signs of the subject.
   components:
   - type: Sprite

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Borgs/borgs_tools.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Borgs/borgs_tools.yml
@@ -63,9 +63,9 @@
 - type: entity
   parent: BaseItem
   id: HandheldHealthAnalyzerBorg
-  name: robot health analyzer
+  name: health analyzer
   suffix: Robot, No Map
-  description: A hand-held body scanner capable of distinguishing vital signs of the subject.
+  description: A batteryless hand-held body scanner capable of distinguishing vital signs of the subject meant for medical robots.
   components:
   - type: Sprite
     sprite: Objects/Specific/Medical/healthanalyzer.rsi
@@ -88,9 +88,9 @@
 - type: entity
   parent: BaseItem
   id: HandheldCrewMonitorBorg
-  name: robot handheld crew monitor
+  name: handheld crew monitor
   suffix: Robot, No Map
-  description: A hand-held crew monitor displaying the status of suit sensors.
+  description: A batteryless hand-held crew monitor displaying the status of suit sensors designed for robots.
   components:
   - type: Sprite
     sprite: Objects/Specific/Medical/handheldcrewmonitor.rsi


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Forgot that they added batteries into everything. 
- Add a special version `HandheldCrewMonitorBorg` that doesn't need charges specifically to the robot.
- Changes the health analyzer id to `HandheldHealthAnalyzerBorg` like previously suggested after #1565 was merged.
- Adds the suffix "Robot, No Map" to all the robot tools to avoid them being mapped by accident since they are meant only for the robot as far as I know.

**Media**

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- fix: Fixed medical robots crew monitor running out of charges.

