### PR TITLE
Add commands for spawning a character directly

### DIFF
--- a/Content.Server/DeltaV/Administration/Commands/LoadCharacter.cs
+++ b/Content.Server/DeltaV/Administration/Commands/LoadCharacter.cs
@@ -1,0 +1,139 @@
+using System.Linq;
+using Content.Server.Administration;
+using Content.Server.GameTicking;
+using Content.Server.Players;
+using Content.Shared.Administration;
+using Content.Shared.Humanoid;
+using Content.Shared.Preferences;
+using Content.Server.Preferences.Managers;
+using Content.Server.Station.Systems;
+using Content.Shared.Humanoid.Prototypes;
+using Robust.Server.Player;
+using Robust.Shared.Console;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.DeltaV.Administration.Commands
+{
+    [AdminCommand(AdminFlags.Admin)]
+    public sealed class LoadCharacter : IConsoleCommand
+    {
+        [Dependency] private readonly IEntitySystemManager _entitySys = default!;
+        [Dependency] private readonly IEntityManager _entityManager = default!;
+        [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+        [Dependency] private readonly IServerPreferencesManager _prefs = default!;
+
+        public string Command => "loadcharacter";
+        public string Description => Loc.GetString("loadcharacter-command-description");
+        public string Help => Loc.GetString("loadcharacter-command-help");
+
+        public void Execute(IConsoleShell shell, string argStr, string[] args)
+        {
+            var player = shell.Player as IPlayerSession;
+            if (player == null)
+            {
+                shell.WriteError(Loc.GetString("shell-only-players-can-run-this-command"));
+                return;
+            }
+
+            var mind = player.ContentData()?.Mind;
+
+            if (mind == null || mind.UserId == null)
+            {
+                shell.WriteError(Loc.GetString("shell-entity-is-not-mob")); // No mind specific errors? :(
+                return;
+            }
+
+            EntityUid target;
+
+            if (args.Length >= 1)
+            {
+                if (!EntityUid.TryParse(args.First(), out var uid))
+                {
+                    shell.WriteLine(Loc.GetString("shell-entity-uid-must-be-number"));
+                    return;
+                }
+
+                target = uid;
+            }
+            else
+            {
+                if (player.AttachedEntity == null ||
+                    !_entityManager.HasComponent<HumanoidAppearanceComponent>(player.AttachedEntity.Value))
+                {
+                    shell.WriteError(Loc.GetString("shell-must-be-attached-to-entity"));
+                    return;
+                }
+                target = player.AttachedEntity.Value;
+            }
+
+            if (!target.IsValid() || !_entityManager.EntityExists(target))
+            {
+                shell.WriteLine(Loc.GetString("shell-invalid-entity-id"));
+                return;
+            }
+
+            if (!_entityManager.TryGetComponent<HumanoidAppearanceComponent>(target, out var humanoidAppearance))
+            {
+                shell.WriteError(Loc.GetString("shell-entity-with-uid-lacks-component", ("uid", target.ToString()), ("componentName", nameof(HumanoidAppearanceComponent))));
+                return;
+            }
+
+            HumanoidCharacterProfile character;
+
+            if (args.Length >= 2)
+            {
+                // This seems like a bad way to go about it, but it works so eh?
+                var name = String.Join(" ", args.Skip(1).ToArray());
+                shell.WriteLine(Loc.GetString("loadcharacter-command-fetching", ("name", name)));
+
+                var charIndex = _prefs.GetPreferences(mind.UserId.Value).IndexOfCharacterName(name);
+                if (charIndex < 0)
+                {
+                    shell.WriteError(Loc.GetString("loadcharacter-command-fetching-failed"));
+                    return;
+                }
+
+                character = (HumanoidCharacterProfile) _prefs.GetPreferences(mind.UserId.Value).GetProfile(charIndex);
+            }
+            else
+                character = (HumanoidCharacterProfile) _prefs.GetPreferences(mind.UserId.Value).SelectedCharacter;
+
+            // This shouldn't ever fail considering the previous checks
+            if (!_prototypeManager.TryIndex<SpeciesPrototype>(humanoidAppearance.Species, out var speciesPrototype) || !_prototypeManager.TryIndex<SpeciesPrototype>(character.Species, out var entPrototype))
+                return;
+
+            if (speciesPrototype != entPrototype)
+                shell.WriteLine(Loc.GetString("loadcharacter-command-mismatch"));
+
+            var coordinates = player.AttachedEntity != null
+                ? _entityManager.GetComponent<TransformComponent>(player.AttachedEntity.Value).Coordinates
+                : _entitySys.GetEntitySystem<GameTicker>().GetObserverSpawnPoint();
+
+            _entityManager.System<StationSpawningSystem>()
+                .SpawnPlayerMob(coordinates: coordinates, profile: character, entity: target, job: null, station: null);
+
+            shell.WriteLine(Loc.GetString("loadcharacter-command-complete"));
+        }
+
+        public CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+        {
+            if (args.Length == 1)
+            {
+                return CompletionResult.FromHint(Loc.GetString("shell-argument-uid"));
+            }
+            if (args.Length == 2)
+            {
+                var player = shell.Player as IPlayerSession;
+                if (player == null)
+                    return CompletionResult.Empty;
+                var mind = player.ContentData()?.Mind;
+                if (mind == null || mind.UserId == null)
+                    return CompletionResult.Empty;
+
+                return CompletionResult.FromHintOptions(_prefs.GetPreferences(mind.UserId.Value).GetCharacterNames(), Loc.GetString("loadcharacter-command-hint-select"));
+            }
+
+            return CompletionResult.Empty;
+        }
+    }
+}

--- a/Content.Server/DeltaV/Administration/Commands/SpawnCharacter.cs
+++ b/Content.Server/DeltaV/Administration/Commands/SpawnCharacter.cs
@@ -1,0 +1,91 @@
+using System.Linq;
+using Content.Server.Administration;
+using Content.Server.GameTicking;
+using Content.Server.Players;
+using Content.Shared.Administration;
+using Content.Shared.Preferences;
+using Content.Server.Preferences.Managers;
+using Content.Server.Station.Systems;
+using Robust.Server.Player;
+using Robust.Shared.Console;
+
+namespace Content.Server.DeltaV.Administration.Commands
+{
+    [AdminCommand(AdminFlags.Admin)]
+    public sealed class SpawnCharacter : IConsoleCommand
+    {
+        [Dependency] private readonly IEntitySystemManager _entitySys = default!;
+        [Dependency] private readonly IEntityManager _entityManager = default!;
+        [Dependency] private readonly IServerPreferencesManager _prefs = default!;
+
+        public string Command => "spawncharacter";
+        public string Description => Loc.GetString("spawncharacter-command-description");
+        public string Help => Loc.GetString("spawncharacter-command-help");
+
+        public void Execute(IConsoleShell shell, string argStr, string[] args)
+        {
+            var player = shell.Player as IPlayerSession;
+            if (player == null)
+            {
+                shell.WriteError(Loc.GetString("shell-only-players-can-run-this-command"));
+                return;
+            }
+
+            var mind = player.ContentData()?.Mind;
+
+            if (mind == null || mind.UserId == null)
+            {
+                shell.WriteError(Loc.GetString("shell-entity-is-not-mob"));
+                return;
+            }
+
+
+            HumanoidCharacterProfile character;
+
+            if (args.Length >= 1)
+            {
+                // This seems like a bad way to go about it, but it works so eh?
+                var name = string.Join(" ", args.ToArray());
+                shell.WriteLine(Loc.GetString("loadcharacter-command-fetching", ("name", name)));
+
+                var charIndex = _prefs.GetPreferences(mind.UserId.Value).IndexOfCharacterName(name);
+                if (charIndex < 0)
+                {
+                    shell.WriteError(Loc.GetString("loadcharacter-command-fetching-failed"));
+                    return;
+                }
+
+                character = (HumanoidCharacterProfile) _prefs.GetPreferences(mind.UserId.Value).GetProfile(charIndex);
+            }
+            else
+                character = (HumanoidCharacterProfile) _prefs.GetPreferences(mind.UserId.Value).SelectedCharacter;
+
+
+            var coordinates = player.AttachedEntity != null
+                ? _entityManager.GetComponent<TransformComponent>(player.AttachedEntity.Value).Coordinates
+                : _entitySys.GetEntitySystem<GameTicker>().GetObserverSpawnPoint();
+
+            mind.TransferTo(_entityManager.System<StationSpawningSystem>()
+                .SpawnPlayerMob(coordinates: coordinates, profile: character, entity: null, job: null, station: null));
+
+            shell.WriteLine(Loc.GetString("spawncharacter-command-complete"));
+        }
+
+        public CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+        {
+            if (args.Length == 1)
+            {
+                var player = shell.Player as IPlayerSession;
+                if (player == null)
+                    return CompletionResult.Empty;
+                var mind = player.ContentData()?.Mind;
+                if (mind == null || mind.UserId == null)
+                    return CompletionResult.Empty;
+
+                return CompletionResult.FromHintOptions(_prefs.GetPreferences(mind.UserId.Value).GetCharacterNames(), Loc.GetString("loadcharacter-command-hint-select"));
+            }
+
+            return CompletionResult.Empty;
+        }
+    }
+}

--- a/Content.Shared/Preferences/PlayerPreferences.cs
+++ b/Content.Shared/Preferences/PlayerPreferences.cs
@@ -51,5 +51,19 @@ namespace Content.Shared.Preferences
         {
             return (index = IndexOfCharacter(profile)) != -1;
         }
+
+        public int IndexOfCharacterName(string name)
+        {
+            return _characters.FirstOrNull(p => p.Value.Name == name)?.Key ?? -1;
+        }
+        public List<string> GetCharacterNames()
+        {
+            List<string> charList = new();
+            foreach (var character in _characters)
+            {
+                charList.Add(character.Value.Name);
+            }
+            return charList;
+        }
     }
 }

--- a/Resources/Locale/en-US/administration/commands/load-character.ftl
+++ b/Resources/Locale/en-US/administration/commands/load-character.ftl
@@ -1,0 +1,11 @@
+﻿loadcharacter-command-description = Applies your currently selected character to an entity
+loadcharacter-command-help = Usage: loadcharacter | loadcharacter <entityUid> | loadcharacter <entityUid> <characterName>
+loadcharacter-command-mismatch = Species mismatch detected between character and selected entity, this may have unexpected results.
+loadcharacter-command-complete = Character loaded.
+loadcharacter-command-fetching = Fetching character data for {$name}...
+loadcharacter-command-fetching-failed = Failed to fetch character data!
+loadcharacter-command-hint-select = Select character
+
+spawncharacter-command-description = Spawns your currently selected/specified character
+spawncharacter-command-help = Usage: spawncharacter | spawncharacter <characterName>
+spawncharacter-command-complete = Character spawned.


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This code isn't the best, but it gets the job done. It adds 2 commands

Loadcharacter, which can be used to apply a character onto an existing entity, which can have some unintended side effects if you use the wrong mob (Loading a felinid player onto an oni doesnt update stuff, so you'd be a buff felinid)

Spawncharacter, which directly uses spawning code to spawn in a character. Not much to say about it