### PR TITLE
[1627] move death check to shared and disable/enable psionics instead of removing them

### DIFF
--- a/Content.Server/Nyanotrasen/Chat/NyanoChatSystem.cs
+++ b/Content.Server/Nyanotrasen/Chat/NyanoChatSystem.cs
@@ -1,19 +1,19 @@
-using System.Linq;
-using Content.Shared.Abilities.Psionics;
-using Content.Shared.Bed.Sleep;
-using Content.Shared.Drugs;
-using Content.Shared.Chat;
-using Content.Shared.Database;
-using Content.Shared.Psionics.Glimmer;
-using Content.Server.Administration.Managers;
 using Content.Server.Administration.Logs;
+using Content.Server.Administration.Managers;
 using Content.Server.Chat.Managers;
 using Content.Server.Chat.Systems;
+using Content.Shared.Abilities.Psionics;
+using Content.Shared.Bed.Sleep;
+using Content.Shared.Chat;
+using Content.Shared.Database;
+using Content.Shared.Drugs;
+using Content.Shared.Mobs;
+using Content.Shared.Mobs.Components;
+using Content.Shared.Psionics.Glimmer;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
 using Robust.Shared.Random;
-using Content.Shared.Mobs.Components;
-using Content.Shared.Mobs;
+using System.Linq;
 
 namespace Content.Server.Nyanotrasen.Chat
 {

--- a/Content.Server/Nyanotrasen/Chat/NyanoChatSystem.cs
+++ b/Content.Server/Nyanotrasen/Chat/NyanoChatSystem.cs
@@ -63,7 +63,7 @@ namespace Content.Server.Nyanotrasen.Chat
             return HasComp<PsionicComponent>(entity)
                 && !HasComp<PsionicsDisabledComponent>(entity)
                 && !HasComp<PsionicInsulationComponent>(entity)
-                && TryComp<MobStateComponent>(entity, out var mobstate) && mobstate.CurrentState == MobState.Alive;
+                && (!TryComp<MobStateComponent>(entity, out var mobstate) || mobstate.CurrentState == MobState.Alive);
         }
 
         public void SendTelepathicChat(EntityUid source, string message, bool hideChat)

--- a/Content.Server/Nyanotrasen/Psionics/PsionicsSystem.cs
+++ b/Content.Server/Nyanotrasen/Psionics/PsionicsSystem.cs
@@ -1,18 +1,18 @@
-using Content.Shared.Abilities.Psionics;
-using Content.Shared.StatusEffect;
-using Content.Shared.Mobs;
-using Content.Shared.Psionics.Glimmer;
-using Content.Shared.Weapons.Melee.Events;
-using Content.Shared.Damage.Events;
-using Content.Shared.IdentityManagement;
 using Content.Server.Abilities.Psionics;
-using Content.Server.Electrocution;
 using Content.Server.Chat.Systems;
+using Content.Server.Electrocution;
 using Content.Server.NPC.Components;
 using Content.Server.NPC.Systems;
-using Robust.Shared.Random;
+using Content.Shared.Abilities.Psionics;
+using Content.Shared.Damage.Events;
+using Content.Shared.IdentityManagement;
+using Content.Shared.Mobs;
+using Content.Shared.Psionics.Glimmer;
+using Content.Shared.StatusEffect;
+using Content.Shared.Weapons.Melee.Events;
 using Robust.Shared.Audio;
 using Robust.Shared.Player;
+using Robust.Shared.Random;
 
 namespace Content.Server.Psionics
 {
@@ -52,7 +52,6 @@ namespace Content.Server.Psionics
 
             SubscribeLocalEvent<PsionicComponent, ComponentInit>(OnInit);
             SubscribeLocalEvent<PsionicComponent, ComponentRemove>(OnRemove);
-            SubscribeLocalEvent<PsionicComponent, MobStateChangedEvent>(OnMobStateChanged);
         }
 
         private void OnStartup(EntityUid uid, PotentialPsionicComponent component, MapInitEvent args)
@@ -129,12 +128,6 @@ namespace Content.Server.Psionics
                 return;
 
             _factions.RemoveFaction(uid, "PsionicInterloper");
-        }
-
-        private void OnMobStateChanged(EntityUid uid, PsionicComponent component, MobStateChangedEvent args)
-        {
-            if (args.NewMobState == MobState.Dead)
-                RemCompDeferred(uid, component);
         }
 
         private void OnStamHit(EntityUid uid, AntiPsionicWeaponComponent component, StaminaMeleeHitEvent args)

--- a/Content.Shared/Nyanotrasen/Abilities/Psionics/Items/PsionicItemsSystem.cs
+++ b/Content.Shared/Nyanotrasen/Abilities/Psionics/Items/PsionicItemsSystem.cs
@@ -26,10 +26,10 @@ namespace Content.Shared.Abilities.Psionics
             if (!clothing.Slots.HasFlag(args.SlotFlags))
                 return;
             
-            _psiAbilities.SetPsionicsThroughEligibility(args.Equipee);
             var insul = EnsureComp<PsionicInsulationComponent>(args.Equipee);
             insul.Passthrough = component.Passthrough;
             component.IsActive = true;
+            _psiAbilities.SetPsionicsThroughEligibility(args.Equipee);
         }
 
         private void OnTinfoilUnequipped(EntityUid uid, TinfoilHatComponent component, GotUnequippedEvent args)
@@ -41,8 +41,7 @@ namespace Content.Shared.Abilities.Psionics
                 RemComp<PsionicInsulationComponent>(args.Equipee);
 
             component.IsActive = false;
-
-                _psiAbilities.SetPsionicsThroughEligibility(args.Equipee);
+            _psiAbilities.SetPsionicsThroughEligibility(args.Equipee);
         }
 
         private void OnGranterEquipped(EntityUid uid, ClothingGrantPsionicPowerComponent component, GotEquippedEvent args)

--- a/Content.Shared/Nyanotrasen/Abilities/Psionics/Items/PsionicItemsSystem.cs
+++ b/Content.Shared/Nyanotrasen/Abilities/Psionics/Items/PsionicItemsSystem.cs
@@ -26,7 +26,7 @@ namespace Content.Shared.Abilities.Psionics
             if (!clothing.Slots.HasFlag(args.SlotFlags))
                 return;
             
-            _psiAbilities.SetPsionics(args.Equipee, psionicsEnabled: false);
+            _psiAbilities.SetPsionicsThroughEligibility(args.Equipee);
             var insul = EnsureComp<PsionicInsulationComponent>(args.Equipee);
             insul.Passthrough = component.Passthrough;
             component.IsActive = true;
@@ -42,8 +42,7 @@ namespace Content.Shared.Abilities.Psionics
 
             component.IsActive = false;
 
-            if (!HasComp<PsionicsDisabledComponent>(args.Equipee))
-                _psiAbilities.SetPsionics(args.Equipee, psionicsEnabled: true);
+                _psiAbilities.SetPsionicsThroughEligibility(args.Equipee);
         }
 
         private void OnGranterEquipped(EntityUid uid, ClothingGrantPsionicPowerComponent component, GotEquippedEvent args)

--- a/Content.Shared/Nyanotrasen/Abilities/Psionics/Items/PsionicItemsSystem.cs
+++ b/Content.Shared/Nyanotrasen/Abilities/Psionics/Items/PsionicItemsSystem.cs
@@ -25,7 +25,7 @@ namespace Content.Shared.Abilities.Psionics
             // Is the clothing in its actual slot?
             if (!clothing.Slots.HasFlag(args.SlotFlags))
                 return;
-            
+
             var insul = EnsureComp<PsionicInsulationComponent>(args.Equipee);
             insul.Passthrough = component.Passthrough;
             component.IsActive = true;

--- a/Content.Shared/Nyanotrasen/Abilities/Psionics/Items/PsionicItemsSystem.cs
+++ b/Content.Shared/Nyanotrasen/Abilities/Psionics/Items/PsionicItemsSystem.cs
@@ -26,7 +26,7 @@ namespace Content.Shared.Abilities.Psionics
             if (!clothing.Slots.HasFlag(args.SlotFlags))
                 return;
             
-            _psiAbilities.SetPsionics(args.Equipee, false);
+            _psiAbilities.SetPsionics(args.Equipee, psionicsEnabled: false);
             var insul = EnsureComp<PsionicInsulationComponent>(args.Equipee);
             insul.Passthrough = component.Passthrough;
             component.IsActive = true;
@@ -43,7 +43,7 @@ namespace Content.Shared.Abilities.Psionics
             component.IsActive = false;
 
             if (!HasComp<PsionicsDisabledComponent>(args.Equipee))
-                _psiAbilities.SetPsionics(args.Equipee, true);
+                _psiAbilities.SetPsionics(args.Equipee, psionicsEnabled: true);
         }
 
         private void OnGranterEquipped(EntityUid uid, ClothingGrantPsionicPowerComponent component, GotEquippedEvent args)

--- a/Content.Shared/Nyanotrasen/Abilities/Psionics/Items/PsionicItemsSystem.cs
+++ b/Content.Shared/Nyanotrasen/Abilities/Psionics/Items/PsionicItemsSystem.cs
@@ -26,7 +26,7 @@ namespace Content.Shared.Abilities.Psionics
             if (!clothing.Slots.HasFlag(args.SlotFlags))
                 return;
             
-            _psiAbilities.TogglePsionics(args.Equipee, false);
+            _psiAbilities.SetPsionics(args.Equipee, false);
             var insul = EnsureComp<PsionicInsulationComponent>(args.Equipee);
             insul.Passthrough = component.Passthrough;
             component.IsActive = true;
@@ -43,7 +43,7 @@ namespace Content.Shared.Abilities.Psionics
             component.IsActive = false;
 
             if (!HasComp<PsionicsDisabledComponent>(args.Equipee))
-                _psiAbilities.TogglePsionics(args.Equipee, true);
+                _psiAbilities.SetPsionics(args.Equipee, true);
         }
 
         private void OnGranterEquipped(EntityUid uid, ClothingGrantPsionicPowerComponent component, GotEquippedEvent args)

--- a/Content.Shared/Nyanotrasen/Abilities/Psionics/SharedPsionicAbilitiesSystem.cs
+++ b/Content.Shared/Nyanotrasen/Abilities/Psionics/SharedPsionicAbilitiesSystem.cs
@@ -1,8 +1,8 @@
 using Content.Shared.Actions;
 using Content.Shared.Administration.Logs;
+using Content.Shared.Mobs;
 using Content.Shared.Popups;
 using Content.Shared.Psionics.Glimmer;
-using Robust.Shared.Player;
 using Robust.Shared.Random;
 using Robust.Shared.Serialization;
 
@@ -23,6 +23,8 @@ namespace Content.Shared.Abilities.Psionics
             SubscribeLocalEvent<PsionicsDisabledComponent, ComponentInit>(OnInit);
             SubscribeLocalEvent<PsionicsDisabledComponent, ComponentShutdown>(OnShutdown);
             SubscribeLocalEvent<PsionicComponent, PsionicPowerUsedEvent>(OnPowerUsed);
+
+            SubscribeLocalEvent<PsionicComponent, MobStateChangedEvent>(OnMobStateChanged);
         }
 
         private void OnPowerUsed(EntityUid uid, PsionicComponent component, PsionicPowerUsedEvent args)
@@ -46,6 +48,14 @@ namespace Content.Shared.Abilities.Psionics
         private void OnShutdown(EntityUid uid, PsionicsDisabledComponent component, ComponentShutdown args)
         {
             if (!HasComp<PsionicInsulationComponent>(uid))
+                TogglePsionics(uid, true);
+        }
+
+        private void OnMobStateChanged(EntityUid uid, PsionicComponent component, MobStateChangedEvent args)
+        {
+            if (args.NewMobState == MobState.Dead)
+                TogglePsionics(uid, false);
+            else
                 TogglePsionics(uid, true);
         }
 

--- a/Content.Shared/Nyanotrasen/Abilities/Psionics/SharedPsionicAbilitiesSystem.cs
+++ b/Content.Shared/Nyanotrasen/Abilities/Psionics/SharedPsionicAbilitiesSystem.cs
@@ -56,6 +56,9 @@ namespace Content.Shared.Abilities.Psionics
             SetPsionicsThroughEligibility(uid);
         }
 
+        /// <summary>
+        /// Checks whether the entity is eligible to use its psionic ability. This should be run after anything that could effect psionic eligibility.
+        /// </summary>
         public void SetPsionicsThroughEligibility(EntityUid uid)
         {
             PsionicComponent? component = null;

--- a/Content.Shared/Nyanotrasen/Abilities/Psionics/SharedPsionicAbilitiesSystem.cs
+++ b/Content.Shared/Nyanotrasen/Abilities/Psionics/SharedPsionicAbilitiesSystem.cs
@@ -43,20 +43,20 @@ namespace Content.Shared.Abilities.Psionics
 
         private void OnInit(EntityUid uid, PsionicsDisabledComponent component, ComponentInit args)
         {
-            SetPsionics(uid, IsEligibleForPsionics(uid));
+            SetPsionicsThroughEligibility(uid);
         }
 
         private void OnShutdown(EntityUid uid, PsionicsDisabledComponent component, ComponentShutdown args)
         {
-            SetPsionics(uid, IsEligibleForPsionics(uid));
+            SetPsionicsThroughEligibility(uid);
         }
 
         private void OnMobStateChanged(EntityUid uid, PsionicComponent component, MobStateChangedEvent args)
         {
-            SetPsionics(uid, IsEligibleForPsionics(uid));
+            SetPsionicsThroughEligibility(uid);
         }
 
-        public void SetPsionics(EntityUid uid, bool psionicsEnabled)
+        public void SetPsionicsThroughEligibility(EntityUid uid)
         {
             PsionicComponent? component = null;
             if (!Resolve(uid, ref component, false))
@@ -65,7 +65,7 @@ namespace Content.Shared.Abilities.Psionics
             if (component.PsionicAbility == null)
                 return;
 
-            _actions.SetEnabled(component.PsionicAbility, psionicsEnabled);
+            _actions.SetEnabled(component.PsionicAbility, IsEligibleForPsionics(uid));
         }
 
         private bool IsEligibleForPsionics(EntityUid uid)

--- a/Content.Shared/Nyanotrasen/Abilities/Psionics/SharedPsionicAbilitiesSystem.cs
+++ b/Content.Shared/Nyanotrasen/Abilities/Psionics/SharedPsionicAbilitiesSystem.cs
@@ -43,20 +43,20 @@ namespace Content.Shared.Abilities.Psionics
 
         private void OnInit(EntityUid uid, PsionicsDisabledComponent component, ComponentInit args)
         {
-            TogglePsionics(uid);
+            SetPsionicsThroughEligibility(uid);
         }
 
         private void OnShutdown(EntityUid uid, PsionicsDisabledComponent component, ComponentShutdown args)
         {
-            TogglePsionics(uid);
+            SetPsionicsThroughEligibility(uid);
         }
 
         private void OnMobStateChanged(EntityUid uid, PsionicComponent component, MobStateChangedEvent args)
         {
-            TogglePsionics(uid);
+            SetPsionicsThroughEligibility(uid);
         }
 
-        public void TogglePsionics(EntityUid uid, PsionicComponent? component = null)
+        public void SetPsionicsThroughEligibility(EntityUid uid, PsionicComponent? component = null)
         {
             if (!Resolve(uid, ref component, false))
                 return;

--- a/Content.Shared/Nyanotrasen/Abilities/Psionics/SharedPsionicAbilitiesSystem.cs
+++ b/Content.Shared/Nyanotrasen/Abilities/Psionics/SharedPsionicAbilitiesSystem.cs
@@ -56,7 +56,7 @@ namespace Content.Shared.Abilities.Psionics
             SetPsionics(uid, IsEligibleForPsionics(uid));
         }
 
-        public void SetPsionics(EntityUid uid, bool newValue, PsionicComponent? component = null)
+        public void SetPsionics(EntityUid uid, bool psionicsEnabled, PsionicComponent? component = null)
         {
             if (!Resolve(uid, ref component, false))
                 return;
@@ -64,7 +64,7 @@ namespace Content.Shared.Abilities.Psionics
             if (component.PsionicAbility == null)
                 return;
 
-            _actions.SetEnabled(component.PsionicAbility, newValue);
+            _actions.SetEnabled(component.PsionicAbility, psionicsEnabled);
         }
 
         private bool IsEligibleForPsionics(EntityUid uid)

--- a/Content.Shared/Nyanotrasen/Abilities/Psionics/SharedPsionicAbilitiesSystem.cs
+++ b/Content.Shared/Nyanotrasen/Abilities/Psionics/SharedPsionicAbilitiesSystem.cs
@@ -56,8 +56,9 @@ namespace Content.Shared.Abilities.Psionics
             SetPsionics(uid, IsEligibleForPsionics(uid));
         }
 
-        public void SetPsionics(EntityUid uid, bool psionicsEnabled, PsionicComponent? component = null)
+        public void SetPsionics(EntityUid uid, bool psionicsEnabled)
         {
+            PsionicComponent? component = null;
             if (!Resolve(uid, ref component, false))
                 return;
 

--- a/Content.Shared/Nyanotrasen/Abilities/Psionics/SharedPsionicAbilitiesSystem.cs
+++ b/Content.Shared/Nyanotrasen/Abilities/Psionics/SharedPsionicAbilitiesSystem.cs
@@ -43,20 +43,20 @@ namespace Content.Shared.Abilities.Psionics
 
         private void OnInit(EntityUid uid, PsionicsDisabledComponent component, ComponentInit args)
         {
-            SetPsionicsThroughEligibility(uid);
+            SetPsionics(uid, IsEligibleForPsionics(uid));
         }
 
         private void OnShutdown(EntityUid uid, PsionicsDisabledComponent component, ComponentShutdown args)
         {
-            SetPsionicsThroughEligibility(uid);
+            SetPsionics(uid, IsEligibleForPsionics(uid));
         }
 
         private void OnMobStateChanged(EntityUid uid, PsionicComponent component, MobStateChangedEvent args)
         {
-            SetPsionicsThroughEligibility(uid);
+            SetPsionics(uid, IsEligibleForPsionics(uid));
         }
 
-        public void SetPsionicsThroughEligibility(EntityUid uid, PsionicComponent? component = null)
+        public void SetPsionics(EntityUid uid, bool newValue, PsionicComponent? component = null)
         {
             if (!Resolve(uid, ref component, false))
                 return;
@@ -64,7 +64,7 @@ namespace Content.Shared.Abilities.Psionics
             if (component.PsionicAbility == null)
                 return;
 
-            _actions.SetEnabled(component.PsionicAbility, IsEligibleForPsionics(uid));
+            _actions.SetEnabled(component.PsionicAbility, newValue);
         }
 
         private bool IsEligibleForPsionics(EntityUid uid)


### PR DESCRIPTION
Fixes #1627 