### PR TITLE
Alternate shuttle map for shipwrecked gamemode. 

### DIFF
--- a/Resources/Maps/Shuttles/endeavour.yml
+++ b/Resources/Maps/Shuttles/endeavour.yml
@@ -1,0 +1,7866 @@
+meta:
+  format: 5
+  postmapinit: false
+tilemap:
+  0: Space
+  12: FloorBar
+  24: FloorDark
+  33: FloorDarkPlastic
+  53: FloorMetalDiamond
+  59: FloorPlastic
+  61: FloorReinforced
+  76: FloorSteelMini
+  81: FloorTechMaint
+  93: FloorWhitePlastic
+  94: FloorWood
+  96: Lattice
+  97: Plating
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+    - pos: 0.75547075,12.53907
+      parent: invalid
+      type: Transform
+    - chunks:
+        0,0:
+          ind: 0,0
+          tiles: IQAAACEAAAAhAAACIQAAACEAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD0AAAA9AAAAPQAAAD0AAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+        -1,0:
+          ind: -1,0
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAIQAAAiEAAAIhAAAAIQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAAA9AAAAPQAAAD0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+        -1,-1:
+          ind: -1,-1
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD0AAABeAAACXgAAAF4AAAJeAAADOwAAADsAAAMMAAABDAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABhAAAAXgAAAV4AAAJeAAABXgAAAjsAAAE7AAAADAAAAgwAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYQAAAGEAAABhAAAAYQAAAGEAAAA7AAABOwAAA2EAAABhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGEAAABMAAAATAAAAUwAAAE7AAACOwAAAjsAAAM7AAABTAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABhAAAATAAAAUwAAABMAAACYQAAADsAAAM7AAADYQAAAEwAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYQAAAGEAAABhAAAAYQAAAGEAAAA7AAACOwAAAWEAAABhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGEAAABMAAACTAAAAkwAAAA7AAADOwAAAzsAAAFhAAAAXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABhAAAATAAAAkwAAAFMAAACYQAAADsAAAA7AAADYQAAAF0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAGEAAABhAAAAYQAAAGEAAAA7AAADOwAAAD0AAABdAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAABhAAAAIQAAAyEAAAM7AAADOwAAADsAAAA9AAAAXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAGEAAABhAAAAYQAAADsAAAE7AAACYQAAAF0AAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAYQAAAGEAAABRAAAAUQAAAGEAAABhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAABhAAAAIQAAASEAAAAhAAACIQAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPQAAACEAAAIhAAABIQAAASEAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD0AAAAhAAAAIQAAACEAAAMhAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA9AAAAIQAAASEAAAEhAAADIQAAAQ==
+        0,-1:
+          ind: 0,-1
+          tiles: DAAAAQwAAAJhAAAAGAAAABgAAAIYAAADGAAAABgAAAMYAAACYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAEMAAAADAAAARgAAAAYAAACGAAAARgAAAIYAAADGAAAAGEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABhAAAAYQAAAGEAAAAYAAADGAAAABgAAAAYAAABGAAAAxgAAAJhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATAAAAUwAAABhAAAAGAAAAxgAAAIYAAACGAAAAxgAAAIYAAADYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEwAAANMAAACYQAAABgAAAIYAAACGAAAAxgAAAAYAAADGAAAAWEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABhAAAAYQAAAGEAAAAYAAABGAAAAxgAAAIYAAACGAAAABgAAABhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXQAAAF0AAABhAAAAYQAAAFEAAABhAAAAYQAAAGEAAABhAAAAYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF0AAABdAAAAYQAAAFEAAABRAAAAUQAAAFEAAABRAAAAUQAAAGEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABdAAAAXQAAAGEAAABRAAAAUQAAAFEAAABRAAAAUQAAAFEAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXQAAAF0AAANhAAAAUQAAAFEAAABRAAAAUQAAAFEAAABhAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF0AAAJdAAABYQAAAFEAAABRAAAAUQAAAFEAAABhAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABhAAAAYQAAAGEAAABhAAAAYQAAAGEAAABhAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIQAAAyEAAAIhAAAAIQAAACEAAAJhAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACEAAAEhAAACIQAAASEAAAMhAAAAPQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAhAAAAIQAAAyEAAAMhAAADIQAAAj0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIQAAAiEAAAAhAAADIQAAAiEAAAE9AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+        -1,-2:
+          ind: -1,-2
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAGEAAAA1AAAAYQAAADUAAABgAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAGEAAABhAAAAYQAAAGEAAABhAAAAYQAAAGEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAGEAAABhAAAAYQAAADUAAABhAAAANQAAAAwAAAAMAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGEAAABeAAADXgAAA14AAAFeAAADOwAAADsAAAEMAAABDAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA9AAAAXgAAAl4AAANeAAABXgAAADsAAAM7AAAADAAAAgwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPQAAAF4AAAFeAAABXgAAAV4AAAE7AAABOwAAAAwAAAEMAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD0AAABeAAADXgAAA14AAABeAAACOwAAAzsAAAAMAAAADAAAAg==
+        0,-2:
+          ind: 0,-2
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAGAAAABgAAAANQAAAGEAAAA1AAAAYQAAAGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGEAAABhAAAAYQAAAGEAAABhAAAAYQAAAGEAAABhAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAACDAAAA2EAAAA1AAAAYQAAADUAAABhAAAAYQAAAGEAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAgwAAABhAAAAGAAAAhgAAAEYAAADGAAAAxgAAAIYAAABYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAIMAAADYQAAABgAAAAYAAADGAAAARgAAAMYAAADGAAAA2EAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAACDAAAAWEAAAAYAAAAGAAAARgAAAEYAAACGAAAAhgAAANhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAgwAAANhAAAAGAAAABgAAAEYAAADGAAAABgAAAEYAAADYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+      type: MapGrid
+    - type: Broadphase
+    - angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+      type: Physics
+    - fixtures: {}
+      type: Fixtures
+    - type: OccluderTree
+    - nextUpdate: 0
+      type: SpreaderGrid
+    - type: Shuttle
+    - type: GridPathfinding
+    - gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+      type: Gravity
+    - chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            color: '#FFFFFFFF'
+            id: BotLeft
+          decals:
+            28: 5,-18
+            29: 4,-19
+            30: 4,-13
+            31: 5,-12
+            32: 7,-13
+            33: 8,-12
+            34: 8,-18
+            35: 7,-19
+            36: 4,-16
+            37: 5,-15
+            38: 8,-15
+            39: 7,-16
+        - node:
+            color: '#FFFFFFFF'
+            id: BotRight
+          decals:
+            20: 8,-19
+            21: 7,-18
+            22: 8,-13
+            23: 7,-12
+            24: 4,-12
+            25: 5,-13
+            26: 4,-18
+            27: 5,-19
+            40: 4,-15
+            41: 5,-16
+            42: 7,-15
+            43: 8,-16
+        - node:
+            color: '#52B4E996'
+            id: BrickTileSteelCornerNe
+          decals:
+            164: 1,-6
+        - node:
+            color: '#9FED5896'
+            id: BrickTileSteelCornerNe
+          decals:
+            79: 1,-12
+            83: -6,-9
+            84: -6,-12
+        - node:
+            color: '#52B4E996'
+            id: BrickTileSteelCornerNw
+          decals:
+            163: -1,-6
+        - node:
+            color: '#9FED5896'
+            id: BrickTileSteelCornerNw
+          decals:
+            80: -1,-12
+            81: -8,-9
+            82: -8,-12
+        - node:
+            color: '#52B4E996'
+            id: BrickTileSteelCornerSe
+          decals:
+            162: 1,-10
+        - node:
+            color: '#9FED5896'
+            id: BrickTileSteelCornerSe
+          decals:
+            60: -3,-13
+            85: -6,-13
+            86: 1,-13
+            87: -6,-10
+        - node:
+            color: '#52B4E996'
+            id: BrickTileSteelCornerSw
+          decals:
+            165: -1,-10
+        - node:
+            color: '#9FED5896'
+            id: BrickTileSteelCornerSw
+          decals:
+            55: -4,-13
+            88: -8,-13
+            89: -8,-10
+            90: -1,-13
+        - node:
+            color: '#52B4E996'
+            id: BrickTileSteelLineE
+          decals:
+            154: -3,-10
+            155: -3,-9
+            156: -3,-8
+            157: -3,-7
+            159: -3,-6
+            171: 1,-7
+            172: 1,-8
+            173: 1,-9
+        - node:
+            color: '#9FED5896'
+            id: BrickTileSteelLineE
+          decals:
+            61: -3,-12
+            62: -3,-11
+        - node:
+            color: '#A4610696'
+            id: BrickTileSteelLineE
+          decals:
+            45: 1,-15
+            46: 1,-16
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileSteelLineN
+          decals:
+            44: -4,-6
+            158: -3,-6
+        - node:
+            color: '#52B4E996'
+            id: BrickTileSteelLineN
+          decals:
+            166: 0,-6
+        - node:
+            color: '#9FED5896'
+            id: BrickTileSteelLineN
+          decals:
+            50: -4,-15
+            51: -3,-15
+            91: -7,-9
+            92: 0,-12
+            93: -7,-12
+        - node:
+            color: '#EFB34196'
+            id: BrickTileSteelLineN
+          decals:
+            52: 3,-11
+            53: 4,-11
+            54: 5,-11
+        - node:
+            color: '#52B4E996'
+            id: BrickTileSteelLineS
+          decals:
+            167: 0,-10
+        - node:
+            color: '#9FED5896'
+            id: BrickTileSteelLineS
+          decals:
+            94: -7,-13
+            95: 0,-13
+            96: -7,-10
+        - node:
+            color: '#52B4E996'
+            id: BrickTileSteelLineW
+          decals:
+            168: -1,-7
+            169: -1,-8
+            170: -1,-9
+        - node:
+            color: '#9FED5896'
+            id: BrickTileSteelLineW
+          decals:
+            47: 3,-14
+            48: 3,-15
+            49: 3,-16
+            56: -4,-12
+            57: -4,-11
+            58: -4,-6
+            59: -4,-7
+            63: -4,-8
+            160: -4,-9
+            161: -4,-10
+        - node:
+            color: '#FFFFFFFF'
+            id: DirtHeavy
+          decals:
+            174: -3,-7
+        - node:
+            cleanable: True
+            color: '#FFFFFFFF'
+            id: DirtHeavy
+          decals:
+            105: 6,-17
+            106: 4,-20
+            107: 7,-20
+            108: 3,-17
+            109: 7,-17
+            110: 7,-14
+            111: 5,-14
+            112: 6,-11
+            113: 7,-11
+            114: 3,-11
+            115: 4,-9
+            116: 5,-7
+            117: 7,-8
+            118: 4,-7
+            143: -2,-4
+            144: -1,-3
+            145: 2,-4
+            146: 3,-4
+            147: 1,-2
+            148: -6,-13
+            149: -6,-10
+            150: -1,-13
+        - node:
+            cleanable: True
+            color: '#FFFFFFFF'
+            id: DirtLight
+          decals:
+            119: 3,-12
+            120: 7,-11
+            121: 6,-16
+            122: 8,-14
+            123: 3,-17
+            124: 7,-20
+            125: 4,-17
+            126: 8,-20
+            134: -4,-20
+            135: -4,-19
+            136: -3,-18
+            137: -4,-16
+            138: -3,-16
+            139: -3,-13
+            140: -4,-12
+            141: -3,-11
+            142: -4,-6
+        - node:
+            color: '#FFFFFFFF'
+            id: DirtMedium
+          decals:
+            175: -4,-9
+        - node:
+            cleanable: True
+            color: '#FFFFFFFF'
+            id: DirtMedium
+          decals:
+            127: -2,-20
+            128: 0,-21
+            129: 0,-19
+            130: 1,-16
+            131: -1,-15
+            132: 1,-15
+            133: -2,-17
+            151: -8,-13
+            152: -8,-10
+            153: 1,-13
+        - node:
+            angle: 3.141592653589793 rad
+            color: '#FFFFFFFF'
+            id: LoadingArea
+          decals:
+            97: 3,-20
+            98: 5,-20
+        - node:
+            color: '#FFFFFFFF'
+            id: MiniTileDarkCornerNe
+          decals:
+            73: 2,-1
+            74: 3,-2
+            77: 4,-4
+        - node:
+            color: '#FFFFFFFF'
+            id: MiniTileDarkCornerNw
+          decals:
+            64: -4,-4
+            67: -3,-2
+            68: -2,-1
+        - node:
+            color: '#FFFFFFFF'
+            id: MiniTileDarkInnerNe
+          decals:
+            75: 2,-2
+            78: 3,-4
+        - node:
+            color: '#FFFFFFFF'
+            id: MiniTileDarkInnerNw
+          decals:
+            65: -3,-4
+            69: -2,-2
+        - node:
+            color: '#FFFFFFFF'
+            id: MiniTileDarkLineE
+          decals:
+            76: 3,-3
+        - node:
+            color: '#FFFFFFFF'
+            id: MiniTileDarkLineN
+          decals:
+            70: -1,-1
+            71: 0,-1
+            72: 1,-1
+        - node:
+            color: '#FFFFFFFF'
+            id: MiniTileDarkLineW
+          decals:
+            66: -3,-3
+        - node:
+            color: '#79150096'
+            id: MiniTileSteelLineW
+          decals:
+            99: -2,-20
+            100: -2,-19
+            101: -2,-18
+            102: -2,-17
+            103: -2,-16
+            104: -2,-15
+        - node:
+            color: '#FFFFFFFF'
+            id: StandClear
+          decals:
+            0: 3,-21
+            1: 5,-21
+            2: 5,-23
+            3: 3,-23
+            4: -3,-23
+            5: -5,-23
+            6: -5,-21
+            7: -3,-21
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinCornerNe
+          decals:
+            16: -5,-15
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinCornerSe
+          decals:
+            12: -5,-20
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineE
+          decals:
+            8: -5,-16
+            9: -5,-17
+            10: -5,-18
+            11: -5,-19
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineN
+          decals:
+            17: -6,-15
+            18: -7,-15
+            19: -8,-15
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineS
+          decals:
+            13: -6,-20
+            14: -7,-20
+            15: -8,-20
+      type: DecalGrid
+    - version: 2
+      data:
+        tiles:
+          0,0:
+            0: 255
+          -1,0:
+            0: 255
+          -1,-1:
+            0: 65535
+          0,-1:
+            0: 65535
+          1,0:
+            0: 19
+          -2,0:
+            0: 8
+          -3,-4:
+            0: 34952
+          -3,-3:
+            0: 34952
+          -3,-2:
+            0: 136
+          -2,-4:
+            0: 65535
+          -2,-3:
+            0: 65535
+          -2,-2:
+            0: 61439
+          -2,-1:
+            0: 34956
+          -1,-4:
+            0: 65535
+          -1,-3:
+            0: 65535
+          -1,-2:
+            0: 65535
+          0,-4:
+            0: 65535
+          0,-3:
+            0: 65535
+          0,-2:
+            0: 65535
+          1,-4:
+            0: 65535
+          1,-3:
+            0: 65535
+          1,-2:
+            0: 65535
+          1,-1:
+            0: 13111
+          2,-4:
+            0: 13107
+          2,-3:
+            0: 13107
+          2,-2:
+            0: 307
+          -3,-6:
+            0: 32768
+          -3,-5:
+            0: 34952
+          -2,-6:
+            0: 65504
+          -2,-5:
+            0: 65535
+          -1,-6:
+            0: 65520
+          -1,-5:
+            0: 65535
+          0,-6:
+            0: 65520
+          0,-5:
+            0: 65535
+          1,-6:
+            0: 65520
+          1,-5:
+            0: 65535
+          2,-6:
+            0: 12544
+          2,-5:
+            0: 13107
+        uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        chunkSize: 4
+      type: GridAtmosphere
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+    - following:
+      - invalid
+      type: Followed
+- proto: Airlock
+  entities:
+  - uid: 249
+    components:
+    - name: first bunk
+      type: MetaData
+    - pos: -4.5,-12.5
+      parent: 1
+      type: Transform
+  - uid: 252
+    components:
+    - name: second bunk
+      type: MetaData
+    - pos: -1.5,-12.5
+      parent: 1
+      type: Transform
+  - uid: 261
+    components:
+    - name: third bunk
+      type: MetaData
+    - pos: -4.5,-9.5
+      parent: 1
+      type: Transform
+- proto: AirlockCommand
+  entities:
+  - uid: 54
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -2.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 802
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -3.5,-4.5
+      parent: 1
+      type: Transform
+- proto: AirlockEngineering
+  entities:
+  - uid: 153
+    components:
+    - name: engine bay
+      type: MetaData
+    - pos: 4.5,-9.5
+      parent: 1
+      type: Transform
+- proto: AirlockEngineeringGlassLocked
+  entities:
+  - uid: 188
+    components:
+    - name: cargo hold
+      type: MetaData
+    - pos: 2.5,-14.5
+      parent: 1
+      type: Transform
+- proto: AirlockExternalGlass
+  entities:
+  - uid: 140
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 5.5,-20.5
+      parent: 1
+      type: Transform
+  - uid: 142
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 3.5,-20.5
+      parent: 1
+      type: Transform
+  - uid: 148
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -4.5,-20.5
+      parent: 1
+      type: Transform
+  - uid: 149
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -2.5,-20.5
+      parent: 1
+      type: Transform
+- proto: AirlockGlass
+  entities:
+  - uid: 219
+    components:
+    - pos: -3.5,-13.5
+      parent: 1
+      type: Transform
+  - uid: 220
+    components:
+    - pos: -2.5,-13.5
+      parent: 1
+      type: Transform
+- proto: AirlockMaint
+  entities:
+  - uid: 263
+    components:
+    - name: bathroom
+      type: MetaData
+    - pos: -4.5,-6.5
+      parent: 1
+      type: Transform
+- proto: AirlockMedicalGlass
+  entities:
+  - uid: 475
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,-8.5
+      parent: 1
+      type: Transform
+- proto: AirlockShuttle
+  entities:
+  - uid: 109
+    components:
+    - pos: 5.5,-22.5
+      parent: 1
+      type: Transform
+  - uid: 111
+    components:
+    - pos: 3.5,-22.5
+      parent: 1
+      type: Transform
+  - uid: 117
+    components:
+    - pos: -2.5,-22.5
+      parent: 1
+      type: Transform
+  - uid: 119
+    components:
+    - pos: -4.5,-22.5
+      parent: 1
+      type: Transform
+- proto: AloeSeeds
+  entities:
+  - uid: 746
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 391
+      type: Transform
+    - nextSound: 403.9288867
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: AltarSpawner
+  entities:
+  - uid: 646
+    components:
+    - pos: 5.5,-14.5
+      parent: 1
+      type: Transform
+- proto: AmbrosiaVulgarisSeeds
+  entities:
+  - uid: 392
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 391
+      type: Transform
+    - nextSound: 402.0303181
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: AnomalyScanner
+  entities:
+  - uid: 666
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 660
+      type: Transform
+    - nextSound: 2441.2377403
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: APCBasic
+  entities:
+  - uid: 505
+    components:
+    - pos: -1.5,-13.5
+      parent: 1
+      type: Transform
+  - uid: 506
+    components:
+    - pos: 5.5,-9.5
+      parent: 1
+      type: Transform
+  - uid: 545
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -1.5,-4.5
+      parent: 1
+      type: Transform
+- proto: AppleSeeds
+  entities:
+  - uid: 748
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 391
+      type: Transform
+    - nextSound: 398.2117735
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: AutolatheMachineCircuitboard
+  entities:
+  - uid: 501
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 492
+      type: Transform
+    - nextSound: 3157.9884609
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: BananaSeeds
+  entities:
+  - uid: 751
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 391
+      type: Transform
+    - nextSound: 395.6448234
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: BaseComputer
+  entities:
+  - uid: 30
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -3.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 223
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -3.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 224
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 4.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 244
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 4.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 455
+    components:
+    - pos: -1.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 465
+    components:
+    - pos: 2.5,0.5
+      parent: 1
+      type: Transform
+- proto: Beaker
+  entities:
+  - uid: 812
+    components:
+    - name: romerol
+      type: MetaData
+    - pos: -0.7632849,-5.1547194
+      parent: 1
+      type: Transform
+    - nextAttack: 177.5480343
+      type: MeleeWeapon
+    - solutions:
+        beaker:
+          temperature: 293.15
+          canMix: True
+          canReact: True
+          maxVol: 50
+          reagents:
+          - Quantity: 50
+            ReagentId: Romerol
+      type: SolutionContainerManager
+    - nextSound: 177.7480343
+      type: EmitSoundOnCollide
+- proto: Bed
+  entities:
+  - uid: 265
+    components:
+    - pos: -7.5,-11.5
+      parent: 1
+      type: Transform
+  - uid: 266
+    components:
+    - pos: -5.5,-11.5
+      parent: 1
+      type: Transform
+  - uid: 267
+    components:
+    - pos: -7.5,-8.5
+      parent: 1
+      type: Transform
+  - uid: 268
+    components:
+    - pos: -5.5,-8.5
+      parent: 1
+      type: Transform
+  - uid: 273
+    components:
+    - pos: -0.5,-11.5
+      parent: 1
+      type: Transform
+  - uid: 274
+    components:
+    - pos: 1.5,-11.5
+      parent: 1
+      type: Transform
+- proto: BedsheetMedical
+  entities:
+  - uid: 3
+    components:
+    - pos: 1.5,-9.5
+      parent: 1
+      type: Transform
+    - nextSound: 374.256124
+      type: EmitSoundOnCollide
+  - uid: 303
+    components:
+    - pos: 1.5,-7.5
+      parent: 1
+      type: Transform
+    - nextSound: 373.7550796
+      type: EmitSoundOnCollide
+- proto: BedsheetSpawner
+  entities:
+  - uid: 280
+    components:
+    - pos: -7.5,-11.5
+      parent: 1
+      type: Transform
+  - uid: 281
+    components:
+    - pos: -5.5,-11.5
+      parent: 1
+      type: Transform
+  - uid: 282
+    components:
+    - pos: -5.5,-8.5
+      parent: 1
+      type: Transform
+  - uid: 283
+    components:
+    - pos: -7.5,-8.5
+      parent: 1
+      type: Transform
+  - uid: 286
+    components:
+    - pos: 1.5,-11.5
+      parent: 1
+      type: Transform
+  - uid: 287
+    components:
+    - pos: -0.5,-11.5
+      parent: 1
+      type: Transform
+- proto: BiomassReclaimerMachineCircuitboard
+  entities:
+  - uid: 312
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 492
+      type: Transform
+    - nextSound: 347.1625877
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: BlastDoor
+  entities:
+  - uid: 313
+    components:
+    - pos: -4.5,-21.5
+      parent: 1
+      type: Transform
+    - links:
+      - 828
+      type: DeviceLinkSink
+  - uid: 314
+    components:
+    - pos: -2.5,-21.5
+      parent: 1
+      type: Transform
+    - links:
+      - 828
+      type: DeviceLinkSink
+  - uid: 315
+    components:
+    - pos: 3.5,-21.5
+      parent: 1
+      type: Transform
+    - links:
+      - 829
+      type: DeviceLinkSink
+  - uid: 343
+    components:
+    - pos: 5.5,-21.5
+      parent: 1
+      type: Transform
+    - links:
+      - 829
+      type: DeviceLinkSink
+- proto: BoxBeaker
+  entities:
+  - uid: 673
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 660
+      type: Transform
+    - nextSound: 2337.0478033
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: BoxBodyBag
+  entities:
+  - uid: 667
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 660
+      type: Transform
+    - nextSound: 2369.2494486
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: BoxBottle
+  entities:
+  - uid: 683
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 660
+      type: Transform
+    - nextSound: 2371.1832893
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: BoxHeadset
+  entities:
+  - uid: 68
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 704
+      type: Transform
+    - nextSound: 536.2690628
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 344
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 704
+      type: Transform
+    - nextSound: 311.7765872
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: BoxHolyWater
+  entities:
+  - uid: 669
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 660
+      type: Transform
+    - nextSound: 2394.1687124
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: BoxLatexGloves
+  entities:
+  - uid: 677
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 660
+      type: Transform
+    - nextSound: 2281.8606578
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: BoxLethalshot
+  entities:
+  - uid: 67
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 58
+      type: Transform
+    - nextSound: 6473.9950142
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: BoxShotgunFlare
+  entities:
+  - uid: 64
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 58
+      type: Transform
+    - nextSound: 6453.5273404
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: BoxSterileMask
+  entities:
+  - uid: 679
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 660
+      type: Transform
+    - nextSound: 2300.1624475
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: BoxSyringe
+  entities:
+  - uid: 676
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 660
+      type: Transform
+    - nextSound: 2275.3279816
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 817
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 319
+      type: Transform
+    - nextSound: 178.4015255
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: BoxTrashbag
+  entities:
+  - uid: 662
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 660
+      type: Transform
+    - nextSound: 2413.4694152
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: CabbageSeeds
+  entities:
+  - uid: 749
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 391
+      type: Transform
+    - nextSound: 393.5463932
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: CableApcExtension
+  entities:
+  - uid: 44
+    components:
+    - pos: -1.5,-8.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+    - fixtures: {}
+      type: Fixtures
+  - uid: 45
+    components:
+    - pos: -0.5,-8.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 291
+    components:
+    - pos: 0.5,-6.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 302
+    components:
+    - pos: 0.5,-7.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 316
+    components:
+    - pos: 0.5,-8.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 507
+    components:
+    - pos: -1.5,-0.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 508
+    components:
+    - pos: -1.5,-1.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 509
+    components:
+    - pos: -1.5,-2.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 510
+    components:
+    - pos: -1.5,-3.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 511
+    components:
+    - pos: -1.5,-14.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 546
+    components:
+    - pos: 2.5,-0.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 547
+    components:
+    - pos: -1.5,-4.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+    - fixtures: {}
+      type: Fixtures
+  - uid: 548
+    components:
+    - pos: -1.5,-13.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+    - fixtures: {}
+      type: Fixtures
+  - uid: 549
+    components:
+    - pos: -0.5,-2.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 550
+    components:
+    - pos: 0.5,-2.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 551
+    components:
+    - pos: 1.5,-2.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 552
+    components:
+    - pos: 2.5,-2.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 553
+    components:
+    - pos: 2.5,-1.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 554
+    components:
+    - pos: -2.5,-14.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 555
+    components:
+    - pos: -2.5,-13.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 556
+    components:
+    - pos: -2.5,-12.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 557
+    components:
+    - pos: -2.5,-11.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 558
+    components:
+    - pos: -2.5,-10.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 559
+    components:
+    - pos: -2.5,-9.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 560
+    components:
+    - pos: -2.5,-8.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 561
+    components:
+    - pos: -2.5,-7.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 562
+    components:
+    - pos: -2.5,-6.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 563
+    components:
+    - pos: -3.5,-6.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 564
+    components:
+    - pos: -4.5,-6.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 565
+    components:
+    - pos: -5.5,-6.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 572
+    components:
+    - pos: -3.5,-9.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 573
+    components:
+    - pos: -4.5,-9.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 574
+    components:
+    - pos: -5.5,-9.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 575
+    components:
+    - pos: -6.5,-9.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 576
+    components:
+    - pos: -3.5,-12.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 577
+    components:
+    - pos: -4.5,-12.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 578
+    components:
+    - pos: -5.5,-12.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 579
+    components:
+    - pos: -6.5,-12.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 580
+    components:
+    - pos: -1.5,-12.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 581
+    components:
+    - pos: -0.5,-12.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 582
+    components:
+    - pos: 0.5,-12.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 583
+    components:
+    - pos: -2.5,-15.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 584
+    components:
+    - pos: -2.5,-16.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 585
+    components:
+    - pos: -2.5,-17.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 586
+    components:
+    - pos: -3.5,-17.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 587
+    components:
+    - pos: -4.5,-17.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 588
+    components:
+    - pos: -5.5,-17.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 589
+    components:
+    - pos: -6.5,-17.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 590
+    components:
+    - pos: -7.5,-17.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 591
+    components:
+    - pos: -3.5,-14.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 592
+    components:
+    - pos: -4.5,-14.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 593
+    components:
+    - pos: -5.5,-14.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 594
+    components:
+    - pos: -6.5,-14.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 595
+    components:
+    - pos: -1.5,-17.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 596
+    components:
+    - pos: -0.5,-17.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 597
+    components:
+    - pos: 0.5,-17.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 598
+    components:
+    - pos: -2.5,-18.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 599
+    components:
+    - pos: -2.5,-19.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 600
+    components:
+    - pos: -2.5,-20.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 601
+    components:
+    - pos: -2.5,-21.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+    - fixtures: {}
+      type: Fixtures
+  - uid: 602
+    components:
+    - pos: -3.5,-21.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+    - fixtures: {}
+      type: Fixtures
+  - uid: 603
+    components:
+    - pos: -4.5,-21.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+    - fixtures: {}
+      type: Fixtures
+  - uid: 604
+    components:
+    - pos: 0.5,-18.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 605
+    components:
+    - pos: 0.5,-19.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 606
+    components:
+    - pos: 0.5,-20.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 607
+    components:
+    - pos: 5.5,-9.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+    - fixtures: {}
+      type: Fixtures
+  - uid: 608
+    components:
+    - pos: 5.5,-10.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 609
+    components:
+    - pos: 4.5,-10.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 610
+    components:
+    - pos: 4.5,-9.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 611
+    components:
+    - pos: 4.5,-8.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 612
+    components:
+    - pos: 4.5,-7.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 613
+    components:
+    - pos: 4.5,-6.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 614
+    components:
+    - pos: 5.5,-7.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 615
+    components:
+    - pos: 6.5,-7.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 616
+    components:
+    - pos: 7.5,-7.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 617
+    components:
+    - pos: 7.5,-6.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 618
+    components:
+    - pos: -6.5,-6.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 619
+    components:
+    - pos: 6.5,-10.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 620
+    components:
+    - pos: 6.5,-11.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 621
+    components:
+    - pos: 6.5,-12.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 622
+    components:
+    - pos: 6.5,-13.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 623
+    components:
+    - pos: 6.5,-14.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 624
+    components:
+    - pos: 6.5,-15.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 625
+    components:
+    - pos: 6.5,-16.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 626
+    components:
+    - pos: 6.5,-17.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 627
+    components:
+    - pos: 6.5,-18.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 628
+    components:
+    - pos: 6.5,-19.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 629
+    components:
+    - pos: 5.5,-13.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 630
+    components:
+    - pos: 4.5,-13.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 631
+    components:
+    - pos: 7.5,-16.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 632
+    components:
+    - pos: 5.5,-19.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 633
+    components:
+    - pos: 5.5,-20.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 634
+    components:
+    - pos: 5.5,-21.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+    - fixtures: {}
+      type: Fixtures
+  - uid: 635
+    components:
+    - pos: 4.5,-21.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+    - fixtures: {}
+      type: Fixtures
+  - uid: 636
+    components:
+    - pos: 3.5,-21.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+    - fixtures: {}
+      type: Fixtures
+- proto: CableHV
+  entities:
+  - uid: 374
+    components:
+    - pos: 8.5,-8.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 375
+    components:
+    - pos: 7.5,-8.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 376
+    components:
+    - pos: 7.5,-7.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 378
+    components:
+    - pos: 6.5,-6.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 379
+    components:
+    - pos: 5.5,-6.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 380
+    components:
+    - pos: 4.5,-6.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 381
+    components:
+    - pos: 3.5,-6.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 382
+    components:
+    - pos: 3.5,-5.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 782
+    components:
+    - pos: 6.5,-8.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 804
+    components:
+    - pos: 6.5,-7.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+- proto: CableMV
+  entities:
+  - uid: 504
+    components:
+    - pos: 3.5,-5.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 512
+    components:
+    - pos: 5.5,-9.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+    - fixtures: {}
+      type: Fixtures
+  - uid: 513
+    components:
+    - pos: 5.5,-10.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 514
+    components:
+    - pos: -1.5,-13.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+    - fixtures: {}
+      type: Fixtures
+  - uid: 515
+    components:
+    - pos: -1.5,-4.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+    - fixtures: {}
+      type: Fixtures
+  - uid: 516
+    components:
+    - pos: -1.5,-3.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 517
+    components:
+    - pos: -2.5,-3.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 518
+    components:
+    - pos: -2.5,-4.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 519
+    components:
+    - pos: -2.5,-5.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 520
+    components:
+    - pos: -2.5,-6.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 521
+    components:
+    - pos: -2.5,-7.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 522
+    components:
+    - pos: -2.5,-8.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 523
+    components:
+    - pos: -2.5,-9.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 524
+    components:
+    - pos: -2.5,-10.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 525
+    components:
+    - pos: -2.5,-11.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 526
+    components:
+    - pos: -2.5,-12.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 527
+    components:
+    - pos: -2.5,-13.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 528
+    components:
+    - pos: -2.5,-14.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 529
+    components:
+    - pos: -1.5,-14.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 530
+    components:
+    - pos: -0.5,-14.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 531
+    components:
+    - pos: 0.5,-14.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 532
+    components:
+    - pos: 1.5,-14.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 533
+    components:
+    - pos: 2.5,-14.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 534
+    components:
+    - pos: 3.5,-14.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 535
+    components:
+    - pos: 3.5,-13.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 536
+    components:
+    - pos: 3.5,-12.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 537
+    components:
+    - pos: 3.5,-11.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 538
+    components:
+    - pos: 3.5,-10.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 539
+    components:
+    - pos: 4.5,-10.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 540
+    components:
+    - pos: 4.5,-9.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 541
+    components:
+    - pos: 4.5,-8.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 542
+    components:
+    - pos: 4.5,-7.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 543
+    components:
+    - pos: 4.5,-6.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 544
+    components:
+    - pos: 3.5,-6.5
+      parent: 1
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+- proto: CableTerminal
+  entities:
+  - uid: 806
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 6.5,-7.5
+      parent: 1
+      type: Transform
+- proto: CannabisSeeds
+  entities:
+  - uid: 778
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 391
+      type: Transform
+    - nextSound: 391.312899
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: CapacitorStockPart
+  entities:
+  - uid: 710
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 709
+      type: Transform
+    - nextSound: 3469.1388228
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 711
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 709
+      type: Transform
+    - nextSound: 3468.9930469
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: CarpetSBlue
+  entities:
+  - uid: 325
+    components:
+    - pos: -7.5,-15.5
+      parent: 1
+      type: Transform
+  - uid: 326
+    components:
+    - pos: -7.5,-16.5
+      parent: 1
+      type: Transform
+  - uid: 327
+    components:
+    - pos: -7.5,-17.5
+      parent: 1
+      type: Transform
+  - uid: 328
+    components:
+    - pos: -7.5,-18.5
+      parent: 1
+      type: Transform
+  - uid: 329
+    components:
+    - pos: -6.5,-15.5
+      parent: 1
+      type: Transform
+  - uid: 330
+    components:
+    - pos: -6.5,-16.5
+      parent: 1
+      type: Transform
+  - uid: 331
+    components:
+    - pos: -6.5,-17.5
+      parent: 1
+      type: Transform
+  - uid: 332
+    components:
+    - pos: -6.5,-18.5
+      parent: 1
+      type: Transform
+  - uid: 333
+    components:
+    - pos: -5.5,-15.5
+      parent: 1
+      type: Transform
+  - uid: 334
+    components:
+    - pos: -5.5,-16.5
+      parent: 1
+      type: Transform
+  - uid: 335
+    components:
+    - pos: -5.5,-17.5
+      parent: 1
+      type: Transform
+  - uid: 336
+    components:
+    - pos: -5.5,-18.5
+      parent: 1
+      type: Transform
+- proto: CarrotSeeds
+  entities:
+  - uid: 753
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 391
+      type: Transform
+    - nextSound: 389.3973036
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: ChairPilotSeat
+  entities:
+  - uid: 12
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 13
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 3.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 20
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -2.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 46
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -1.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 72
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,-0.5
+      parent: 1
+      type: Transform
+- proto: ChairWood
+  entities:
+  - uid: 150
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -7.5,-16.5
+      parent: 1
+      type: Transform
+  - uid: 164
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -6.5,-14.5
+      parent: 1
+      type: Transform
+  - uid: 165
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -5.5,-17.5
+      parent: 1
+      type: Transform
+  - uid: 166
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -5.5,-16.5
+      parent: 1
+      type: Transform
+  - uid: 175
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -6.5,-18.5
+      parent: 1
+      type: Transform
+  - uid: 208
+    components:
+    - pos: -6.5,-15.5
+      parent: 1
+      type: Transform
+  - uid: 209
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -7.5,-17.5
+      parent: 1
+      type: Transform
+- proto: ChanterelleSeeds
+  entities:
+  - uid: 647
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 391
+      type: Transform
+    - nextSound: 387.1613048
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: ChiliSeeds
+  entities:
+  - uid: 754
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 391
+      type: Transform
+    - nextSound: 385.4115216
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: CigarGoldCase
+  entities:
+  - uid: 810
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 738
+      type: Transform
+    - nextSound: 419.3937575
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: CigCartonBlue
+  entities:
+  - uid: 809
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 738
+      type: Transform
+    - nextSound: 357.5573976
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: CigCartonGreen
+  entities:
+  - uid: 801
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 738
+      type: Transform
+    - nextSound: 383.2337286
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: CircuitImprinterMachineCircuitboard
+  entities:
+  - uid: 502
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 492
+      type: Transform
+    - nextSound: 3153.6055529
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: CloningConsoleComputerCircuitboard
+  entities:
+  - uid: 217
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 492
+      type: Transform
+    - nextSound: 334.9447147
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: ClosetEmergencyFilledRandom
+  entities:
+  - uid: 349
+    components:
+    - pos: -5.5,-21.5
+      parent: 1
+      type: Transform
+  - uid: 350
+    components:
+    - pos: 6.5,-21.5
+      parent: 1
+      type: Transform
+- proto: ClosetMaintenanceFilledRandom
+  entities:
+  - uid: 388
+    components:
+    - pos: 4.5,-15.5
+      parent: 1
+      type: Transform
+- proto: ClosetWallFireFilledRandom
+  entities:
+  - uid: 351
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -5.5,-20.5
+      parent: 1
+      type: Transform
+  - uid: 352
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 6.5,-20.5
+      parent: 1
+      type: Transform
+- proto: ClothingBackpackSatchelLeather
+  entities:
+  - uid: 688
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 660
+      type: Transform
+    - nextSound: 4522.6593366
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: ClothingBackpackSatchelMedical
+  entities:
+  - uid: 818
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 319
+      type: Transform
+    - nextSound: 197.1854807
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: ClothingBeltMedical
+  entities:
+  - uid: 813
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 319
+      type: Transform
+    - nextAttack: 207.985924
+      type: MeleeWeapon
+    - nextSound: 208.185924
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: ClothingBeltUtilityFilled
+  entities:
+  - uid: 727
+    components:
+    - pos: 5.448533,-8.371668
+      parent: 1
+      type: Transform
+    - nextAttack: 25.070894
+      type: MeleeWeapon
+    - nextSound: 25.2708939
+      type: EmitSoundOnCollide
+- proto: ClothingEyesGlasses
+  entities:
+  - uid: 665
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 660
+      type: Transform
+    - nextSound: 2313.7793598
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 674
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 660
+      type: Transform
+    - nextSound: 2314.9296377
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 675
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 660
+      type: Transform
+    - nextSound: 2314.7464684
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: ClothingHandsGlovesColorYellow
+  entities:
+  - uid: 703
+    components:
+    - pos: 5.485503,-8.430397
+      parent: 1
+      type: Transform
+    - nextSound: 4493.1227001
+      type: EmitSoundOnCollide
+- proto: ClothingHandsGlovesCombat
+  entities:
+  - uid: 491
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 58
+      type: Transform
+    - nextSound: 4478.1378795
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: ClothingHeadHatBeret
+  entities:
+  - uid: 323
+    components:
+    - pos: 3.4717312,0.49747467
+      parent: 1
+      type: Transform
+    - nextSound: 703.2290829
+      type: EmitSoundOnCollide
+- proto: ClothingHeadHatCorpsoft
+  entities:
+  - uid: 836
+    components:
+    - pos: 0.4862504,-11.377753
+      parent: 1
+      type: Transform
+    - nextSound: 405.2649616
+      type: EmitSoundOnCollide
+- proto: ClothingHeadHatFedoraBrown
+  entities:
+  - uid: 840
+    components:
+    - pos: -6.7481246,-11.284003
+      parent: 1
+      type: Transform
+    - nextSound: 441.6005687
+      type: EmitSoundOnCollide
+- proto: ClothingHeadHatFlowerCrown
+  entities:
+  - uid: 837
+    components:
+    - pos: -6.4199996,-8.330878
+      parent: 1
+      type: Transform
+    - nextSound: 425.5495665
+      type: EmitSoundOnCollide
+- proto: ClothingHeadHatHairflower
+  entities:
+  - uid: 838
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -6.7324996,-8.409003
+      parent: 1
+      type: Transform
+    - nextSound: 418.9658689
+      type: EmitSoundOnCollide
+- proto: ClothingHeadHatHoodRad
+  entities:
+  - uid: 687
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 660
+      type: Transform
+    - nextSound: 2819.9000986
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: ClothingHeadHatTophat
+  entities:
+  - uid: 839
+    components:
+    - pos: -6.3574996,-11.315253
+      parent: 1
+      type: Transform
+    - nextSound: 432.1178453
+      type: EmitSoundOnCollide
+- proto: ClothingHeadHatWelding
+  entities:
+  - uid: 690
+    components:
+    - pos: 5.532378,-8.289772
+      parent: 1
+      type: Transform
+    - nextSound: 4501.8380547
+      type: EmitSoundOnCollide
+- proto: ClothingHeadTinfoil
+  entities:
+  - uid: 682
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 660
+      type: Transform
+    - nextSound: 2261.9074381
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: ClothingMaskBreathMedical
+  entities:
+  - uid: 814
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 319
+      type: Transform
+    - nextSound: 199.8018366
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: ClothingMaskGas
+  entities:
+  - uid: 680
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 660
+      type: Transform
+    - nextSound: 2297.6467408
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: ClothingMaskGasSwat
+  entities:
+  - uid: 74
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 58
+      type: Transform
+    - nextSound: 34.120149
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: ClothingNeckCloakTrans
+  entities:
+  - uid: 834
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -5.4512496,-8.518378
+      parent: 1
+      type: Transform
+    - nextSound: 411.7991042
+      type: EmitSoundOnCollide
+- proto: ClothingNeckScarfStripedBlue
+  entities:
+  - uid: 842
+    components:
+    - pos: -2.5222707,0.3886509
+      parent: 1
+      type: Transform
+    - nextSound: 470.4370173
+      type: EmitSoundOnCollide
+- proto: ClothingNeckScarfStripedGreen
+  entities:
+  - uid: 320
+    components:
+    - pos: -2.5282688,0.5912247
+      parent: 1
+      type: Transform
+    - nextSound: 701.3111335
+      type: EmitSoundOnCollide
+- proto: ClothingOuterCoatLab
+  entities:
+  - uid: 661
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 660
+      type: Transform
+    - nextSound: 2327.6136144
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 664
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 660
+      type: Transform
+    - nextSound: 2327.831815
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 670
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 660
+      type: Transform
+    - nextSound: 2327.0971874
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: ClothingOuterHardsuitSecurity
+  entities:
+  - uid: 70
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 58
+      type: Transform
+    - nextSound: 6812.0801768
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: ClothingOuterSuitRad
+  entities:
+  - uid: 686
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 660
+      type: Transform
+    - group:
+      - hoverMessage: ""
+        contextText: verb-examine-group-other
+        icon: /Textures/Interface/examine-star.png
+        components:
+        - Armor
+        - ClothingSpeedModifier
+        entries:
+        - message: This decreases your speed by [color=yellow]10%[/color].
+          priority: 0
+          component: ClothingSpeedModifier
+        - message: >-
+            It provides the following protection:
+
+            - [color=yellow]Heat[/color] damage reduced by [color=lightblue]10%[/color].
+
+            - [color=yellow]Radiation[/color] damage reduced by [color=lightblue]55%[/color].
+          priority: 0
+          component: Armor
+        title: null
+      type: GroupExamine
+    - nextSound: 2822.3004624
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: ClothingOuterWinterCoatLong
+  entities:
+  - uid: 835
+    components:
+    - pos: 0.5175004,-11.534003
+      parent: 1
+      type: Transform
+    - nextSound: 399.0984997
+      type: EmitSoundOnCollide
+- proto: ClothingOuterWinterMed
+  entities:
+  - uid: 347
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 319
+      type: Transform
+    - nextSound: 211.5192357
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: ClothingOuterWinterSci
+  entities:
+  - uid: 729
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 660
+      type: Transform
+    - nextSound: 43.598629
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 743
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 660
+      type: Transform
+    - nextSound: 44.0301327
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 744
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 660
+      type: Transform
+    - nextSound: 43.8302076
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: ClothingUniformJumpsuitMedicalDoctor
+  entities:
+  - uid: 816
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 319
+      type: Transform
+    - nextUpdate: 204.6183713
+      type: SuitSensor
+    - nextSound: 204.8183713
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: CombatKnife
+  entities:
+  - uid: 721
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 58
+      type: Transform
+    - nextAttack: 546.2044802
+      type: MeleeWeapon
+    - nextSound: 546.4044802
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: ComputerAlert
+  entities:
+  - uid: 464
+    components:
+    - pos: 1.5,0.5
+      parent: 1
+      type: Transform
+- proto: ComputerIFF
+  entities:
+  - uid: 463
+    components:
+    - pos: -0.5,0.5
+      parent: 1
+      type: Transform
+- proto: ComputerPowerMonitoring
+  entities:
+  - uid: 384
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 3.5,-6.5
+      parent: 1
+      type: Transform
+- proto: ComputerResearchAndDevelopment
+  entities:
+  - uid: 689
+    components:
+    - pos: 4.5,-12.5
+      parent: 1
+      type: Transform
+- proto: ComputerShuttle
+  entities:
+  - uid: 466
+    components:
+    - pos: 0.5,0.5
+      parent: 1
+      type: Transform
+- proto: CornSeeds
+  entities:
+  - uid: 752
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 391
+      type: Transform
+    - nextSound: 383.6790533
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: CrateEngineeringSecure
+  entities:
+  - uid: 492
+    components:
+    - name: technical crate
+      type: MetaData
+    - pos: 7.5,-12.5
+      parent: 1
+      type: Transform
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 293.14972
+        moles:
+        - 1.8856695
+        - 7.0937095
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
+    - containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 500
+          - 499
+          - 498
+          - 497
+          - 496
+          - 495
+          - 494
+          - 493
+          - 503
+          - 63
+          - 308
+          - 217
+          - 501
+          - 310
+          - 312
+          - 502
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+      type: ContainerContainer
+- proto: CrateFilledSpawner
+  entities:
+  - uid: 695
+    components:
+    - pos: 5.5,-18.5
+      parent: 1
+      type: Transform
+  - uid: 697
+    components:
+    - pos: 4.5,-17.5
+      parent: 1
+      type: Transform
+  - uid: 702
+    components:
+    - pos: 4.5,-18.5
+      parent: 1
+      type: Transform
+- proto: CrateFunATV
+  entities:
+  - uid: 701
+    components:
+    - pos: 7.5,-17.5
+      parent: 1
+      type: Transform
+- proto: CrateFunBoardGames
+  entities:
+  - uid: 216
+    components:
+    - pos: -6.5,-19.5
+      parent: 1
+      type: Transform
+- proto: CrateHydroSecure
+  entities:
+  - uid: 391
+    components:
+    - name: botanical supplies crate
+      type: MetaData
+    - pos: 5.5,-17.5
+      parent: 1
+      type: Transform
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 293.1496
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
+    - containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 392
+          - 647
+          - 698
+          - 746
+          - 748
+          - 749
+          - 750
+          - 751
+          - 752
+          - 753
+          - 754
+          - 755
+          - 756
+          - 757
+          - 758
+          - 759
+          - 760
+          - 761
+          - 762
+          - 763
+          - 764
+          - 765
+          - 766
+          - 767
+          - 768
+          - 769
+          - 770
+          - 771
+          - 772
+          - 773
+          - 774
+          - 775
+          - 776
+          - 777
+          - 778
+          - 779
+          - 780
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+      type: ContainerContainer
+- proto: CrateNPCCat
+  entities:
+  - uid: 400
+    components:
+    - pos: 7.5,-18.5
+      parent: 1
+      type: Transform
+- proto: CratePlasma
+  entities:
+  - uid: 709
+    components:
+    - name: parts crate
+      type: MetaData
+    - pos: 8.5,-11.5
+      parent: 1
+      type: Transform
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 293.1497
+        moles:
+        - 1.8856695
+        - 7.0937095
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
+    - containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 713
+          - 714
+          - 715
+          - 716
+          - 717
+          - 718
+          - 719
+          - 710
+          - 725
+          - 711
+          - 712
+          - 724
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+      type: ContainerContainer
+- proto: CratePlastic
+  entities:
+  - uid: 738
+    components:
+    - name: Smokeables plastic crate
+      type: MetaData
+    - pos: 8.5,-17.5
+      parent: 1
+      type: Transform
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 293.1496
+        moles:
+        - 1.8856695
+        - 7.0937095
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
+    - containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 798
+          - 799
+          - 700
+          - 784
+          - 722
+          - 723
+          - 781
+          - 783
+          - 801
+          - 809
+          - 810
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+      type: ContainerContainer
+- proto: CrateScienceSecure
+  entities:
+  - uid: 648
+    components:
+    - name: research data crate
+      type: MetaData
+    - pos: 5.5,-11.5
+      parent: 1
+      type: Transform
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 75.31249
+        moles:
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
+    - containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 649
+          - 650
+          - 651
+          - 652
+          - 653
+          - 654
+          - 655
+          - 656
+          - 657
+          - 658
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+      type: ContainerContainer
+  - uid: 660
+    components:
+    - name: science supplies crate
+      type: MetaData
+    - pos: 5.5,-12.5
+      parent: 1
+      type: Transform
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 293.14972
+        moles:
+        - 1.8968438
+        - 7.1357465
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
+    - containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 664
+          - 662
+          - 661
+          - 683
+          - 743
+          - 729
+          - 744
+          - 685
+          - 688
+          - 745
+          - 143
+          - 696
+          - 687
+          - 61
+          - 60
+          - 686
+          - 682
+          - 681
+          - 680
+          - 679
+          - 678
+          - 677
+          - 676
+          - 675
+          - 674
+          - 673
+          - 672
+          - 671
+          - 670
+          - 669
+          - 668
+          - 667
+          - 666
+          - 665
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+      type: ContainerContainer
+- proto: CrateSecure
+  entities:
+  - uid: 704
+    components:
+    - name: radio crate
+      type: MetaData
+    - pos: 8.5,-12.5
+      parent: 1
+      type: Transform
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 293.1497
+        moles:
+        - 1.8856695
+        - 7.0937095
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
+    - containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 705
+          - 68
+          - 706
+          - 344
+          - 65
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+      type: ContainerContainer
+- proto: Crowbar
+  entities:
+  - uid: 846
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 5.6628127,-7.4813013
+      parent: 1
+      type: Transform
+    - nextAttack: 513.3557043
+      type: MeleeWeapon
+    - nextSound: 513.5557043
+      type: EmitSoundOnCollide
+- proto: d6Dice
+  entities:
+  - uid: 232
+    components:
+    - pos: -6.4931316,-17.396418
+      parent: 1
+      type: Transform
+    - nextSound: 3361.8626669
+      type: EmitSoundOnCollide
+  - uid: 233
+    components:
+    - pos: -6.6337566,-17.271418
+      parent: 1
+      type: Transform
+    - nextSound: 3362.5119501
+      type: EmitSoundOnCollide
+  - uid: 234
+    components:
+    - pos: -6.3681316,-17.208918
+      parent: 1
+      type: Transform
+    - nextSound: 3363.0946491
+      type: EmitSoundOnCollide
+  - uid: 235
+    components:
+    - pos: -6.5712566,-17.162043
+      parent: 1
+      type: Transform
+    - nextSound: 3363.7276956
+      type: EmitSoundOnCollide
+  - uid: 236
+    components:
+    - pos: -6.4306316,-17.068293
+      parent: 1
+      type: Transform
+    - nextSound: 3364.5128883
+      type: EmitSoundOnCollide
+- proto: DefibrillatorCabinetFilled
+  entities:
+  - uid: 269
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 2.5,-6.5
+      parent: 1
+      type: Transform
+- proto: DiceBag
+  entities:
+  - uid: 225
+    components:
+    - pos: -6.47651,-16.639446
+      parent: 1
+      type: Transform
+    - nextSound: 3292.3409831
+      type: EmitSoundOnCollide
+- proto: DisposalUnit
+  entities:
+  - uid: 820
+    components:
+    - pos: -7.5,-19.5
+      parent: 1
+      type: Transform
+  - uid: 821
+    components:
+    - pos: 8.5,-10.5
+      parent: 1
+      type: Transform
+  - uid: 823
+    components:
+    - pos: 0.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 824
+    components:
+    - pos: 8.5,-19.5
+      parent: 1
+      type: Transform
+  - uid: 826
+    components:
+    - pos: 0.5,-5.5
+      parent: 1
+      type: Transform
+- proto: Dresser
+  entities:
+  - uid: 176
+    components:
+    - pos: -6.5,-11.5
+      parent: 1
+      type: Transform
+  - uid: 275
+    components:
+    - pos: -6.5,-8.5
+      parent: 1
+      type: Transform
+  - uid: 278
+    components:
+    - pos: 0.5,-11.5
+      parent: 1
+      type: Transform
+- proto: DrinkGlass
+  entities:
+  - uid: 733
+    components:
+    - pos: -0.52298045,-18.153336
+      parent: 1
+      type: Transform
+    - nextAttack: 482.1993477
+      type: MeleeWeapon
+    - nextSound: 482.3993477
+      type: EmitSoundOnCollide
+  - uid: 737
+    components:
+    - pos: -0.42923045,-16.01271
+      parent: 1
+      type: Transform
+    - nextAttack: 480.6334718
+      type: MeleeWeapon
+    - nextSound: 480.8334718
+      type: EmitSoundOnCollide
+- proto: DrinkMugBlue
+  entities:
+  - uid: 339
+    components:
+    - name: captain's mug
+      type: MetaData
+    - pos: 0.8096051,0.37135792
+      parent: 1
+      type: Transform
+    - solutions:
+        drink:
+          temperature: 293.15
+          canMix: True
+          canReact: True
+          maxVol: 20
+          reagents:
+          - Quantity: 20
+            ReagentId: CoffeeLiqueur
+      type: SolutionContainerManager
+    - nextAttack: 859.0282833
+      type: MeleeWeapon
+    - nextSound: 859.2282833
+      type: EmitSoundOnCollide
+- proto: EggplantSeeds
+  entities:
+  - uid: 760
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 391
+      type: Transform
+    - nextSound: 378.6965338
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: EggySeeds
+  entities:
+  - uid: 755
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 391
+      type: Transform
+    - nextSound: 381.461677
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: EngineeringTechFabCircuitboard
+  entities:
+  - uid: 500
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 492
+      type: Transform
+    - nextSound: 3177.7590435
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: EpinephrineChemistryBottle
+  entities:
+  - uid: 346
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 319
+      type: Transform
+    - nextAttack: 173.5843733
+      type: MeleeWeapon
+    - nextSound: 173.7843733
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 815
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 319
+      type: Transform
+    - nextAttack: 173.7845717
+      type: MeleeWeapon
+    - nextSound: 173.9845717
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 819
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 319
+      type: Transform
+    - nextAttack: 173.367181
+      type: MeleeWeapon
+    - nextSound: 173.567181
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: ExosuitFabricatorMachineCircuitboard
+  entities:
+  - uid: 496
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 492
+      type: Transform
+    - nextSound: 3183.4397086
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: ExtinguisherCabinetFilled
+  entities:
+  - uid: 9
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -4.5,-8.5
+      parent: 1
+      type: Transform
+  - uid: 277
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 354
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -5.5,-13.5
+      parent: 1
+      type: Transform
+  - uid: 358
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 7.5,-20.5
+      parent: 1
+      type: Transform
+  - uid: 406
+    components:
+    - pos: 6.5,-9.5
+      parent: 1
+      type: Transform
+  - uid: 444
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 2.5,-15.5
+      parent: 1
+      type: Transform
+- proto: FireAxeCabinetFilledOpen
+  entities:
+  - uid: 732
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 2.5,-7.5
+      parent: 1
+      type: Transform
+- proto: Flash
+  entities:
+  - uid: 62
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 58
+      type: Transform
+    - nextAttack: 6437.5586257
+      type: MeleeWeapon
+    - nextSound: 6437.7586257
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: FlashlightLantern
+  entities:
+  - uid: 730
+    components:
+    - pos: -3.5824041,-0.4690323
+      parent: 1
+      type: Transform
+    - nextAttack: 339.0896612
+      type: MeleeWeapon
+    - nextSound: 339.2896612
+      type: EmitSoundOnCollide
+  - uid: 735
+    components:
+    - pos: 4.433221,-0.4377823
+      parent: 1
+      type: Transform
+    - nextAttack: 338.1571595
+      type: MeleeWeapon
+    - nextSound: 338.3571595
+      type: EmitSoundOnCollide
+- proto: FlashlightSeclite
+  entities:
+  - uid: 720
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 58
+      type: Transform
+    - nextAttack: 399.2282302
+      type: MeleeWeapon
+    - nextSound: 399.4282301
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: Floodlight
+  entities:
+  - uid: 731
+    components:
+    - pos: 5.4614024,-6.481311
+      parent: 1
+      type: Transform
+    - nextSound: 506.950774
+      type: EmitSoundOnCollide
+- proto: FlyAmanitaSeeds
+  entities:
+  - uid: 698
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 391
+      type: Transform
+    - nextSound: 376.160366
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: FoodBowlBig
+  entities:
+  - uid: 741
+    components:
+    - pos: -0.6170506,-18.806862
+      parent: 1
+      type: Transform
+    - nextAttack: 445.480048
+      type: MeleeWeapon
+    - nextSound: 445.680048
+      type: EmitSoundOnCollide
+- proto: FoodCakeLemon
+  entities:
+  - uid: 794
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 206
+      type: Transform
+    - nextSound: 58.571003
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: FoodFrozenSandwich
+  entities:
+  - uid: 787
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 206
+      type: Transform
+    - nextSound: 118.2254804
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: FoodMealCornedbeef
+  entities:
+  - uid: 279
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 206
+      type: Transform
+    - nextSound: 839.2049597
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 284
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 206
+      type: Transform
+    - nextSound: 838.736901
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: FoodMothToastedSeeds
+  entities:
+  - uid: 779
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 391
+      type: Transform
+    - nextSound: 312.369504
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: FoodPizzaArnold
+  entities:
+  - uid: 797
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 206
+      type: Transform
+    - nextSound: 69.1211995
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: FoodPizzaSassysage
+  entities:
+  - uid: 795
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 206
+      type: Transform
+    - nextSound: 82.0901011
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: FoodPlate
+  entities:
+  - uid: 742
+    components:
+    - pos: -0.5076756,-16.994362
+      parent: 1
+      type: Transform
+    - nextSound: 451.0326009
+      type: EmitSoundOnCollide
+- proto: FoodSnackMREBrownie
+  entities:
+  - uid: 796
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 206
+      type: Transform
+    - nextSound: 96.9901737
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: ForensicScanner
+  entities:
+  - uid: 668
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 660
+      type: Transform
+    - nextSound: 2450.638114
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: GalaxythistleSeeds
+  entities:
+  - uid: 750
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 391
+      type: Transform
+    - nextSound: 373.7603492
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: GarlicSeeds
+  entities:
+  - uid: 762
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 391
+      type: Transform
+    - nextSound: 371.3601081
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: GasAnalyzer
+  entities:
+  - uid: 672
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 660
+      type: Transform
+    - nextSound: 2428.7708827
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: GasPassiveVent
+  entities:
+  - uid: 113
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,-22.5
+      parent: 1
+      type: Transform
+    - nextSound: 7524.9129232
+      type: EmitSoundOnCollide
+- proto: GasPipeBend
+  entities:
+  - uid: 40
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 0.5,-8.5
+      parent: 1
+      type: Transform
+    - nextSound: 338.3871854
+      type: EmitSoundOnCollide
+  - uid: 423
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 4.5,-10.5
+      parent: 1
+      type: Transform
+    - nextSound: 7581.5358842
+      type: EmitSoundOnCollide
+  - uid: 424
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 3.5,-10.5
+      parent: 1
+      type: Transform
+    - nextSound: 7582.5859688
+      type: EmitSoundOnCollide
+  - uid: 436
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 3.5,-21.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+    - nextSound: 7604.9359075
+      type: EmitSoundOnCollide
+  - uid: 481
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -2.5,-3.5
+      parent: 1
+      type: Transform
+    - nextSound: 7858.6355035
+      type: EmitSoundOnCollide
+  - uid: 484
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 0.5,-3.5
+      parent: 1
+      type: Transform
+    - nextSound: 7863.6694793
+      type: EmitSoundOnCollide
+  - uid: 489
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -2.5,-21.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+    - nextSound: 7886.0709038
+      type: EmitSoundOnCollide
+- proto: GasPipeFourway
+  entities:
+  - uid: 452
+    components:
+    - pos: -2.5,-12.5
+      parent: 1
+      type: Transform
+    - nextSound: 7813.6007894
+      type: EmitSoundOnCollide
+- proto: GasPipeStraight
+  entities:
+  - uid: 37
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,-8.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+    - nextSound: 335.3696981
+      type: EmitSoundOnCollide
+  - uid: 39
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -0.5,-8.5
+      parent: 1
+      type: Transform
+    - nextSound: 336.1860353
+      type: EmitSoundOnCollide
+  - uid: 414
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,-21.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+    - nextSound: 7566.1009638
+      type: EmitSoundOnCollide
+  - uid: 415
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,-20.5
+      parent: 1
+      type: Transform
+    - nextSound: 7566.58493
+      type: EmitSoundOnCollide
+  - uid: 416
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,-19.5
+      parent: 1
+      type: Transform
+    - nextSound: 7567.0346572
+      type: EmitSoundOnCollide
+  - uid: 417
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,-18.5
+      parent: 1
+      type: Transform
+    - nextSound: 7567.9850369
+      type: EmitSoundOnCollide
+  - uid: 418
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,-17.5
+      parent: 1
+      type: Transform
+    - nextSound: 7568.5350098
+      type: EmitSoundOnCollide
+  - uid: 420
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,-15.5
+      parent: 1
+      type: Transform
+    - nextSound: 7572.4351699
+      type: EmitSoundOnCollide
+  - uid: 421
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 4.5,-8.5
+      parent: 1
+      type: Transform
+    - nextSound: 7576.251634
+      type: EmitSoundOnCollide
+  - uid: 422
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 4.5,-9.5
+      parent: 1
+      type: Transform
+    - nextSound: 7577.3508968
+      type: EmitSoundOnCollide
+  - uid: 425
+    components:
+    - pos: 3.5,-11.5
+      parent: 1
+      type: Transform
+    - nextSound: 7584.7692409
+      type: EmitSoundOnCollide
+  - uid: 426
+    components:
+    - pos: 3.5,-12.5
+      parent: 1
+      type: Transform
+    - nextSound: 7585.7184653
+      type: EmitSoundOnCollide
+  - uid: 429
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 4.5,-13.5
+      parent: 1
+      type: Transform
+    - nextSound: 7594.2687916
+      type: EmitSoundOnCollide
+  - uid: 430
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 5.5,-13.5
+      parent: 1
+      type: Transform
+    - nextSound: 7594.5709785
+      type: EmitSoundOnCollide
+  - uid: 431
+    components:
+    - pos: 3.5,-15.5
+      parent: 1
+      type: Transform
+    - nextSound: 7596.06975
+      type: EmitSoundOnCollide
+  - uid: 432
+    components:
+    - pos: 3.5,-16.5
+      parent: 1
+      type: Transform
+    - nextSound: 7596.5018331
+      type: EmitSoundOnCollide
+  - uid: 433
+    components:
+    - pos: 3.5,-17.5
+      parent: 1
+      type: Transform
+    - nextSound: 7597.0029917
+      type: EmitSoundOnCollide
+  - uid: 434
+    components:
+    - pos: 3.5,-18.5
+      parent: 1
+      type: Transform
+    - nextSound: 7598.1860029
+      type: EmitSoundOnCollide
+  - uid: 435
+    components:
+    - pos: 3.5,-19.5
+      parent: 1
+      type: Transform
+    - nextSound: 7601.1528706
+      type: EmitSoundOnCollide
+  - uid: 437
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 3.5,-20.5
+      parent: 1
+      type: Transform
+    - nextSound: 7607.7859083
+      type: EmitSoundOnCollide
+  - uid: 440
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 2.5,-14.5
+      parent: 1
+      type: Transform
+    - nextSound: 7626.2882902
+      type: EmitSoundOnCollide
+  - uid: 441
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,-14.5
+      parent: 1
+      type: Transform
+    - nextSound: 7627.1882023
+      type: EmitSoundOnCollide
+  - uid: 445
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -0.5,-14.5
+      parent: 1
+      type: Transform
+    - nextSound: 7743.4959159
+      type: EmitSoundOnCollide
+  - uid: 446
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -1.5,-14.5
+      parent: 1
+      type: Transform
+    - nextSound: 7743.9283115
+      type: EmitSoundOnCollide
+  - uid: 447
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -1.5,-12.5
+      parent: 1
+      type: Transform
+    - nextSound: 7822.5011982
+      type: EmitSoundOnCollide
+  - uid: 449
+    components:
+    - pos: -2.5,-15.5
+      parent: 1
+      type: Transform
+    - nextSound: 7806.3780619
+      type: EmitSoundOnCollide
+  - uid: 450
+    components:
+    - pos: -2.5,-16.5
+      parent: 1
+      type: Transform
+    - nextSound: 7806.7834168
+      type: EmitSoundOnCollide
+  - uid: 453
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -2.5,-13.5
+      parent: 1
+      type: Transform
+    - nextSound: 7819.334732
+      type: EmitSoundOnCollide
+  - uid: 456
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -0.5,-12.5
+      parent: 1
+      type: Transform
+    - nextSound: 7823.5010629
+      type: EmitSoundOnCollide
+  - uid: 457
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -3.5,-12.5
+      parent: 1
+      type: Transform
+    - nextSound: 7824.2007025
+      type: EmitSoundOnCollide
+  - uid: 458
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -4.5,-12.5
+      parent: 1
+      type: Transform
+    - nextSound: 7824.6013434
+      type: EmitSoundOnCollide
+  - uid: 459
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -5.5,-12.5
+      parent: 1
+      type: Transform
+    - nextSound: 7825.3833068
+      type: EmitSoundOnCollide
+  - uid: 460
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -3.5,-9.5
+      parent: 1
+      type: Transform
+    - nextSound: 7826.3511727
+      type: EmitSoundOnCollide
+  - uid: 461
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -4.5,-9.5
+      parent: 1
+      type: Transform
+    - nextSound: 7826.634453
+      type: EmitSoundOnCollide
+  - uid: 462
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -5.5,-9.5
+      parent: 1
+      type: Transform
+    - nextSound: 7826.8846576
+      type: EmitSoundOnCollide
+  - uid: 467
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -3.5,-6.5
+      parent: 1
+      type: Transform
+    - nextSound: 7830.9677219
+      type: EmitSoundOnCollide
+  - uid: 468
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -4.5,-6.5
+      parent: 1
+      type: Transform
+    - nextSound: 7832.1678893
+      type: EmitSoundOnCollide
+  - uid: 469
+    components:
+    - pos: -2.5,-7.5
+      parent: 1
+      type: Transform
+    - nextSound: 7833.1343219
+      type: EmitSoundOnCollide
+  - uid: 471
+    components:
+    - pos: -2.5,-11.5
+      parent: 1
+      type: Transform
+    - nextSound: 7833.8339428
+      type: EmitSoundOnCollide
+  - uid: 472
+    components:
+    - pos: -2.5,-10.5
+      parent: 1
+      type: Transform
+    - nextSound: 7834.3016224
+      type: EmitSoundOnCollide
+  - uid: 479
+    components:
+    - pos: -2.5,-5.5
+      parent: 1
+      type: Transform
+    - nextSound: 7852.4709469
+      type: EmitSoundOnCollide
+  - uid: 480
+    components:
+    - pos: -2.5,-4.5
+      parent: 1
+      type: Transform
+    - nextSound: 7854.2355253
+      type: EmitSoundOnCollide
+  - uid: 482
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -1.5,-3.5
+      parent: 1
+      type: Transform
+    - nextSound: 7861.0036675
+      type: EmitSoundOnCollide
+  - uid: 483
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -0.5,-3.5
+      parent: 1
+      type: Transform
+    - nextSound: 7861.6532461
+      type: EmitSoundOnCollide
+  - uid: 486
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -2.5,-18.5
+      parent: 1
+      type: Transform
+    - nextSound: 7880.0203422
+      type: EmitSoundOnCollide
+  - uid: 487
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -2.5,-19.5
+      parent: 1
+      type: Transform
+    - nextSound: 7880.9719567
+      type: EmitSoundOnCollide
+  - uid: 488
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -2.5,-20.5
+      parent: 1
+      type: Transform
+    - nextSound: 7881.7219517
+      type: EmitSoundOnCollide
+- proto: GasPipeTJunction
+  entities:
+  - uid: 285
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -2.5,-9.5
+      parent: 1
+      type: Transform
+    - nextSound: 315.6346265
+      type: EmitSoundOnCollide
+  - uid: 288
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -2.5,-6.5
+      parent: 1
+      type: Transform
+    - nextSound: 314.3846335
+      type: EmitSoundOnCollide
+  - uid: 305
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -2.5,-8.5
+      parent: 1
+      type: Transform
+    - nextSound: 319.9685386
+      type: EmitSoundOnCollide
+  - uid: 353
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -2.5,-14.5
+      parent: 1
+      type: Transform
+    - nextSound: 7790.7162112
+      type: EmitSoundOnCollide
+  - uid: 419
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 0.5,-16.5
+      parent: 1
+      type: Transform
+    - nextSound: 7618.886586
+      type: EmitSoundOnCollide
+  - uid: 427
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,-14.5
+      parent: 1
+      type: Transform
+    - nextSound: 7591.1027909
+      type: EmitSoundOnCollide
+  - uid: 428
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 3.5,-13.5
+      parent: 1
+      type: Transform
+    - nextSound: 7592.4026423
+      type: EmitSoundOnCollide
+  - uid: 442
+    components:
+    - pos: 0.5,-14.5
+      parent: 1
+      type: Transform
+    - nextSound: 7629.4542662
+      type: EmitSoundOnCollide
+  - uid: 451
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -2.5,-17.5
+      parent: 1
+      type: Transform
+    - nextSound: 7878.4372429
+      type: EmitSoundOnCollide
+- proto: GasVentScrubber
+  entities:
+  - uid: 43
+    components:
+    - pos: 0.5,-7.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+    - nextSound: 342.9868302
+      type: EmitSoundOnCollide
+  - uid: 409
+    components:
+    - pos: 4.5,-7.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+    - nextSound: 7544.7994895
+      type: EmitSoundOnCollide
+  - uid: 413
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 6.5,-13.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+    - nextSound: 7551.7008238
+      type: EmitSoundOnCollide
+  - uid: 438
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 4.5,-21.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+    - nextSound: 7611.1872819
+      type: EmitSoundOnCollide
+  - uid: 439
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,-16.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+    - nextSound: 7622.0217517
+      type: EmitSoundOnCollide
+  - uid: 448
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -3.5,-17.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+    - nextSound: 7803.0127764
+      type: EmitSoundOnCollide
+  - uid: 473
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -6.5,-12.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+    - nextSound: 7838.0850091
+      type: EmitSoundOnCollide
+  - uid: 474
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -6.5,-9.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+    - nextSound: 7838.6024848
+      type: EmitSoundOnCollide
+  - uid: 476
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 0.5,-12.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+    - nextSound: 7840.0693126
+      type: EmitSoundOnCollide
+  - uid: 478
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -5.5,-6.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+    - nextSound: 7841.9690866
+      type: EmitSoundOnCollide
+  - uid: 485
+    components:
+    - pos: 0.5,-2.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+    - nextSound: 7865.8875266
+      type: EmitSoundOnCollide
+  - uid: 490
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -3.5,-21.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+    - nextSound: 7888.5041057
+      type: EmitSoundOnCollide
+- proto: GeigerCounter
+  entities:
+  - uid: 678
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 660
+      type: Transform
+    - nextSound: 2269.1407685
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: GeneratorUranium
+  entities:
+  - uid: 370
+    components:
+    - pos: 8.5,-8.5
+      parent: 1
+      type: Transform
+  - uid: 739
+    components:
+    - pos: 7.5,-8.5
+      parent: 1
+      type: Transform
+- proto: GrapeSeeds
+  entities:
+  - uid: 764
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 391
+      type: Transform
+    - nextSound: 368.859889
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 357
+    components:
+    - pos: 5.5,-5.5
+      parent: 1
+      type: Transform
+- proto: Grille
+  entities:
+  - uid: 57
+    components:
+    - pos: -4.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 83
+    components:
+    - pos: -8.5,-15.5
+      parent: 1
+      type: Transform
+  - uid: 114
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -8.5,-16.5
+      parent: 1
+      type: Transform
+  - uid: 171
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -8.5,-17.5
+      parent: 1
+      type: Transform
+  - uid: 218
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -8.5,-18.5
+      parent: 1
+      type: Transform
+  - uid: 295
+    components:
+    - pos: -4.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 340
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 359
+    components:
+    - pos: -4.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 360
+    components:
+    - pos: -1.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 361
+    components:
+    - pos: -2.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 362
+    components:
+    - pos: -0.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 363
+    components:
+    - pos: 0.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 364
+    components:
+    - pos: 1.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 365
+    components:
+    - pos: 2.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 366
+    components:
+    - pos: 3.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 367
+    components:
+    - pos: 5.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 368
+    components:
+    - pos: 5.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 369
+    components:
+    - pos: 5.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 567
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,-7.5
+      parent: 1
+      type: Transform
+- proto: GroundCannabis
+  entities:
+  - uid: 722
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 738
+      type: Transform
+    - nextSound: 174.6782945
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: GroundTobacco
+  entities:
+  - uid: 700
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 738
+      type: Transform
+    - nextSound: 167.6115993
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 723
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 738
+      type: Transform
+    - nextSound: 167.9108654
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 784
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 738
+      type: Transform
+    - nextSound: 168.1450779
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: GunSafe
+  entities:
+  - uid: 58
+    components:
+    - name: arms safe
+      type: MetaData
+    - pos: 4.5,-3.5
+      parent: 1
+      type: Transform
+    - containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 721
+          - 62
+          - 491
+          - 67
+          - 66
+          - 59
+          - 385
+          - 70
+          - 684
+          - 707
+          - 69
+          - 386
+          - 64
+          - 663
+          - 74
+          - 720
+      type: ContainerContainer
+- proto: Gyroscope
+  entities:
+  - uid: 373
+    components:
+    - pos: 4.5,-5.5
+      parent: 1
+      type: Transform
+    - nextFire: 6177.3766343
+      type: Thruster
+- proto: HandheldGPSBasic
+  entities:
+  - uid: 213
+    components:
+    - pos: -2.4657688,-0.06502533
+      parent: 1
+      type: Transform
+    - nextSound: 708.0297447
+      type: EmitSoundOnCollide
+- proto: HandheldHealthAnalyzer
+  entities:
+  - uid: 736
+    components:
+    - pos: -0.4060216,-5.6687975
+      parent: 1
+      type: Transform
+    - nextUpdate: 520.1711821
+      type: PowerCellDraw
+    - nextSound: 520.3711821
+      type: EmitSoundOnCollide
+- proto: HandLabeler
+  entities:
+  - uid: 685
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 660
+      type: Transform
+    - nextSound: 2496.4732899
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: HatBandBlue
+  entities:
+  - uid: 345
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 319
+      type: Transform
+    - nextSound: 242.0357974
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: HatBandBotany
+  entities:
+  - uid: 841
+    components:
+    - pos: -6.5054994,-8.183867
+      parent: 1
+      type: Transform
+    - nextSound: 455.7349592
+      type: EmitSoundOnCollide
+- proto: IngotGold1
+  entities:
+  - uid: 143
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 660
+      type: Transform
+    - nextSound: 369.6458401
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: KillerTomatoSeeds
+  entities:
+  - uid: 767
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 391
+      type: Transform
+    - nextSound: 366.2100059
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: KitchenDeepFryer
+  entities:
+  - uid: 199
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,-17.5
+      parent: 1
+      type: Transform
+    - nextFryTime: 5
+      type: DeepFryer
+- proto: KitchenKnife
+  entities:
+  - uid: 740
+    components:
+    - pos: 1.4454494,-18.666237
+      parent: 1
+      type: Transform
+    - nextAttack: 439.913909
+      type: MeleeWeapon
+    - nextSound: 440.113909
+      type: EmitSoundOnCollide
+- proto: KitchenMicrowave
+  entities:
+  - uid: 177
+    components:
+    - pos: 1.5,-18.5
+      parent: 1
+      type: Transform
+- proto: KitchenReagentGrinder
+  entities:
+  - uid: 172
+    components:
+    - pos: 1.5,-19.5
+      parent: 1
+      type: Transform
+- proto: LemonSeeds
+  entities:
+  - uid: 765
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 391
+      type: Transform
+    - nextSound: 361.2454599
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: LimeSeeds
+  entities:
+  - uid: 768
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 391
+      type: Transform
+    - nextSound: 358.7760637
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: LingzhiSeeds
+  entities:
+  - uid: 761
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 391
+      type: Transform
+    - nextSound: 356.7093614
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: LockerFreezer
+  entities:
+  - uid: 206
+    components:
+    - pos: 1.5,-20.5
+      parent: 1
+      type: Transform
+    - air:
+        volume: 200
+        immutable: False
+        temperature: 293.1496
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+      type: EntityStorage
+    - containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 279
+          - 284
+          - 797
+          - 796
+          - 795
+          - 794
+          - 787
+      type: ContainerContainer
+    missingComponents:
+    - AccessReader
+- proto: LockerMedicineFilled
+  entities:
+  - uid: 319
+    components:
+    - pos: 1.5,-5.5
+      parent: 1
+      type: Transform
+    - containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 345
+          - 346
+          - 347
+          - 348
+          - 813
+          - 814
+          - 815
+          - 816
+          - 817
+          - 818
+          - 819
+      type: ContainerContainer
+- proto: MaintenanceToolSpawner
+  entities:
+  - uid: 803
+    components:
+    - pos: 6.5,-8.5
+      parent: 1
+      type: Transform
+  - uid: 805
+    components:
+    - pos: 6.5,-8.5
+      parent: 1
+      type: Transform
+  - uid: 807
+    components:
+    - pos: 6.5,-8.5
+      parent: 1
+      type: Transform
+- proto: Matchbox
+  entities:
+  - uid: 798
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 738
+      type: Transform
+    - nextSound: 428.0129961
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 799
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 738
+      type: Transform
+    - nextSound: 427.8293116
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: MaterialReclaimerMachineCircuitboard
+  entities:
+  - uid: 495
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 492
+      type: Transform
+    - nextSound: 3255.047338
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: MatterBinStockPart
+  entities:
+  - uid: 717
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 709
+      type: Transform
+    - nextSound: 3467.2263441
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 719
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 709
+      type: Transform
+    - nextSound: 3467.0926882
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: MedicalBed
+  entities:
+  - uid: 304
+    components:
+    - pos: 1.5,-9.5
+      parent: 1
+      type: Transform
+  - uid: 317
+    components:
+    - pos: 1.5,-7.5
+      parent: 1
+      type: Transform
+- proto: MedicalScannerMachineCircuitboard
+  entities:
+  - uid: 308
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 492
+      type: Transform
+    - nextSound: 343.2783974
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: MedicalTechFabCircuitboard
+  entities:
+  - uid: 493
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 492
+      type: Transform
+    - nextSound: 3185.9249349
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: MedkitCombatFilled
+  entities:
+  - uid: 811
+    components:
+    - pos: -0.32578492,-6.2703447
+      parent: 1
+      type: Transform
+    - nextSound: 171.6449775
+      type: EmitSoundOnCollide
+- proto: MedkitFilled
+  entities:
+  - uid: 318
+    components:
+    - pos: -0.3278966,-7.4812975
+      parent: 1
+      type: Transform
+    - nextSound: 497.8535461
+      type: EmitSoundOnCollide
+- proto: MedkitOxygenFilled
+  entities:
+  - uid: 397
+    components:
+    - pos: -0.6091466,-7.2000475
+      parent: 1
+      type: Transform
+    - nextSound: 500.9036518
+      type: EmitSoundOnCollide
+- proto: MedkitRadiationFilled
+  entities:
+  - uid: 271
+    components:
+    - pos: -0.3435216,-6.9344225
+      parent: 1
+      type: Transform
+    - nextSound: 503.5710804
+      type: EmitSoundOnCollide
+- proto: MedkitToxinFilled
+  entities:
+  - uid: 404
+    components:
+    - pos: -0.6091466,-6.5437975
+      parent: 1
+      type: Transform
+    - nextSound: 505.9868118
+      type: EmitSoundOnCollide
+- proto: MetempsychoticMachineCircuitboard
+  entities:
+  - uid: 310
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 492
+      type: Transform
+    - nextSound: 338.4109768
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: MicroLaserStockPart
+  entities:
+  - uid: 715
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 709
+      type: Transform
+    - nextSound: 3465.2725615
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 718
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 709
+      type: Transform
+    - nextSound: 3465.1245779
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: MicroManipulatorStockPart
+  entities:
+  - uid: 712
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 709
+      type: Transform
+    - nextSound: 3462.9246038
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 713
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 709
+      type: Transform
+    - nextSound: 3463.0923606
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: Mirror
+  entities:
+  - uid: 290
+    components:
+    - pos: -5.5,-5.5
+      parent: 1
+      type: Transform
+- proto: NettleSeeds
+  entities:
+  - uid: 756
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 391
+      type: Transform
+    - nextSound: 354.8100765
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: NodeScanner
+  entities:
+  - uid: 671
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 660
+      type: Transform
+    - nextSound: 2447.5562339
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: OatSeeds
+  entities:
+  - uid: 758
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 391
+      type: Transform
+    - nextSound: 352.2769111
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: OnionRedSeeds
+  entities:
+  - uid: 770
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 391
+      type: Transform
+    - nextSound: 340.7274722
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: OnionSeeds
+  entities:
+  - uid: 757
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 391
+      type: Transform
+    - nextSound: 350.1028519
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: OrangeSeeds
+  entities:
+  - uid: 780
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 391
+      type: Transform
+    - nextSound: 348.4089135
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: OreBag
+  entities:
+  - uid: 63
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 492
+      type: Transform
+    - nextSound: 116.2110966
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: OreProcessor
+  entities:
+  - uid: 708
+    components:
+    - pos: 7.5,-11.5
+      parent: 1
+      type: Transform
+- proto: PackPaperRollingFilters
+  entities:
+  - uid: 783
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 738
+      type: Transform
+    - nextSound: 1564.3980684
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: PaperCargoInvoice
+  entities:
+  - uid: 785
+    components:
+    - name: Excavation Industries cargo
+      type: MetaData
+    - pos: 8.031446,-11.898206
+      parent: 1
+      type: Transform
+    - stampState: paper_stamp-trader
+      stampedBy:
+      - Trader
+      content: >-
+        Package type: Equipment
+
+
+        Receiver: Excavation Industries
+
+
+        Contents:
+
+        New ore processor
+
+        Boards, parts for machines
+
+        Communication equipment
+      type: Paper
+    - nextSound: 435.7483458
+      type: EmitSoundOnCollide
+  - uid: 788
+    components:
+    - name: Space Ranch Above The Mountains cargo
+      type: MetaData
+    - pos: 7.9820466,-17.999077
+      parent: 1
+      type: Transform
+    - stampState: paper_stamp-trader
+      stampedBy:
+      - Trader
+      content: >-
+        Package type: General
+
+
+        Receiver: Space Ranch Above The Mountains
+
+
+        Contents:
+
+        All Terrain Vehicle
+
+        Smokes supplies
+
+        A new feline pet
+
+        Ressuply materials
+      type: Paper
+    - nextSound: 442.4486715
+      type: EmitSoundOnCollide
+  - uid: 790
+    components:
+    - name: Torus Colony cargo
+      type: MetaData
+    - pos: 4.9507966,-14.999078
+      parent: 1
+      type: Transform
+    - stampState: paper_stamp-trader
+      stampedBy:
+      - Trader
+      content: >-
+        Package type: Supplies
+
+
+        Receiver: Torus Colony
+
+
+        Contents:
+
+        New fancy table, often called "Altar"
+
+        2 vending machines
+
+        Sturdy metal locker with requested contents
+      type: Paper
+    - nextSound: 438.1489845
+      type: EmitSoundOnCollide
+  - uid: 791
+    components:
+    - name: Phantom Hotel Station's cargo
+      type: MetaData
+    - pos: 4.9976716,-18.014702
+      parent: 1
+      type: Transform
+    - stampState: paper_stamp-trader
+      stampedBy:
+      - Trader
+      content: >-
+        Package type: Supplies
+
+
+        Receiver: Phantom Hotel Station
+
+        Sender: Nanotrasen Trading Division
+
+
+        Contents:
+
+        Extensive seed package for kickstarting local farms
+
+        Ressuply for the station's storage
+      type: Paper
+    - nextSound: 440.5977564
+      type: EmitSoundOnCollide
+  - uid: 792
+    components:
+    - name: Robustonics Inc cargo
+      type: MetaData
+    - pos: 5.0445466,-12.014703
+      parent: 1
+      type: Transform
+    - stampState: paper_stamp-trader
+      stampedBy:
+      - Trader
+      content: >-
+        Package type: Equipment
+
+
+        Receiver: Robustonics Inc
+
+
+        Contents:
+
+        New server with computer
+
+        Science supplies, equipment
+
+        Prototypes
+      type: Paper
+    - nextSound: 434.3973652
+      type: EmitSoundOnCollide
+  - uid: 793
+    components:
+    - name: Cosmos Freight Co cargo
+      type: MetaData
+    - pos: 8.044546,-15.014703
+      parent: 1
+      type: Transform
+    - stampState: paper_stamp-trader
+      stampedBy:
+      - Trader
+      content: >-
+        Package type: Supplies
+
+
+        Receiver: Cosmos Freight Co
+
+        Sender: Cerberus Inc
+
+
+        Contents:
+
+        Supplies recovered from debries orbiting around lunar celestial body
+      type: Paper
+    - nextSound: 437.0982915
+      type: EmitSoundOnCollide
+- proto: PersonalAI
+  entities:
+  - uid: 338
+    components:
+    - flags: SessionSpecific
+      type: MetaData
+    - pos: -3.0438938,-0.40877533
+      parent: 1
+      type: Transform
+    - nextSound: 689.1767377
+      type: EmitSoundOnCollide
+  - uid: 454
+    components:
+    - flags: SessionSpecific
+      type: MetaData
+    - pos: 3.9873562,-0.44002533
+      parent: 1
+      type: Transform
+    - nextSound: 690.8611273
+      type: EmitSoundOnCollide
+- proto: Pickaxe
+  entities:
+  - uid: 390
+    components:
+    - pos: 5.4653015,-8.42474
+      parent: 1
+      type: Transform
+    - nextAttack: 6342.0535515
+      type: MeleeWeapon
+    - nextSound: 6342.2535515
+      type: EmitSoundOnCollide
+- proto: PineappleSeeds
+  entities:
+  - uid: 763
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 391
+      type: Transform
+    - nextSound: 346.7251596
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: PinpointerUniversal
+  entities:
+  - uid: 696
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 660
+      type: Transform
+    - nextSound: 401.2430902
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: PlasticFlapsClear
+  entities:
+  - uid: 830
+    components:
+    - pos: 4.5,-17.5
+      parent: 1
+      type: Transform
+  - uid: 831
+    components:
+    - pos: 5.5,-17.5
+      parent: 1
+      type: Transform
+  - uid: 832
+    components:
+    - pos: 5.5,-18.5
+      parent: 1
+      type: Transform
+  - uid: 833
+    components:
+    - pos: 4.5,-18.5
+      parent: 1
+      type: Transform
+- proto: PlushieLizard
+  entities:
+  - uid: 324
+    components:
+    - pos: -5.526058,-11.403181
+      parent: 1
+      type: Transform
+    - nextAttack: 4448.7095484
+      type: MeleeWeapon
+    - nextSound: 4448.9095484
+      type: EmitSoundOnCollide
+- proto: PlushieMoffRandom
+  entities:
+  - uid: 270
+    components:
+    - pos: -0.56295395,-11.384417
+      parent: 1
+      type: Transform
+    - nextSound: 4935.5747611
+      type: EmitSoundOnCollide
+    - nextAttack: 4935.3747611
+      type: MeleeWeapon
+- proto: PlushieRouny
+  entities:
+  - uid: 322
+    components:
+    - pos: 1.4739418,-11.455091
+      parent: 1
+      type: Transform
+    - nextSound: 4428.0575418
+      type: EmitSoundOnCollide
+    - nextAttack: 4427.8575418
+      type: MeleeWeapon
+- proto: PlushieSharkBlue
+  entities:
+  - uid: 35
+    components:
+    - pos: -5.4965386,-8.479141
+      parent: 1
+      type: Transform
+    - nextSound: 115.6717818
+      type: EmitSoundOnCollide
+    - nextAttack: 115.4717818
+      type: MeleeWeapon
+- proto: PlushieSlime
+  entities:
+  - uid: 321
+    components:
+    - pos: -7.572933,-8.501966
+      parent: 1
+      type: Transform
+    - nextSound: 4424.8581496
+      type: EmitSoundOnCollide
+    - nextAttack: 4424.6581497
+      type: MeleeWeapon
+- proto: PlushieSpaceLizard
+  entities:
+  - uid: 36
+    components:
+    - pos: -7.5121636,-11.385391
+      parent: 1
+      type: Transform
+    - nextAttack: 120.6725237
+      type: MeleeWeapon
+    - nextSound: 120.8725237
+      type: EmitSoundOnCollide
+- proto: PoppySeeds
+  entities:
+  - uid: 769
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 391
+      type: Transform
+    - nextSound: 344.609556
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: PosterLegitHelpOthers
+  entities:
+  - uid: 641
+    components:
+    - pos: -4.5,-7.5
+      parent: 1
+      type: Transform
+- proto: PosterLegitJustAWeekAway
+  entities:
+  - uid: 642
+    components:
+    - pos: -0.5,-13.5
+      parent: 1
+      type: Transform
+- proto: PotatoSeeds
+  entities:
+  - uid: 759
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 391
+      type: Transform
+    - nextSound: 342.7776094
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: PottedPlantRandom
+  entities:
+  - uid: 11
+    components:
+    - pos: 1.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 34
+    components:
+    - pos: -0.5,-9.5
+      parent: 1
+      type: Transform
+  - uid: 212
+    components:
+    - pos: -0.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 822
+    components:
+    - pos: -7.5,-18.5
+      parent: 1
+      type: Transform
+  - uid: 825
+    components:
+    - pos: -7.5,-15.5
+      parent: 1
+      type: Transform
+- proto: PowerCellRecharger
+  entities:
+  - uid: 393
+    components:
+    - pos: -2.5,-0.5
+      parent: 1
+      type: Transform
+- proto: Poweredlight
+  entities:
+  - uid: 383
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -3.5,-5.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 395
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -2.5,-10.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 396
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 2.5,-3.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 401
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,-17.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 402
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -1.5,-3.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 407
+    components:
+    - pos: -6.5,-14.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 408
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -6.5,-19.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 410
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 3.5,-13.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 411
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 8.5,-16.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 477
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,-7.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+  - uid: 808
+    components:
+    - pos: 0.5,-22.5
+      parent: 1
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+- proto: PoweredSmallLight
+  entities:
+  - uid: 377
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 6.5,-21.5
+      parent: 1
+      type: Transform
+  - uid: 398
+    components:
+    - pos: 0.5,-11.5
+      parent: 1
+      type: Transform
+  - uid: 399
+    components:
+    - pos: -6.5,-11.5
+      parent: 1
+      type: Transform
+  - uid: 403
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -5.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 405
+    components:
+    - pos: -6.5,-8.5
+      parent: 1
+      type: Transform
+  - uid: 412
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 7.5,-8.5
+      parent: 1
+      type: Transform
+  - uid: 800
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -5.5,-21.5
+      parent: 1
+      type: Transform
+- proto: ProtolatheMachineCircuitboard
+  entities:
+  - uid: 494
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 492
+      type: Transform
+    - nextSound: 3166.8895303
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: ProximitySensor
+  entities:
+  - uid: 724
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 709
+      type: Transform
+    - nextSound: 83.4082544
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 725
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 709
+      type: Transform
+    - nextSound: 83.8576655
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: Rack
+  entities:
+  - uid: 387
+    components:
+    - pos: 5.5,-8.5
+      parent: 1
+      type: Transform
+  - uid: 786
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 6.5,-8.5
+      parent: 1
+      type: Transform
+- proto: RadioHandheld
+  entities:
+  - uid: 222
+    components:
+    - pos: 3.5029812,-0.0025253296
+      parent: 1
+      type: Transform
+    - nextSound: 709.9117727
+      type: EmitSoundOnCollide
+  - uid: 705
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 704
+      type: Transform
+    - nextSound: 2812.649527
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 706
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 704
+      type: Transform
+    - nextSound: 2803.5324265
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: RandomBook
+  entities:
+  - uid: 728
+    components:
+    - pos: -7.5,-8.5
+      parent: 1
+      type: Transform
+- proto: RandomDrinkBottle
+  entities:
+  - uid: 307
+    components:
+    - pos: 0.5,-15.5
+      parent: 1
+      type: Transform
+  - uid: 309
+    components:
+    - pos: -0.5,-15.5
+      parent: 1
+      type: Transform
+  - uid: 311
+    components:
+    - pos: -0.5,-19.5
+      parent: 1
+      type: Transform
+- proto: RandomInstruments
+  entities:
+  - uid: 342
+    components:
+    - pos: -6.5,-8.5
+      parent: 1
+      type: Transform
+  - uid: 356
+    components:
+    - pos: 0.5,-11.5
+      parent: 1
+      type: Transform
+- proto: RandomItem
+  entities:
+  - uid: 355
+    components:
+    - pos: -6.5,-11.5
+      parent: 1
+      type: Transform
+- proto: RandomPosterLegit
+  entities:
+  - uid: 639
+    components:
+    - pos: -4.5,-10.5
+      parent: 1
+      type: Transform
+  - uid: 640
+    components:
+    - pos: -1.5,-10.5
+      parent: 1
+      type: Transform
+  - uid: 643
+    components:
+    - pos: 7.5,-9.5
+      parent: 1
+      type: Transform
+  - uid: 644
+    components:
+    - pos: 2.5,-17.5
+      parent: 1
+      type: Transform
+  - uid: 645
+    components:
+    - pos: 9.5,-13.5
+      parent: 1
+      type: Transform
+- proto: RandomSoap
+  entities:
+  - uid: 276
+    components:
+    - pos: -5.5,-6.5
+      parent: 1
+      type: Transform
+- proto: RandomVending
+  entities:
+  - uid: 637
+    components:
+    - pos: 4.5,-14.5
+      parent: 1
+      type: Transform
+  - uid: 638
+    components:
+    - pos: 5.5,-15.5
+      parent: 1
+      type: Transform
+- proto: ResearchAndDevelopmentServer
+  entities:
+  - uid: 659
+    components:
+    - pos: 4.5,-11.5
+      parent: 1
+      type: Transform
+    - nextUpdateTime: 1957.3571679
+      type: ResearchServer
+- proto: ResearchDisk10000
+  entities:
+  - uid: 649
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 648
+      type: Transform
+    - nextSound: 2015.1264072
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 650
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 648
+      type: Transform
+    - nextSound: 2014.3747488
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 651
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 648
+      type: Transform
+    - nextSound: 2014.7600645
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 652
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 648
+      type: Transform
+    - nextSound: 2013.4068718
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 653
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 648
+      type: Transform
+    - nextSound: 2013.8602733
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 654
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 648
+      type: Transform
+    - nextSound: 2012.4610124
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 655
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 648
+      type: Transform
+    - nextSound: 2012.9404517
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 656
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 648
+      type: Transform
+    - nextSound: 2011.4270826
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 657
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 648
+      type: Transform
+    - nextSound: 2011.9595456
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 658
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 648
+      type: Transform
+    - nextSound: 2010.7414452
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: RiceSeeds
+  entities:
+  - uid: 776
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 391
+      type: Transform
+    - nextSound: 339.0374084
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: SalvageMaterialCrateSpawner
+  entities:
+  - uid: 691
+    components:
+    - pos: 7.5,-15.5
+      parent: 1
+      type: Transform
+  - uid: 692
+    components:
+    - pos: 8.5,-15.5
+      parent: 1
+      type: Transform
+  - uid: 693
+    components:
+    - pos: 8.5,-14.5
+      parent: 1
+      type: Transform
+  - uid: 694
+    components:
+    - pos: 7.5,-14.5
+      parent: 1
+      type: Transform
+  - uid: 699
+    components:
+    - pos: 8.5,-18.5
+      parent: 1
+      type: Transform
+- proto: SawAdvanced
+  entities:
+  - uid: 61
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 660
+      type: Transform
+    - nextAttack: 421.86171
+      type: MeleeWeapon
+    - nextSound: 422.06171
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: ScalpelAdvanced
+  entities:
+  - uid: 60
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 660
+      type: Transform
+    - nextAttack: 425.8978507
+      type: MeleeWeapon
+    - nextSound: 426.0978507
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: ScanningModuleStockPart
+  entities:
+  - uid: 714
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 709
+      type: Transform
+    - nextSound: 3453.2585144
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 716
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 709
+      type: Transform
+    - nextSound: 3453.4389095
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: Screwdriver
+  entities:
+  - uid: 844
+    components:
+    - pos: 5.0534377,-7.8406763
+      parent: 1
+      type: Transform
+    - nextAttack: 500.303883
+      type: MeleeWeapon
+    - nextSound: 500.503883
+      type: EmitSoundOnCollide
+- proto: SecBreachingHammer
+  entities:
+  - uid: 684
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 58
+      type: Transform
+    - nextAttack: 187.6310549
+      type: MeleeWeapon
+    - nextSound: 187.8310549
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: SecurityTechFabCircuitboard
+  entities:
+  - uid: 498
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 492
+      type: Transform
+    - nextSound: 3188.3581397
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: ServiceTechFabCircuitboard
+  entities:
+  - uid: 497
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 492
+      type: Transform
+    - nextSound: 3190.0738492
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: ShuttleWindow
+  entities:
+  - uid: 4
+    components:
+    - pos: 0.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 5
+    components:
+    - pos: -0.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 6
+    components:
+    - pos: 1.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 7
+    components:
+    - pos: -1.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 8
+    components:
+    - pos: 2.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 15
+    components:
+    - pos: -2.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 18
+    components:
+    - pos: 3.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 22
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -8.5,-18.5
+      parent: 1
+      type: Transform
+  - uid: 24
+    components:
+    - pos: 5.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 26
+    components:
+    - pos: -4.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 27
+    components:
+    - pos: -4.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 28
+    components:
+    - pos: 5.5,-1.5
+      parent: 1
+      type: Transform
+  - uid: 47
+    components:
+    - pos: 5.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 49
+    components:
+    - pos: -4.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 51
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -8.5,-17.5
+      parent: 1
+      type: Transform
+  - uid: 92
+    components:
+    - pos: -8.5,-16.5
+      parent: 1
+      type: Transform
+  - uid: 237
+    components:
+    - pos: -8.5,-15.5
+      parent: 1
+      type: Transform
+  - uid: 341
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 566
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,-6.5
+      parent: 1
+      type: Transform
+- proto: SignalButtonDirectional
+  entities:
+  - uid: 828
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -3.5,-20.5
+      parent: 1
+      type: Transform
+    - linkedPorts:
+        313:
+        - Pressed: Toggle
+        314:
+        - Pressed: Toggle
+      registeredSinks:
+        Pressed:
+        - 313
+        - 314
+      type: DeviceLinkSource
+  - uid: 829
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 4.5,-20.5
+      parent: 1
+      type: Transform
+    - linkedPorts:
+        315:
+        - Pressed: Toggle
+        343:
+        - Pressed: Toggle
+      registeredSinks:
+        Pressed:
+        - 315
+        - 343
+      type: DeviceLinkSource
+- proto: SignMedical
+  entities:
+  - uid: 238
+    components:
+    - pos: -1.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 272
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,-9.5
+      parent: 1
+      type: Transform
+- proto: Sink
+  entities:
+  - uid: 443
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,-16.5
+      parent: 1
+      type: Transform
+    - solutions:
+        tank:
+          temperature: 293.15
+          canMix: False
+          canReact: True
+          maxVol: 1500
+          reagents:
+          - Quantity: 1500
+            ReagentId: Water
+      type: SolutionContainerManager
+    - nextChargeTime: 7681.6084766
+      type: SolutionRegeneration
+- proto: SinkWide
+  entities:
+  - uid: 292
+    components:
+    - pos: -5.5,-6.5
+      parent: 1
+      type: Transform
+    - solutions:
+        tank:
+          temperature: 293.15
+          canMix: False
+          canReact: True
+          maxVol: 1500
+          reagents:
+          - Quantity: 1500
+            ReagentId: Water
+      type: SolutionContainerManager
+    - nextChargeTime: 4258.3678788
+      type: SolutionRegeneration
+- proto: SMESBasic
+  entities:
+  - uid: 372
+    components:
+    - pos: 6.5,-6.5
+      parent: 1
+      type: Transform
+- proto: SmokingPipeFilledTobacco
+  entities:
+  - uid: 781
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 738
+      type: Transform
+    - nextSound: 160.1278312
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: SoybeanSeeds
+  entities:
+  - uid: 777
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 391
+      type: Transform
+    - nextSound: 336.3371818
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: SpaceCash10
+  entities:
+  - uid: 226
+    components:
+    - pos: -6.399391,-17.732786
+      parent: 1
+      type: Transform
+    - nextSound: 3299.5243499
+      type: EmitSoundOnCollide
+  - uid: 227
+    components:
+    - pos: -6.118141,-17.467161
+      parent: 1
+      type: Transform
+    - nextSound: 3301.1417892
+      type: EmitSoundOnCollide
+  - uid: 228
+    components:
+    - pos: -6.821266,-17.467161
+      parent: 1
+      type: Transform
+    - nextSound: 3302.1255721
+      type: EmitSoundOnCollide
+  - uid: 229
+    components:
+    - pos: -6.821266,-16.607786
+      parent: 1
+      type: Transform
+    - nextSound: 3302.8573562
+      type: EmitSoundOnCollide
+  - uid: 230
+    components:
+    - pos: -6.024391,-16.560911
+      parent: 1
+      type: Transform
+    - nextSound: 3303.3254913
+      type: EmitSoundOnCollide
+  - uid: 231
+    components:
+    - pos: -6.477516,-16.154661
+      parent: 1
+      type: Transform
+    - nextSound: 3304.0257487
+      type: EmitSoundOnCollide
+- proto: SpawnMobDrone
+  entities:
+  - uid: 747
+    components:
+    - pos: 3.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 789
+    components:
+    - pos: 7.5,-6.5
+      parent: 1
+      type: Transform
+- proto: SpawnPointShipwreckHecate
+  entities:
+  - uid: 337
+    components:
+    - pos: -4.5,-14.5
+      parent: 1
+      type: Transform
+- proto: SpawnPointShipwreckTraveller
+  entities:
+  - uid: 17
+    components:
+    - pos: -6.5,-14.5
+      parent: 1
+      type: Transform
+  - uid: 296
+    components:
+    - pos: -7.5,-8.5
+      parent: 1
+      type: Transform
+  - uid: 297
+    components:
+    - pos: -5.5,-8.5
+      parent: 1
+      type: Transform
+  - uid: 298
+    components:
+    - pos: -5.5,-11.5
+      parent: 1
+      type: Transform
+  - uid: 299
+    components:
+    - pos: -7.5,-11.5
+      parent: 1
+      type: Transform
+  - uid: 300
+    components:
+    - pos: -0.5,-11.5
+      parent: 1
+      type: Transform
+  - uid: 301
+    components:
+    - pos: 1.5,-11.5
+      parent: 1
+      type: Transform
+  - uid: 306
+    components:
+    - pos: -6.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 568
+    components:
+    - pos: -5.5,-16.5
+      parent: 1
+      type: Transform
+  - uid: 569
+    components:
+    - pos: -5.5,-17.5
+      parent: 1
+      type: Transform
+  - uid: 570
+    components:
+    - pos: -1.5,-16.5
+      parent: 1
+      type: Transform
+  - uid: 571
+    components:
+    - pos: -1.5,-18.5
+      parent: 1
+      type: Transform
+- proto: SpeedLoaderLightRifle
+  entities:
+  - uid: 59
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 58
+      type: Transform
+    - nextSound: 6762.2835321
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 66
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 58
+      type: Transform
+    - nextSound: 6761.913464
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: SprayBottleSpaceCleaner
+  entities:
+  - uid: 294
+    components:
+    - pos: -5.253708,-5.9786873
+      parent: 1
+      type: Transform
+    - nextSound: 4289.9878167
+      type: EmitSoundOnCollide
+- proto: StoolBar
+  entities:
+  - uid: 174
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -1.5,-15.5
+      parent: 1
+      type: Transform
+  - uid: 179
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -1.5,-18.5
+      parent: 1
+      type: Transform
+  - uid: 180
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -1.5,-16.5
+      parent: 1
+      type: Transform
+  - uid: 181
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -1.5,-17.5
+      parent: 1
+      type: Transform
+  - uid: 204
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -1.5,-19.5
+      parent: 1
+      type: Transform
+- proto: SubstationBasic
+  entities:
+  - uid: 371
+    components:
+    - pos: 3.5,-5.5
+      parent: 1
+      type: Transform
+- proto: SugarcaneSeeds
+  entities:
+  - uid: 772
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 391
+      type: Transform
+    - nextSound: 334.7368069
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: SuitStorageEngi
+  entities:
+  - uid: 726
+    components:
+    - pos: 3.5,-8.5
+      parent: 1
+      type: Transform
+- proto: SurvivalKnife
+  entities:
+  - uid: 65
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 704
+      type: Transform
+    - nextAttack: 529.2028828
+      type: MeleeWeapon
+    - nextSound: 529.4028828
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: SyringeSpaceacillin
+  entities:
+  - uid: 734
+    components:
+    - pos: -0.5466466,-5.4500475
+      parent: 1
+      type: Transform
+    - nextSound: 518.2864949
+      type: EmitSoundOnCollide
+- proto: SyringeTranexamicAcid
+  entities:
+  - uid: 348
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 319
+      type: Transform
+    - nextSound: 180.1508294
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: TableCarpet
+  entities:
+  - uid: 145
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -6.5,-16.5
+      parent: 1
+      type: Transform
+  - uid: 202
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -6.5,-17.5
+      parent: 1
+      type: Transform
+- proto: TableGlass
+  entities:
+  - uid: 31
+    components:
+    - pos: -0.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 33
+    components:
+    - pos: -0.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 289
+    components:
+    - pos: -0.5,-5.5
+      parent: 1
+      type: Transform
+- proto: TableReinforced
+  entities:
+  - uid: 10
+    components:
+    - pos: -2.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 29
+    components:
+    - pos: -3.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 32
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 3.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 38
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -2.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 41
+    components:
+    - pos: 3.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 42
+    components:
+    - pos: 4.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 200
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 1.5,-18.5
+      parent: 1
+      type: Transform
+  - uid: 201
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 1.5,-19.5
+      parent: 1
+      type: Transform
+- proto: TableWoodReinforced
+  entities:
+  - uid: 178
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -0.5,-18.5
+      parent: 1
+      type: Transform
+  - uid: 198
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -0.5,-16.5
+      parent: 1
+      type: Transform
+  - uid: 203
+    components:
+    - pos: -0.5,-15.5
+      parent: 1
+      type: Transform
+  - uid: 205
+    components:
+    - pos: 0.5,-15.5
+      parent: 1
+      type: Transform
+  - uid: 207
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -0.5,-17.5
+      parent: 1
+      type: Transform
+  - uid: 214
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -0.5,-20.5
+      parent: 1
+      type: Transform
+  - uid: 215
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -0.5,-19.5
+      parent: 1
+      type: Transform
+- proto: Thruster
+  entities:
+  - uid: 2
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -0.5,-22.5
+      parent: 1
+      type: Transform
+    - nextFire: 2197.5606945
+      type: Thruster
+  - uid: 115
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 1.5,-22.5
+      parent: 1
+      type: Transform
+    - nextFire: 2198.0609494
+      type: Thruster
+  - uid: 134
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 8.5,-21.5
+      parent: 1
+      type: Transform
+    - nextFire: 2175.24038
+      type: Thruster
+  - uid: 137
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -7.5,-21.5
+      parent: 1
+      type: Transform
+    - nextFire: 2173.6095336
+      type: Thruster
+  - uid: 156
+    components:
+    - pos: -6.5,-4.5
+      parent: 1
+      type: Transform
+    - nextFire: 2078.801942
+      type: Thruster
+  - uid: 157
+    components:
+    - pos: 7.5,-4.5
+      parent: 1
+      type: Transform
+    - nextFire: 2080.1173509
+      type: Thruster
+  - uid: 160
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -8.5,-6.5
+      parent: 1
+      type: Transform
+    - nextFire: 2157.9232497
+      type: Thruster
+  - uid: 161
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 9.5,-6.5
+      parent: 1
+      type: Transform
+    - nextFire: 2163.4394205
+      type: Thruster
+- proto: ThrusterMachineCircuitboard
+  entities:
+  - uid: 499
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 492
+      type: Transform
+    - nextSound: 3113.5702975
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+  - uid: 503
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 492
+      type: Transform
+    - nextSound: 3113.2690106
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: TobaccoSeeds
+  entities:
+  - uid: 771
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 391
+      type: Transform
+    - nextSound: 332.6584391
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: ToiletEmpty
+  entities:
+  - uid: 293
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -6.5,-6.5
+      parent: 1
+      type: Transform
+- proto: TomatoSeeds
+  entities:
+  - uid: 774
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 391
+      type: Transform
+    - nextSound: 330.5358043
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: ToolboxMechanicalFilled
+  entities:
+  - uid: 389
+    components:
+    - pos: 5.553749,-8.586319
+      parent: 1
+      type: Transform
+    - nextAttack: 6331.5530244
+      type: MeleeWeapon
+    - nextSound: 6331.7530244
+      type: EmitSoundOnCollide
+- proto: TowercapSeeds
+  entities:
+  - uid: 775
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 391
+      type: Transform
+    - nextSound: 328.4243265
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: trayScanner
+  entities:
+  - uid: 681
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 660
+      type: Transform
+    - nextSound: 2443.6558411
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: UprightPianoInstrument
+  entities:
+  - uid: 170
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -7.5,-14.5
+      parent: 1
+      type: Transform
+- proto: VendingMachineCondiments
+  entities:
+  - uid: 167
+    components:
+    - flags: SessionSpecific
+      type: MetaData
+    - rot: 1.5707963267948966 rad
+      pos: -0.5,-20.5
+      parent: 1
+      type: Transform
+    - nextEmpEject: 3241.3536554
+      type: VendingMachine
+- proto: WallShuttle
+  entities:
+  - uid: 48
+    components:
+    - pos: -4.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 50
+    components:
+    - pos: 5.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 78
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 6.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 79
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -5.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 80
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -6.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 82
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -8.5,-13.5
+      parent: 1
+      type: Transform
+  - uid: 84
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -8.5,-10.5
+      parent: 1
+      type: Transform
+  - uid: 85
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -8.5,-12.5
+      parent: 1
+      type: Transform
+  - uid: 86
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -8.5,-11.5
+      parent: 1
+      type: Transform
+  - uid: 89
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 7.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 90
+    components:
+    - pos: -7.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 91
+    components:
+    - pos: 8.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 95
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 9.5,-8.5
+      parent: 1
+      type: Transform
+  - uid: 96
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 9.5,-9.5
+      parent: 1
+      type: Transform
+  - uid: 97
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -8.5,-14.5
+      parent: 1
+      type: Transform
+  - uid: 98
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -8.5,-8.5
+      parent: 1
+      type: Transform
+  - uid: 99
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -8.5,-9.5
+      parent: 1
+      type: Transform
+  - uid: 100
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -7.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 104
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -5.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 105
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -8.5,-19.5
+      parent: 1
+      type: Transform
+  - uid: 106
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -7.5,-20.5
+      parent: 1
+      type: Transform
+  - uid: 107
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -6.5,-21.5
+      parent: 1
+      type: Transform
+  - uid: 108
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -5.5,-22.5
+      parent: 1
+      type: Transform
+  - uid: 110
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -3.5,-22.5
+      parent: 1
+      type: Transform
+  - uid: 118
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 4.5,-22.5
+      parent: 1
+      type: Transform
+  - uid: 120
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 6.5,-22.5
+      parent: 1
+      type: Transform
+  - uid: 121
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 7.5,-21.5
+      parent: 1
+      type: Transform
+  - uid: 122
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 8.5,-20.5
+      parent: 1
+      type: Transform
+  - uid: 123
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 9.5,-19.5
+      parent: 1
+      type: Transform
+  - uid: 124
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 9.5,-18.5
+      parent: 1
+      type: Transform
+  - uid: 125
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 9.5,-17.5
+      parent: 1
+      type: Transform
+  - uid: 126
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 9.5,-16.5
+      parent: 1
+      type: Transform
+  - uid: 127
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 9.5,-15.5
+      parent: 1
+      type: Transform
+  - uid: 128
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 9.5,-14.5
+      parent: 1
+      type: Transform
+  - uid: 129
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 9.5,-13.5
+      parent: 1
+      type: Transform
+  - uid: 130
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 9.5,-12.5
+      parent: 1
+      type: Transform
+  - uid: 131
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 9.5,-11.5
+      parent: 1
+      type: Transform
+  - uid: 132
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 9.5,-10.5
+      parent: 1
+      type: Transform
+  - uid: 139
+    components:
+    - pos: 0.5,-21.5
+      parent: 1
+      type: Transform
+  - uid: 146
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 7.5,-20.5
+      parent: 1
+      type: Transform
+  - uid: 159
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -6.5,-20.5
+      parent: 1
+      type: Transform
+  - uid: 162
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,-21.5
+      parent: 1
+      type: Transform
+  - uid: 163
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 2.5,-21.5
+      parent: 1
+      type: Transform
+  - uid: 168
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -0.5,-21.5
+      parent: 1
+      type: Transform
+  - uid: 169
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,-21.5
+      parent: 1
+      type: Transform
+- proto: WallShuttleDiagonal
+  entities:
+  - uid: 16
+    components:
+    - pos: -4.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 19
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 4.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 21
+    components:
+    - pos: -3.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 23
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 5.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 25
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -3.5,0.5
+      parent: 1
+      type: Transform
+  - uid: 52
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 4.5,1.5
+      parent: 1
+      type: Transform
+  - uid: 81
+    components:
+    - pos: -7.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 87
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 8.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 88
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 8.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 93
+    components:
+    - pos: -8.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 94
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 9.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 101
+    components:
+    - pos: -5.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 102
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 6.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 103
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 6.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 112
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -1.5,-22.5
+      parent: 1
+      type: Transform
+  - uid: 116
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 2.5,-22.5
+      parent: 1
+      type: Transform
+  - uid: 133
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -8.5,-20.5
+      parent: 1
+      type: Transform
+  - uid: 135
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -6.5,-22.5
+      parent: 1
+      type: Transform
+  - uid: 136
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 9.5,-20.5
+      parent: 1
+      type: Transform
+  - uid: 138
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 7.5,-22.5
+      parent: 1
+      type: Transform
+  - uid: 173
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,-20.5
+      parent: 1
+      type: Transform
+- proto: WallShuttleInterior
+  entities:
+  - uid: 14
+    components:
+    - pos: 5.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 53
+    components:
+    - pos: -1.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 55
+    components:
+    - pos: 3.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 56
+    components:
+    - pos: 4.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 71
+    components:
+    - pos: -4.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 73
+    components:
+    - pos: 2.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 75
+    components:
+    - pos: -0.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 76
+    components:
+    - pos: 1.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 77
+    components:
+    - pos: 0.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 141
+    components:
+    - pos: 3.5,-9.5
+      parent: 1
+      type: Transform
+  - uid: 144
+    components:
+    - pos: 4.5,-20.5
+      parent: 1
+      type: Transform
+  - uid: 147
+    components:
+    - pos: 6.5,-20.5
+      parent: 1
+      type: Transform
+  - uid: 151
+    components:
+    - pos: 8.5,-9.5
+      parent: 1
+      type: Transform
+  - uid: 152
+    components:
+    - pos: 7.5,-9.5
+      parent: 1
+      type: Transform
+  - uid: 154
+    components:
+    - pos: 5.5,-9.5
+      parent: 1
+      type: Transform
+  - uid: 155
+    components:
+    - pos: 6.5,-9.5
+      parent: 1
+      type: Transform
+  - uid: 158
+    components:
+    - pos: -5.5,-20.5
+      parent: 1
+      type: Transform
+  - uid: 182
+    components:
+    - pos: 2.5,-20.5
+      parent: 1
+      type: Transform
+  - uid: 183
+    components:
+    - pos: 2.5,-19.5
+      parent: 1
+      type: Transform
+  - uid: 184
+    components:
+    - pos: 2.5,-18.5
+      parent: 1
+      type: Transform
+  - uid: 185
+    components:
+    - pos: 2.5,-17.5
+      parent: 1
+      type: Transform
+  - uid: 186
+    components:
+    - pos: 2.5,-16.5
+      parent: 1
+      type: Transform
+  - uid: 187
+    components:
+    - pos: 2.5,-15.5
+      parent: 1
+      type: Transform
+  - uid: 189
+    components:
+    - pos: 2.5,-8.5
+      parent: 1
+      type: Transform
+  - uid: 190
+    components:
+    - pos: 2.5,-9.5
+      parent: 1
+      type: Transform
+  - uid: 191
+    components:
+    - pos: 2.5,-10.5
+      parent: 1
+      type: Transform
+  - uid: 192
+    components:
+    - pos: 2.5,-11.5
+      parent: 1
+      type: Transform
+  - uid: 193
+    components:
+    - pos: 2.5,-12.5
+      parent: 1
+      type: Transform
+  - uid: 194
+    components:
+    - pos: 2.5,-13.5
+      parent: 1
+      type: Transform
+  - uid: 195
+    components:
+    - pos: 2.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 196
+    components:
+    - pos: 2.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 197
+    components:
+    - pos: 2.5,-6.5
+      parent: 1
+      type: Transform
+  - uid: 210
+    components:
+    - pos: -5.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 211
+    components:
+    - pos: -6.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 221
+    components:
+    - pos: -1.5,-5.5
+      parent: 1
+      type: Transform
+  - uid: 239
+    components:
+    - pos: -4.5,-7.5
+      parent: 1
+      type: Transform
+  - uid: 240
+    components:
+    - pos: -4.5,-8.5
+      parent: 1
+      type: Transform
+  - uid: 241
+    components:
+    - pos: -7.5,-10.5
+      parent: 1
+      type: Transform
+  - uid: 242
+    components:
+    - pos: -6.5,-10.5
+      parent: 1
+      type: Transform
+  - uid: 243
+    components:
+    - pos: -5.5,-10.5
+      parent: 1
+      type: Transform
+  - uid: 245
+    components:
+    - pos: -4.5,-10.5
+      parent: 1
+      type: Transform
+  - uid: 246
+    components:
+    - pos: -4.5,-11.5
+      parent: 1
+      type: Transform
+  - uid: 247
+    components:
+    - pos: 1.5,-10.5
+      parent: 1
+      type: Transform
+  - uid: 248
+    components:
+    - pos: 0.5,-10.5
+      parent: 1
+      type: Transform
+  - uid: 250
+    components:
+    - pos: -0.5,-10.5
+      parent: 1
+      type: Transform
+  - uid: 251
+    components:
+    - pos: -1.5,-10.5
+      parent: 1
+      type: Transform
+  - uid: 253
+    components:
+    - pos: -0.5,-13.5
+      parent: 1
+      type: Transform
+  - uid: 254
+    components:
+    - pos: -4.5,-13.5
+      parent: 1
+      type: Transform
+  - uid: 255
+    components:
+    - pos: -1.5,-11.5
+      parent: 1
+      type: Transform
+  - uid: 256
+    components:
+    - pos: 1.5,-13.5
+      parent: 1
+      type: Transform
+  - uid: 257
+    components:
+    - pos: 0.5,-13.5
+      parent: 1
+      type: Transform
+  - uid: 258
+    components:
+    - pos: -1.5,-13.5
+      parent: 1
+      type: Transform
+  - uid: 259
+    components:
+    - pos: -5.5,-13.5
+      parent: 1
+      type: Transform
+  - uid: 260
+    components:
+    - pos: -6.5,-13.5
+      parent: 1
+      type: Transform
+  - uid: 262
+    components:
+    - pos: -7.5,-13.5
+      parent: 1
+      type: Transform
+  - uid: 264
+    components:
+    - pos: -4.5,-4.5
+      parent: 1
+      type: Transform
+  - uid: 470
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,-9.5
+      parent: 1
+      type: Transform
+  - uid: 827
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -3.5,-20.5
+      parent: 1
+      type: Transform
+- proto: WatermelonSeeds
+  entities:
+  - uid: 766
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 391
+      type: Transform
+    - nextSound: 326.0905527
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: WeaponCapacitorRecharger
+  entities:
+  - uid: 394
+    components:
+    - pos: 3.5,-0.5
+      parent: 1
+      type: Transform
+- proto: WeaponCrusherGlaive
+  entities:
+  - uid: 745
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 660
+      type: Transform
+    - nextFire: 27.3952051
+      type: Gun
+    - nextAttack: 27.3952051
+      type: MeleeWeapon
+    - nextSound: 27.5952051
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: WeaponDisabler
+  entities:
+  - uid: 707
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 58
+      type: Transform
+    - nextFire: 178.0137153
+      type: Gun
+    - nextSound: 178.2137153
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: WeaponFlareGun
+  entities:
+  - uid: 663
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 58
+      type: Transform
+    - nextFire: 166.8633087
+      type: Gun
+    - nextSound: 167.0633087
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: WeaponLaserCarbine
+  entities:
+  - uid: 69
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 58
+      type: Transform
+    - nextFire: 163.1798434
+      type: Gun
+    - nextSound: 163.3798434
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: WeaponShotgunKammerer
+  entities:
+  - uid: 385
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 58
+      type: Transform
+    - nextFire: 157.7128923
+      type: Gun
+    - nextSound: 157.9128924
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: WeaponSniperMosin
+  entities:
+  - uid: 386
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 58
+      type: Transform
+    - nextFire: 172.5637776
+      type: Gun
+    - nextSound: 172.7637776
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: WheatSeeds
+  entities:
+  - uid: 773
+    components:
+    - flags: InContainer
+      type: MetaData
+    - parent: 391
+      type: Transform
+    - nextSound: 323.4356381
+      type: EmitSoundOnCollide
+    - canCollide: False
+      type: Physics
+    - type: InsideEntityStorage
+- proto: Wirecutter
+  entities:
+  - uid: 845
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 4.8815627,-6.6531763
+      parent: 1
+      type: Transform
+    - nextAttack: 505.6877672
+      type: MeleeWeapon
+    - nextSound: 505.8877672
+      type: EmitSoundOnCollide
+- proto: Wrench
+  entities:
+  - uid: 843
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 6.4753127,-7.4813013
+      parent: 1
+      type: Transform
+    - nextAttack: 494.4698226
+      type: MeleeWeapon
+    - nextSound: 494.6698226
+      type: EmitSoundOnCollide
+...


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Adds new alternative shuttle map for the new shipwrecked gamemode.
The Endeavour.

It is a transport shuttle which specialises in transporting both people and cargo at same time.
For cutting costs and providing extra profit.

==Gameplay Effect==
The map provides much higher amount of tools for players to utilise. From weapons and armor to new option of utilising present resources in manufacturing equipment and machinery which should help in survival.
The shuttle's cargo hold is mostly randomised, making each run unique in what materials players start with.
Players get chance to spend 100k research points (unless they get lucky and more disks spawn) on whatever research they deem important in raising their chances of survival. [For context, as of writing the PR. The amount of research points needed for unlocking every research is  380 500 research points]

Now, while shuttle has all of these things which makes things easier. It isn't without extra challenges.

First being, power. As the shuttle by default already consumes more power than Adventurer. Each machine which players build will add to consumption.
This means that players do need to think quickly or otherwise will face blackout.

Second being, increased thruster requirement. As they now need to find 8 thrusters instead of 5.
Which means that more exploration will be needed.
Although in order to still provide some alternative solution. 2 thruster boards were added to shuttle.

**Important note**
The PR simply adds the map. It does not enable it automatically. (unless changed)

**Media**
![obraz](https://github.com/Nyanotrasen/Nyanotrasen/assets/52052459/ba04ca33-abc5-440f-8f47-ec3749ddd390)
![obraz](https://github.com/Nyanotrasen/Nyanotrasen/assets/52052459/a6392302-0810-446f-88e5-710a8ce8f164)

<!-- 
If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 
(adding clothing, items, new features, etc) must include ingame media or the PR will not be merged, in accordance with our PR guidelines.
This makes it much easier for us to merge PRs and find media for progress reports. If you include media in your pull request, we 
may potentially use it in the SS14 progress reports, with clear credit given.

Use screenshot software like Window's built in snipping tool, ShareX, Lightshot, or recording software like ShareX (gif), ScreenToGif, or Open Broadcaster Software (cross platform).
If you're unsure whether your PR will require media, ask a maintainer.

Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame
**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: Added new shuttle map for shipwrecked gamemode

