### PR TITLE
Player character spawner, for events

### DIFF
--- a/Content.Server/DeltaV/Ghost/Roles/Components/GhostRoleCharacterSpawnerComponent.cs
+++ b/Content.Server/DeltaV/Ghost/Roles/Components/GhostRoleCharacterSpawnerComponent.cs
@@ -1,0 +1,22 @@
+﻿namespace Content.Server.Ghost.Roles.Components
+{
+    /// <summary>
+    ///     Allows a ghost to take this role, spawning their selected character.
+    /// </summary>
+    [RegisterComponent]
+    [Access(typeof(GhostRoleSystem))]
+    public sealed class GhostRoleCharacterSpawnerComponent : Component
+    {
+        [ViewVariables(VVAccess.ReadWrite)] [DataField("deleteOnSpawn")]
+        public bool DeleteOnSpawn = true;
+
+        [ViewVariables(VVAccess.ReadWrite)] [DataField("availableTakeovers")]
+        public int AvailableTakeovers = 1;
+
+        [ViewVariables]
+        public int CurrentTakeovers = 0;
+
+        [ViewVariables(VVAccess.ReadWrite)] [DataField("outfitPrototype")]
+        public string OutfitPrototype = "PassengerGear";
+    }
+}

--- a/Content.Server/DeltaV/Ghost/Roles/GhostRoleCharacterSystem.cs
+++ b/Content.Server/DeltaV/Ghost/Roles/GhostRoleCharacterSystem.cs
@@ -1,0 +1,73 @@
+﻿using Content.Server.Administration.Commands;
+using Content.Server.Ghost.Roles;
+using Content.Server.Ghost.Roles.Components;
+using Content.Server.Ghost.Roles.Events;
+using Content.Server.Mind.Components;
+using Content.Server.Preferences.Managers;
+using Content.Server.Station.Systems;
+using Content.Shared.Preferences;
+using Content.Shared.Roles;
+using JetBrains.Annotations;
+using Robust.Server.GameObjects;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.DeltaV.Ghost.Roles
+{
+    [UsedImplicitly]
+    public sealed class GhostRoleCharacterSystem : EntitySystem
+    {
+        [Dependency] private readonly TransformSystem _transform = default!;
+        [Dependency] private readonly IServerPreferencesManager _prefs = default!;
+        [Dependency] private readonly IEntityManager _entityManager = default!;
+        [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+
+        public override void Initialize()
+        {
+            base.Initialize();
+            SubscribeLocalEvent<GhostRoleCharacterSpawnerComponent, TakeGhostRoleEvent>(OnSpawnerTakeCharacter);
+        }
+        private void OnSpawnerTakeCharacter( EntityUid uid, GhostRoleCharacterSpawnerComponent component,
+            ref TakeGhostRoleEvent args)
+        {
+            if (!TryComp(uid, out GhostRoleComponent? ghostRole) ||
+                ghostRole.Taken)
+            {
+                args.TookRole = false;
+                return;
+            }
+
+            var character = (HumanoidCharacterProfile) _prefs.GetPreferences(args.Player.UserId).SelectedCharacter;
+
+            var mob = _entityManager.System<StationSpawningSystem>()
+                .SpawnPlayerMob(Transform(uid).Coordinates, null, character, null);
+            _transform.AttachToGridOrMap(mob);
+
+            string? outfit = null;
+            if (_prototypeManager.TryIndex<StartingGearPrototype>(component.OutfitPrototype, out var outfitProto))
+                outfit = outfitProto.ID;
+
+            var spawnedEvent = new GhostRoleSpawnerUsedEvent(uid, mob);
+            RaiseLocalEvent(mob, spawnedEvent);
+
+            mob.EnsureComponent<MindComponent>();
+
+            _entityManager.System<GhostRoleSystem>().GhostRoleInternalCreateMindAndTransfer(args.Player, uid, mob, ghostRole);
+
+            if (outfit != null)
+                SetOutfitCommand.SetOutfit(mob, outfit, _entityManager);
+
+            if (++component.CurrentTakeovers < component.AvailableTakeovers)
+            {
+                args.TookRole = true;
+                return;
+            }
+
+            ghostRole.Taken = true;
+
+            if (component.DeleteOnSpawn)
+                QueueDel(uid);
+
+            args.TookRole = true;
+        }
+    }
+}

--- a/Content.Server/Ghost/Roles/Components/GhostRoleComponent.cs
+++ b/Content.Server/Ghost/Roles/Components/GhostRoleComponent.cs
@@ -1,9 +1,10 @@
-﻿using Content.Server.Mind.Commands;
+﻿using Content.Server.DeltaV.Ghost.Roles;
+using Content.Server.Mind.Commands;
 
 namespace Content.Server.Ghost.Roles.Components
 {
     [RegisterComponent]
-    [Access(typeof(GhostRoleSystem))]
+    [Access(typeof(GhostRoleSystem), typeof(GhostRoleCharacterSystem))]
     public sealed class GhostRoleComponent : Component
     {
         [DataField("name")] public string _roleName = "Unknown";

--- a/Resources/Prototypes/DeltaV/Entities/Markers/Spawners/ghost_roles.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Markers/Spawners/ghost_roles.yml
@@ -1,0 +1,17 @@
+﻿- type: entity
+  id: SpawnPointPlayerCharacter
+  name: ghost role spawn point
+  suffix: player character, DO NOT MAP
+  parent: MarkerBase
+  components:
+    - type: GhostRole
+      name: Roleplay Ghost Role
+      description: Placeholder
+      rules: Placeholder
+    - type: GhostRoleCharacterSpawner
+    - type: Sprite
+      sprite: Markers/jobs.rsi
+      layers:
+        - state: green
+        - sprite: Mobs/Species/Human/parts.rsi
+          state: full


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Currently there is no way to spawn a character with a spesific gender or pronouns, this spawner is just intended to make it easier to have events where you need a player to be their character, instead of a random one.

GhostRoleCharacterSpawnerComponent, gotta love it