### PR TITLE
Add missing InventorySlots components

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -429,6 +429,7 @@
   components:
   - type: Inventory
     templateId: crab
+  - type: InventorySlots
   - type: Fixtures
     fixtures:
       fix1:

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/NPCs/dogs.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/NPCs/dogs.yml
@@ -39,6 +39,7 @@
   - type: Inventory
     speciesId: dog
     templateId: pet
+  - type: InventorySlots
   - type: Strippable
   - type: UserInterface
     interfaces:

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/NPCs/primates.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/NPCs/primates.yml
@@ -8,6 +8,7 @@
     flavorKind: station-event-random-sentience-flavor-primate
   - type: Inventory
     templateId: monkey
+  - type: InventorySlots
   - type: Fixtures
     fixtures:
       fix1:


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
I still don't get why they like to make components that have no reason to be separate from another component. Every inventory will have slots and all inventory slots must belong to an inventory.

