### PR TITLE
Fix fugitive and oneirophage spawn. Update fugitive and ewil twin. Mid round antag event improvements

### DIFF
--- a/Content.Server/Nyanotrasen/Fugitive/FugitiveComponent.cs
+++ b/Content.Server/Nyanotrasen/Fugitive/FugitiveComponent.cs
@@ -1,13 +1,8 @@
-using Robust.Shared.Audio;
-
 namespace Content.Server.Fugitive
 {
     [RegisterComponent]
     public sealed class FugitiveComponent : Component
     {
-        [DataField("spawnSound")]
-        public SoundSpecifier SpawnSoundPath = new SoundPathSpecifier("/Audio/Effects/clang.ogg");
-
         [DataField("firstMindAdded")]
         public bool FirstMindAdded = false;
     }

--- a/Content.Server/Nyanotrasen/Fugitive/FugitiveSpawner.cs
+++ b/Content.Server/Nyanotrasen/Fugitive/FugitiveSpawner.cs
@@ -1,0 +1,54 @@
+using Content.Server.Maps;
+using Content.Server.Players;
+using Content.Server.Popups;
+using Content.Server.Stunnable;
+using Content.Shared.Examine;
+using Robust.Server.GameObjects;
+using Robust.Shared.Audio;
+using Robust.Shared.Map;
+using Robust.Shared.Player;
+using Robust.Shared.Timing;
+using static Content.Shared.Examine.ExamineSystemShared;
+
+namespace Content.Server.Fugitive
+{
+    public sealed class FugitiveSpawnerSystem : EntitySystem
+    {
+        [Dependency] private readonly IGameTiming _timing = default!;
+        [Dependency] private readonly PopupSystem _popupSystem = default!;
+        [Dependency] private readonly AudioSystem _audioSystem = default!;
+        [Dependency] private readonly StunSystem _stun = default!;
+        [Dependency] private readonly IMapManager _mapManager = default!;
+        [Dependency] private readonly TileSystem _tile = default!;
+
+        public override void Initialize()
+        {
+            base.Initialize();
+            SubscribeLocalEvent<FugitiveSpawnerComponent, PlayerAttachedEvent>(OnPlayerAttached);
+        }
+
+        private void OnPlayerAttached(EntityUid uid, FugitiveSpawnerComponent component, PlayerAttachedEvent args)
+        {
+            var xform = Transform(uid);
+            var fugitive = Spawn(component.Prototype, xform.Coordinates);
+
+            if (TryComp<FugitiveCountdownComponent>(fugitive, out var cd))
+                cd.AnnounceTime = _timing.CurTime + cd.AnnounceCD;
+
+            _popupSystem.PopupEntity(Loc.GetString("fugitive-spawn", ("name", fugitive)), fugitive,
+                Filter.Pvs(fugitive).RemoveWhereAttachedEntity(entity => !ExamineSystemShared.InRangeUnOccluded(
+                    fugitive, entity, ExamineRange, null)), true,
+                Shared.Popups.PopupType.LargeCaution);
+
+            _stun.TryParalyze(fugitive, TimeSpan.FromSeconds(2), false);
+            _audioSystem.PlayPvs(component.SpawnSoundPath, uid, AudioParams.Default.WithVolume(-6f));
+
+            if (!_mapManager.TryGetGrid(xform.GridUid, out var map))
+                return;
+            var currentTile = map.GetTileRef(xform.Coordinates);
+            _tile.PryTile(currentTile);
+
+            args.Player.ContentData()?.Mind?.TransferTo(fugitive, true);
+        }
+    }
+}

--- a/Content.Server/Nyanotrasen/Fugitive/FugitiveSpawnerComponent.cs
+++ b/Content.Server/Nyanotrasen/Fugitive/FugitiveSpawnerComponent.cs
@@ -1,0 +1,17 @@
+using Robust.Shared.Audio;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+
+namespace Content.Server.Fugitive
+{
+    [RegisterComponent]
+    public sealed class FugitiveSpawnerComponent : Component
+    {
+        [DataField("spawnSound")]
+        public SoundSpecifier SpawnSoundPath = new SoundPathSpecifier("/Audio/Effects/clang.ogg");
+
+        [ViewVariables(VVAccess.ReadWrite),
+         DataField("prototype", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
+        public string Prototype = "MobHumanFugitive";
+    }
+}

--- a/Content.Server/Nyanotrasen/StationEvents/Components/MidRoundAntagRuleComponent.cs
+++ b/Content.Server/Nyanotrasen/StationEvents/Components/MidRoundAntagRuleComponent.cs
@@ -1,16 +1,14 @@
 using Content.Server.StationEvents.Events;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
 namespace Content.Server.StationEvents.Components;
 
 [RegisterComponent, Access(typeof(MidRoundAntagRule))]
 public sealed class MidRoundAntagRuleComponent : Component
 {
-    [DataField("antags")]
-    public readonly IReadOnlyList<string> MidRoundAntags = new[]
-    {
-        "SpawnPointGhostRatKing",
-        "SpawnPointGhostVampSpider",
-        "SpawnPointGhostFugitive",
-        "MobEvilTwinSpawn"
-    };
+
+    [ViewVariables(VVAccess.ReadWrite), DataField("spawnPoint", required: true, customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
+    public string SpawnPoint = String.Empty;
+
 }

--- a/Content.Server/Nyanotrasen/StationEvents/Events/MidRoundAntagRule.cs
+++ b/Content.Server/Nyanotrasen/StationEvents/Events/MidRoundAntagRule.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using Robust.Shared.Random;
 using Content.Server.GameTicking.Rules.Components;
 using Content.Server.StationEvents.Components;
+using Content.Shared.Random.Helpers;
 
 namespace Content.Server.StationEvents.Events;
 
@@ -22,20 +23,18 @@ internal sealed class MidRoundAntagRule : StationEventSystem<MidRoundAntagRuleCo
         {
             var spawnLoc = _robustRandom.Pick(spawnLocations);
             spawn = spawnLoc.Item2;
-        } else if (backupSpawnLocations.Count > 0)
+        }
+        else if (backupSpawnLocations.Count > 0)
         {
             var spawnLoc = _robustRandom.Pick(backupSpawnLocations);
             spawn = spawnLoc.Item2;
         }
-
-        if (spawn == null)
-            return;
 
         if (spawn.GridUid == null)
         {
             return;
         }
 
-        Spawn(_robustRandom.Pick(component.MidRoundAntags), spawn.Coordinates);
+        Spawn(component.SpawnPoint, spawn.Coordinates);
     }
 }

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/humanoid.yml
@@ -1,21 +1,3 @@
-# Unfortunate, isn't it, that these don't work for ghost roles?
-
-# - type: entity
-#   id: RandomHumanoidSpawnerFugitive
-#   name: fugitive
-#   components:
-#     - type: Icon
-#       sprite: Mobs/Species/Human/parts.rsi
-#       state: full
-#     - type: RandomHumanoidSpawner
-#       settings: Fugitive
-
-# - type: randomHumanoidSettings
-#   id: Fugitive
-#   components:
-#     - type: Loadout
-#       prototypes: [FugitiveStartingGear]
-
 - type: entity
   parent: MobHuman
   id: MobHumanFugitive
@@ -29,9 +11,30 @@
     - type: RandomHumanoidAppearance
 
 - type: entity
+  id: SpawnPointGhostFugitive
+  name: Fugitive
+  suffix: DONTMAP, fugitive
   parent: MarkerBase
-  id: MobEvilTwinSpawn
-  name: paradox anomaly
+  components:
+    - type: FugitiveSpawner
+    - type: GhostRole
+      prototype: MobHumanFugitive
+      name: Fugitive
+      description: You're an escaped prisoner. Make it out alive.
+      rules: |
+        You are the lightest of antags.
+        Murderboning = ban and whitelist removal.
+    - type: Sprite
+      sprite: Markers/jobs.rsi
+      layers:
+        - state: green
+        - state: prisoner
+    - type: GhostTakeoverAvailable
+
+- type: entity
+  parent: MarkerBase
+  id: SpawnPointGhostEvilTwin
+  name: Evil Twin
   components:
   - type: EvilTwinSpawner
   - type: Sprite

--- a/Resources/Prototypes/Nyanotrasen/GameRules/events.yml
+++ b/Resources/Prototypes/Nyanotrasen/GameRules/events.yml
@@ -12,18 +12,61 @@
       earliestStart: 15
     - type: NoosphericStormRule
 
-# Rat king, paradox anomaly, fugitive, oneiro, etc.
 - type: entity
-  id: MidRoundAntag
+  id: SpawnVampSpider
   parent: BaseGameRule
   noSpawn: true
   components:
     - type: StationEvent
-      weight: 7
-      reoccurrenceDelay: 5
-      minimumPlayers: 15
       earliestStart: 25
+      minimumPlayers: 15
+      reoccurrenceDelay: 5
+      weight: 5
+      duration: 25
     - type: MidRoundAntagRule
+      spawnPoint: SpawnPointGhostVampSpider
+
+- type: entity
+  id: SpawnFugitive
+  parent: BaseGameRule
+  noSpawn: true
+  components:
+    - type: StationEvent
+      earliestStart: 10
+      minimumPlayers: 15
+      reoccurrenceDelay: 5
+      weight: 10
+      duration: 25
+    - type: MidRoundAntagRule
+      spawnPoint: SpawnPointGhostFugitive
+
+- type: entity
+  id: SpawnEvilTwin
+  parent: BaseGameRule
+  noSpawn: true
+  components:
+    - type: StationEvent
+      earliestStart: 10
+      minimumPlayers: 10
+      reoccurrenceDelay: 5
+      weight: 10
+      duration: 25
+    - type: MidRoundAntagRule
+      spawnPoint: SpawnPointGhostEvilTwin
+
+- type: entity
+  id: SpawnRatKing
+  parent: BaseGameRule
+  noSpawn: true
+  components:
+    - type: StationEvent
+      earliestStart: 25
+      minimumPlayers: 15
+      reoccurrenceDelay: 5
+      weight: 5
+      duration: 25
+    - type: MidRoundAntagRule
+      spawnPoint: SpawnPointGhostRatKing
 
 # Base glimmer event
 - type: entity

--- a/Resources/Prototypes/Nyanotrasen/Markers/Spawners/ghost_roles.yml
+++ b/Resources/Prototypes/Nyanotrasen/Markers/Spawners/ghost_roles.yml
@@ -17,25 +17,6 @@
         state: bat
 
 - type: entity
-  id: SpawnPointGhostFugitive
-  name: ghost role spawn point
-  suffix: DONTMAP, fugitive
-  parent: MarkerBase
-  components:
-  - type: GhostRoleMobSpawner
-    prototype: MobHumanFugitive
-    name: Fugitive
-    description: You're an escaped prisoner. Make it out alive.
-    rules: |
-      You are the lightest of antags.
-      Murderboning = ban and whitelist removal.
-  - type: Sprite
-    sprite: Markers/jobs.rsi
-    layers:
-      - state: green
-      - state: prisoner
-
-- type: entity
   id: SpawnPointLocationMidRoundAntag
   name: possible spawn location
   suffix: MidRoundAntag
@@ -54,11 +35,12 @@
   suffix: Vampire spider
   parent: MarkerBase
   components:
-  - type: GhostRoleMobSpawner
-    prototype: MobGiantSpiderVampireAngry
+  - type: GhostRole
     name: ghost-role-information-giant-spider-vampire-name
     description: ghost-role-information-giant-spider-vampire-description
     rules: No antag restrictions. Just don't talk in emote; you have telepathic chat.
+  - type: GhostRoleMobSpawner
+    prototype: MobGiantSpiderVampireAngry
   - type: Sprite
     sprite: Markers/jobs.rsi
     layers:


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I decided to fix the spawn of the fugitive with the spider, modify the evil double and rework the system of mid-round antag events into different rules, since it’s stupid to put antags of different levels of danger into one random event.
Instead of sending a denunciation to the console, it sends a captain by fax (it is not on all your maps if anything, for example, on a glacier).
Also, if a suitable player is not found to create an evil double, the role of the ghost will not disappear.

**Media**
<!-- 
If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 
(adding clothing, items, new features, etc) must include ingame media or the PR will not be merged, in accordance with our PR guidelines.
This makes it much easier for us to merge PRs and find media for progress reports. If you include media in your pull request, we 
may potentially use it in the SS14 progress reports, with clear credit given.

Use screenshot software like Window's built in snipping tool, ShareX, Lightshot, or recording software like ShareX (gif), ScreenToGif, or Open Broadcaster Software (cross platform).
If you're unsure whether your PR will require media, ask a maintainer.

Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![Screenshot_78](https://github.com/Nyanotrasen/Nyanotrasen/assets/60344369/315ca6d2-6238-412a-9d51-5bdeda25b03b)


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: VigersRay
- fix: Fixed oneirophage spawn
- fix: Fixed fugitive spawn 
- fix: Fix name of evil twin and fugitive in RoundEndText
- tweak: A report on the fugitive is sent to the captain's fax
- tweak: Improved spawn mid round antags

