### PR TITLE
Add Trash tag to FoodBadRecipe

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/ingredients.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/ingredients.yml
@@ -521,3 +521,6 @@
           Quantity: 2
         - ReagentId: Toxin
           Quantity: 3
+  - type: Tag
+    tags:
+    - Trash


### PR DESCRIPTION
This is mainly for the deep fryer, so these waste items don't pile up.

:cl:
- fix: Burned food can now be destroyed in the recycler.