### PR TITLE
Re welders

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/welders.yml
@@ -86,6 +86,10 @@
         - ReagentId: WeldingFuel
           Quantity: 250
         maxVol: 250
+  - type: ReverseEngineering
+    difficulty: 3
+    recipes:
+      - WelderIndustrial
 
 - type: entity
   name: advanced industrial welding tool
@@ -106,6 +110,11 @@
         maxVol: 250
   - type: Tool
     speed: 1.3
+  - type: ReverseEngineering
+    difficulty: 3
+    recipes:
+      - WelderIndustrialAdvanced
+
 
 - type: entity
   name: experimental welding tool
@@ -134,6 +143,12 @@
       reagents:
       - ReagentId: WeldingFuel
         Quantity: 1
+  - type: Tool
+    speed: 1.3
+  - type: ReverseEngineering
+    difficulty: 5 #5 due to infinite fuel + industrial welding speed bonus
+    recipes:
+      - WelderExperimental
 
 - type: entity
   name: emergency welding tool

--- a/Resources/Prototypes/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/welders.yml
@@ -115,7 +115,6 @@
     recipes:
       - WelderIndustrialAdvanced
 
-
 - type: entity
   name: experimental welding tool
   parent: Welder

--- a/Resources/Prototypes/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/welders.yml
@@ -143,8 +143,6 @@
       reagents:
       - ReagentId: WeldingFuel
         Quantity: 1
-  - type: Tool
-    speed: 1.3
 
 - type: entity
   name: emergency welding tool

--- a/Resources/Prototypes/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/welders.yml
@@ -87,7 +87,7 @@
           Quantity: 250
         maxVol: 250
   - type: ReverseEngineering
-    difficulty: 3
+    difficulty: 2
     recipes:
       - WelderIndustrial
 

--- a/Resources/Prototypes/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/welders.yml
@@ -145,10 +145,6 @@
         Quantity: 1
   - type: Tool
     speed: 1.3
-  - type: ReverseEngineering
-    difficulty: 5 #5 due to infinite fuel + industrial welding speed bonus
-    recipes:
-      - WelderExperimental
 
 - type: entity
   name: emergency welding tool

--- a/Resources/Prototypes/Nyanotrasen/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Structures/Machines/lathe.yml
@@ -233,6 +233,9 @@
       - CableStack
       - CableMVStack
       - CableHVStack
+      - WelderIndustrial
+      - WelderIndustrialAdvanced
+      - WelderExperimental
   - type: MaterialStorage
     whitelist:
       tags:

--- a/Resources/Prototypes/Nyanotrasen/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Structures/Machines/lathe.yml
@@ -235,7 +235,6 @@
       - CableHVStack
       - WelderIndustrial
       - WelderIndustrialAdvanced
-      - WelderExperimental
   - type: MaterialStorage
     whitelist:
       tags:

--- a/Resources/Prototypes/Nyanotrasen/Recipes/Lathes/advanced_tools.yml
+++ b/Resources/Prototypes/Nyanotrasen/Recipes/Lathes/advanced_tools.yml
@@ -1,0 +1,26 @@
+- type: latheRecipe
+  id: WelderIndustrial
+  result: WelderIndustrial
+  completetime: 5
+  materials:
+    Steel: 400
+    Plastic: 200
+
+- type: latheRecipe
+  id: WelderIndustrialAdvanced
+  result: WelderIndustrialAdvanced
+  completetime: 7.5
+  materials:
+    Steel: 400
+    Plastic: 200
+    Gold: 100
+
+- type: latheRecipe
+  id: WelderExperimental
+  result: WelderExperimental
+  completetime: 10
+  materials:
+    Steel: 800
+    Gold: 200
+    Bluespace: 200
+

--- a/Resources/Prototypes/Nyanotrasen/Recipes/Lathes/advanced_tools.yml
+++ b/Resources/Prototypes/Nyanotrasen/Recipes/Lathes/advanced_tools.yml
@@ -14,13 +14,3 @@
     Steel: 400
     Plastic: 200
     Gold: 100
-
-- type: latheRecipe
-  id: WelderExperimental
-  result: WelderExperimental
-  completetime: 10
-  materials:
-    Steel: 800
-    Gold: 200
-    Bluespace: 200
-


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Added the ability to reverse engineer advanced welders along with a minor buff to the Experminetal Welding tool.


**Media**
<!-- 
If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 
(adding clothing, items, new features, etc) must include ingame media or the PR will not be merged, in accordance with our PR guidelines.
This makes it much easier for us to merge PRs and find media for progress reports. If you include media in your pull request, we 
may potentially use it in the SS14 progress reports, with clear credit given.

Use screenshot software like Window's built in snipping tool, ShareX, Lightshot, or recording software like ShareX (gif), ScreenToGif, or Open Broadcaster Software (cross platform).
If you're unsure whether your PR will require media, ask a maintainer.

Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Reverse engineering machine can now analyze Industrial and Adavanced Industrial welding tool.

