### PR TITLE
Set text files explicitly in gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,7 +10,18 @@
 # default for csharp files.
 # Note: This is only used by command line
 ###############################################################################
-*.cs     diff=csharp
+*.cs      text diff=csharp
+
+# Explicitly set text files.
+*.csproj  text
+*.json    text
+*.md      text
+*.sln     text
+*.swsl    text
+*.toml    text
+*.txt     text
+*.xaml    text
+*.yml     text
 
 ###############################################################################
 # Set the merge driver for project and solution files


### PR DESCRIPTION
I read [this article](https://adaptivepatchwork.com/2012/03/01/mind-the-end-of-your-line/). Maybe this will cut down on some of the newline churn between Windows & Linux.