### PR TITLE
Fix several reagents satiating vampires

### DIFF
--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -684,6 +684,10 @@
         factor: 2
       - !type:SatiateHunger
         factor: -2
+        conditions:
+        - !type:OrganType
+          type: Vampiric
+          shouldHave: false
       - !type:AdjustReagent
         reagent: Ethanol
         amount: 0.05

--- a/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
@@ -356,6 +356,10 @@
       effects:
       - !type:SatiateHunger
         factor: 1
+        conditions:
+        - !type:OrganType
+          type: Vampiric
+          shouldHave: false
 
 - type: reagent
   id: HotRamen
@@ -370,6 +374,10 @@
       effects:
       - !type:SatiateHunger
         factor: 4
+        conditions:
+        - !type:OrganType
+          type: Vampiric
+          shouldHave: false
 
 - type: reagent
   id: Pilk

--- a/Resources/Prototypes/Reagents/Consumable/Food/condiments.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Food/condiments.yml
@@ -141,6 +141,10 @@
       effects:
       - !type:SatiateHunger
         factor: 0.5
+        conditions:
+        - !type:OrganType
+          type: Vampiric
+          shouldHave: false
       - !type:SatiateThirst
         factor: -0.5 # high salt content
 
@@ -173,5 +177,9 @@
       # eating salt on its own kinda sucks, kids
       - !type:SatiateHunger
         factor: 0.5
+        conditions:
+        - !type:OrganType
+          type: Vampiric
+          shouldHave: false
       - !type:SatiateThirst
         factor: -0.5

--- a/Resources/Prototypes/Reagents/Consumable/Food/food.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Food/food.yml
@@ -51,6 +51,10 @@
           type: Vampiric
           shouldHave: false
       - !type:SatiateHunger #Numbers are balanced with this in mind + it helps limit how much healing you can get from food
+        conditions:
+        - !type:OrganType
+          type: Vampiric
+          shouldHave: false
   pricePerUnit: 2.5
 
 - type: reagent
@@ -91,6 +95,9 @@
         - !type:ReagentThreshold #Only satiates when eaten with nutriment
           reagent: Nutriment
           min: 0.1
+        - !type:OrganType
+          type: Vampiric
+          shouldHave: false
         factor: 1
   plantMetabolism:
   - !type:PlantAdjustNutrition

--- a/Resources/Prototypes/Reagents/biological.yml
+++ b/Resources/Prototypes/Reagents/biological.yml
@@ -58,6 +58,10 @@
       effects:
       - !type:SatiateHunger
         factor: 1.5
+        conditions:
+        - !type:OrganType
+          type: Vampiric
+          shouldHave: false
 
 - type: reagent
   id: Ichor

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -641,6 +641,10 @@
       # what the hell, this isn't satiating at all!!
       - !type:SatiateHunger
         factor: -1
+        conditions:
+        - !type:OrganType
+          type: Vampiric
+          shouldHave: false
 
   # Should heal quite literally everything, use in very small amounts
 - type: reagent


### PR DESCRIPTION
Vampires now must survive off of blood and protein.

I made even the reagents that made you hungrier (except for prometheum) not affect hunger if you have a vampiric stomach, since it made sense in my mind.

:cl:
- fix: Vampiric creatures such as the Arachne will no longer be able to sustain themselves off of salt, sugar, slime, vitamins, ramen, and soy sauce.

(What a diet.)