### PR TITLE
Disable VentClog event

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -225,21 +225,21 @@
     lightBreakChancePerSecond: 0.00003
     doorToggleChancePerSecond: 0.0001
 
-- type: entity
-  id: VentClog
-  parent: BaseGameRule
-  noSpawn: true
-  components:
-  - type: StationEvent
-    startAnnouncement: station-event-vent-clog-start-announcement
-    startAudio:
-      path: /Audio/Announcements/ventclog.ogg
-    earliestStart: 15
-    minimumPlayers: 15
-    weight: 5
-    startDelay: 50
-    duration: 60
-  - type: VentClogRule
+# - type: entity
+#   id: VentClog
+#   parent: BaseGameRule
+#   noSpawn: true
+#   components:
+#   - type: StationEvent
+#     startAnnouncement: station-event-vent-clog-start-announcement
+#     startAudio:
+#       path: /Audio/Announcements/ventclog.ogg
+#     earliestStart: 15
+#     minimumPlayers: 15
+#     weight: 5
+#     startDelay: 50
+#     duration: 60
+#   - type: VentClogRule
 
 - type: entity
   id: VentCritters


### PR DESCRIPTION
At present, foam is either too dangerous or too annoying.

By default, 200 units of any valid reagent enters the system of a character standing in VentClog foam per update. Changing the possible reagents to be less lethal just makes it more annoying.

Having 250 units of water in your system means your ability to digest or process any other reagent is limited for a significant time.

Reducing the amount of reagents makes the event almost pointless.


I have a couple ideas for a new event that can replace this in the future, likely with better results. For now, I think the best thing to do is disable this.