### PR TITLE
Fix Nyano GhostRoleMobSpawners

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/NPCs/mutants.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/NPCs/mutants.yml
@@ -204,6 +204,7 @@
       makeSentient: true
       name: ghost-role-information-giant-spider-vampire-name
       description: ghost-role-information-giant-spider-vampire-description
+      rules: No antagonist restrictions. Just don't talk in emote; you have telepathic chat.
     - type: GhostTakeoverAvailable
 
 - type: entity

--- a/Resources/Prototypes/Nyanotrasen/Markers/Spawners/ghost_roles.yml
+++ b/Resources/Prototypes/Nyanotrasen/Markers/Spawners/ghost_roles.yml
@@ -6,6 +6,7 @@
   components:
   - type: GhostRoleMobSpawner
     prototype: MobIfritFamiliar
+  - type: GhostRole
     name: Mystagogue's Ifrit
     description: Obey the mystagogue. Defend the oracle.
     rules: You are a servant of the mystagogue. Obey them directly.
@@ -24,6 +25,7 @@
   components:
   - type: GhostRoleMobSpawner
     prototype: MobHumanFugitive
+  - type: GhostRole
     name: Fugitive
     description: You're an escaped prisoner. Make it out alive.
     rules: |
@@ -56,9 +58,11 @@
   components:
   - type: GhostRoleMobSpawner
     prototype: MobGiantSpiderVampireAngry
+  - type: GhostRole
+    makeSentient: true
     name: ghost-role-information-giant-spider-vampire-name
     description: ghost-role-information-giant-spider-vampire-description
-    rules: No antag restrictions. Just don't talk in emote; you have telepathic chat.
+    rules: No antagonist restrictions. Just don't talk in emote; you have telepathic chat.
   - type: Sprite
     sprite: Markers/jobs.rsi
     layers:


### PR DESCRIPTION
The ifrit, fugitive, and oneirophage lacked the GhostRole component on their respective spawners.

:cl:
- fix: Fixed the ifrit, fugitive, and oneirophage ghost roles.
