### PR TITLE
Fix Arachne buckling to webs

### DIFF
--- a/Resources/Locale/en-US/abilities/arachne.ftl
+++ b/Resources/Locale/en-US/abilities/arachne.ftl
@@ -10,5 +10,4 @@ cocoon-start-second-person = You start cocooning {THE($target)}.
 cocoon-start-third-person = {CAPITALIZE(THE($spider))} starts cocooning {THE($target)}.
 spun-web-second-person = You spin up a web.
 spun-web-third-person = {CAPITALIZE(THE($spider))} spins up a web!
-rest-on-web = Rest on web
 cocoon = Cocoon

--- a/Resources/Prototypes/Nyanotrasen/Entities/Structures/Webbing/webs.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Structures/Webbing/webs.yml
@@ -80,6 +80,9 @@
       path: /Audio/Effects/plant_rustle.ogg
     unbuckleSound: !type:SoundPathSpecifier
       path: /Audio/Effects/plant_rustle.ogg
+    allowedEntities:
+      components:
+        - Arachne
   - type: HealOnBuckle
     damage:
       groups:


### PR DESCRIPTION
We're using the new refactored buckle code. Much simpler.

I briefly checked if the oneirophage could do this too, but it appears to need hands. Maybe something that can be addressed in a later PR.

:cl:
- fix: Arachne can now safely buckle and unbuckle to webs again, letting them rest.
