### PR TITLE
Make Escape a mandatory Traitor objective

### DIFF
--- a/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
@@ -4,6 +4,7 @@ using Content.Server.Database;
 using Content.Server.Chat.Managers;
 using Content.Server.GameTicking.Rules.Components;
 using Content.Server.NPC.Systems;
+using Content.Server.Objectives;
 using Content.Server.Objectives.Interfaces;
 using Content.Server.PDA.Ringer;
 using Content.Server.Players;
@@ -270,6 +271,10 @@ public sealed class TraitorRuleSystem : GameRuleSystem<TraitorRuleComponent>
             if (traitorRole.Mind.TryAddObjective(objective))
                 difficulty += objective.Difficulty;
         }
+
+        // Begin Nyano-code: Escape is a mandatory objective for Traitors.
+        traitorRole.Mind.TryAddObjective(_prototypeManager.Index<ObjectivePrototype>("EscapeShuttleObjective"));
+        // End Nyano-code.
 
         //give traitors their codewords and uplink code to keep in their character info menu
         traitorRole.Mind.Briefing = Loc.GetString("traitor-role-codewords-short", ("codewords", string.Join(", ", traitorRule.Codewords)))

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -4,7 +4,7 @@
   weights:
     TraitorObjectiveGroupSteal: 2.5
     TraitorObjectiveGroupKill: 1
-    TraitorObjectiveGroupState: 1 #As in, something about your character. Alive, dead, arrested, gained an ability...
+    TraitorObjectiveGroupState: 0.5 #As in, something about your character. Alive, dead, arrested, gained an ability...
     TraitorObjectiveGroupSocial: 1 #Involves helping/harming others without killing them or stealing their stuff
 
 - type: weightedRandom
@@ -29,9 +29,8 @@
 - type: weightedRandom
   id: TraitorObjectiveGroupState
   weights:
-    EscapeShuttleObjective: 1
-    BecomePsionicObjective: 0.5
-    BecomeGolemObjective: 0.25
+    BecomePsionicObjective: 1
+    BecomeGolemObjective: 0.5
 
 - type: weightedRandom
   id: TraitorObjectiveGroupSocial


### PR DESCRIPTION
Supercedes #1329 

:cl:
- tweak: Traitors must escape alive and unrestrained.
