### PR TITLE
Make RatKing self-point stop servant attacks

### DIFF
--- a/Content.Server/RatKing/RatKingSystem.cs
+++ b/Content.Server/RatKing/RatKingSystem.cs
@@ -107,10 +107,20 @@ namespace Content.Server.RatKing
             if (!HasComp<MobStateComponent>(args.Target))
                 return;
 
-            foreach (var servant in component.Servants)
+            if (args.Target == uid)
             {
-                var targeted = EnsureComp<NPCCombatTargetComponent>(servant);
-                targeted.EngagingEnemies.Add(args.Target);
+                // Pointed to self, cancel all attacks.
+                foreach (var servant in component.Servants)
+                    RemComp<NPCCombatTargetComponent>(servant);
+            }
+            else
+            {
+                // Pointed to someone else, go kill.
+                foreach (var servant in component.Servants)
+                {
+                    var targeted = EnsureComp<NPCCombatTargetComponent>(servant);
+                    targeted.EngagingEnemies.Add(args.Target);
+                }
             }
         }
 


### PR DESCRIPTION
So while testing some faction refactor code and how it meshes with our own systems, I discovered that the rat king has no way to stop his servants from attacking. I added some behavior here to fix that. I'm not sure if this should be another action or not, but I feel like pointing at yourself goes with the flow a little better.

Maybe this will help with rat king negotiations. One can hope.

:cl:
- add: Rat kings can now point at themselves to stop their servants from attacking.