### PR TITLE
Cannabis changes

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/joints.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/joints.yml
@@ -25,10 +25,10 @@
   - type: SolutionContainerManager
     solutions:
       smokable:
-        maxVol: 20
+        maxVol: 30
         reagents:
           - ReagentId: THC
-            Quantity: 10
+            Quantity: 20
 
 - type: entity
   id: Blunt
@@ -57,7 +57,7 @@
   - type: SolutionContainerManager
     solutions:
       smokable:
-        maxVol: 20
+        maxVol: 30
         reagents:
           - ReagentId: THC
-            Quantity: 10
+            Quantity: 20

--- a/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/leaves.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/leaves.yml
@@ -16,7 +16,7 @@
       food:
         reagents:
         - ReagentId: THC
-          Quantity: 5
+          Quantity: 15
 
 - type: entity
   name: dried cannabis leaves
@@ -32,7 +32,7 @@
       food:
         reagents:
         - ReagentId: THC
-          Quantity: 2
+          Quantity: 12
   - type: Sprite
     sprite: Objects/Specific/Hydroponics/tobacco.rsi
     state: dried

--- a/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/leaves.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/leaves.yml
@@ -51,7 +51,7 @@
       food:
         reagents:
         - ReagentId: THC
-          Quantity: 10
+          Quantity: 20
   - type: Sprite
     sprite: Objects/Misc/reagent_fillings.rsi
     state: powderpile

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Consumable/Food/Baked/misc.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Consumable/Food/Baked/misc.yml
@@ -15,14 +15,14 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 148
+        maxVol: 228
         reagents:
         - ReagentId: Nutriment
           Quantity: 30
         - ReagentId: Theobromine
           Quantity: 18
         - ReagentId: THC
-          Quantity: 90
+          Quantity: 150
   - type: SliceableFood
     count: 6
     slice: FoodBakedCannabisBrownie
@@ -44,14 +44,14 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 28
+        maxVol: 38
         reagents:
         - ReagentId: Nutriment
           Quantity: 5
         - ReagentId: Theobromine
           Quantity: 3
         - ReagentId: THC
-          Quantity: 15
+          Quantity: 25
 
 - type: entity
   name: cheesecake balls

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Consumable/Food/ingredients.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Consumable/Food/ingredients.yml
@@ -10,12 +10,12 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 60
+        maxVol: 100
         reagents:
         - ReagentId: Butter
           Quantity: 10
         - ReagentId: THC
-          Quantity: 45
+          Quantity: 82
   - type: Extractable
     grindableSolutionName: food
 

--- a/Resources/Prototypes/Nyanotrasen/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/Nyanotrasen/Recipes/Cooking/meal_recipes.yml
@@ -6,7 +6,7 @@
   time: 15
   solids:
     FoodButter: 1
-    LeavesCannabis: 9
+    LeavesCannabis: 6
 
 - type: microwaveMealRecipe
   id: RecipeCannabisBrownies


### PR DESCRIPTION
Changelog:

- Rebalances THC quantities in cannabis products and refactors crafting efficiencies.

LR=15
LD=12(20% loss)
2LD(24)=LG=20(~17% loss)
1LG=Joint=20
(33% overall loss)

LR=15
6leaves(90) + butter = 1CB= 82(10% loss)
2 CB(164) = 6brownies =  150 (~9% loss)
1 brownie = 25 (17% overall loss)