### PR TITLE
Rewrite MassMindSwapRule

### DIFF
--- a/Content.Server/Nyanotrasen/StationEvents/Events/MassMindSwapRule.cs
+++ b/Content.Server/Nyanotrasen/StationEvents/Events/MassMindSwapRule.cs
@@ -66,7 +66,7 @@ internal sealed class MassMindSwapRule : StationEventSystem<MassMindSwapRuleComp
                     return;
 
                 // Pop the last entry off.
-                var other = psionicPool[psionicPool.Count - 1];
+                var other = psionicPool[^1];
                 psionicPool.RemoveAt(psionicPool.Count - 1);
 
                 if (other == actor)

--- a/Content.Server/Nyanotrasen/StationEvents/Events/MassMindSwapRule.cs
+++ b/Content.Server/Nyanotrasen/StationEvents/Events/MassMindSwapRule.cs
@@ -1,3 +1,5 @@
+using Robust.Server.GameObjects;
+using Robust.Shared.Random;
 using Content.Server.Abilities.Psionics;
 using Content.Server.GameTicking.Rules.Components;
 using Content.Server.Psionics;
@@ -14,6 +16,7 @@ namespace Content.Server.StationEvents.Events;
 /// </summary>
 internal sealed class MassMindSwapRule : StationEventSystem<MassMindSwapRuleComponent>
 {
+    [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly MobStateSystem _mobStateSystem = default!;
     [Dependency] private readonly MindSwapPowerSystem _mindSwap = default!;
 
@@ -21,38 +24,67 @@ internal sealed class MassMindSwapRule : StationEventSystem<MassMindSwapRuleComp
     {
         base.Started(uid, component, gameRule, args);
 
-        List<EntityUid> psionicList = new();
+        List<EntityUid> psionicPool = new();
+        List<EntityUid> psionicActors = new();
 
         var query = EntityQueryEnumerator<PotentialPsionicComponent, MobStateComponent>();
         while (query.MoveNext(out var psion, out _, out _))
         {
             if (_mobStateSystem.IsAlive(psion) && !HasComp<PsionicInsulationComponent>(psion))
-                psionicList.Add(psion);
-        }
-
-        // Even out with a scribe...
-        if (psionicList.Count % 2 != 0)
-        {
-            var queryScribe = EntityQueryEnumerator<SophicScribeComponent>();
-            while (queryScribe.MoveNext(out var scribe, out _))
             {
-                psionicList.Add(scribe);
-                break;
+                psionicPool.Add(psion);
+
+                if (HasComp<ActorComponent>(psion))
+                {
+                    // This is so we don't bother mindswapping NPCs with NPCs.
+                    psionicActors.Add(psion);
+                }
             }
         }
 
-        for (int i = 0; i < psionicList.Count; i += 2)
+        // Throw the scribe in there, for old time's sake.
+        var queryScribe = EntityQueryEnumerator<SophicScribeComponent>();
+        while (queryScribe.MoveNext(out var scribe, out _))
         {
-            var performer = psionicList[i];
-            var target = psionicList[i+1];
+            psionicPool.Add(scribe);
 
-            _mindSwap.Swap(performer, target);
+            if (HasComp<ActorComponent>(scribe))
+                // Looks like we found someone who got swapped to a scribe.
+                // Give them a chance to get swapped out again.
+                psionicActors.Add(scribe);
+        }
 
-            if (!component.IsTemporary)
+        // Shuffle the list of candidates.
+        _random.Shuffle(psionicPool);
+
+        foreach (var actor in psionicActors)
+        {
+            do
             {
-                _mindSwap.GetTrapped(performer);
-                _mindSwap.GetTrapped(target);
-            }
+                if (psionicPool.Count == 0)
+                    // We ran out of candidates. Exit early.
+                    return;
+
+                // Pop the last entry off.
+                var other = psionicPool[psionicPool.Count - 1];
+                psionicPool.RemoveAt(psionicPool.Count - 1);
+
+                if (other == actor)
+                    // Don't be yourself. Find someone else.
+                    continue;
+
+                // A valid swap target has been found.
+                // Remove this actor from the pool of swap candidates before they go.
+                psionicPool.Remove(actor);
+
+                // Do the swap.
+                _mindSwap.Swap(actor, other);
+                if (!component.IsTemporary)
+                {
+                    _mindSwap.GetTrapped(actor);
+                    _mindSwap.GetTrapped(other);
+                }
+            } while (true);
         }
     }
 }


### PR DESCRIPTION
During my last update merge, I completely rewrote MassMindSwapRule in an attempt to see if it would help tests pass. Unfortunately it did not, and I had to manually disable the event from running during SpawnAndDirtyAllEntities. The upside of this is we now have a more performant event.

Mass mind swap will now only bother with entities that have an Actor component. You'll still be able to swap to any other potentially-psionic mob (including the scribe), but it won't try to do NPC-to-NPC swaps anymore.

This should help a bit with the lag that occurs with mass mind swap, but there will probably still be lag from PVS getting refreshed for every swapped client.

@Elijahrane: Let me know if there are any oversights here.