### PR TITLE
Revert "Set text files explicitly in gitattributes (#1699)"

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,18 +10,7 @@
 # default for csharp files.
 # Note: This is only used by command line
 ###############################################################################
-*.cs      text diff=csharp
-
-# Explicitly set text files.
-*.csproj  text
-*.json    text
-*.md      text
-*.sln     text
-*.swsl    text
-*.toml    text
-*.txt     text
-*.xaml    text
-*.yml     text
+*.cs     diff=csharp
 
 ###############################################################################
 # Set the merge driver for project and solution files


### PR DESCRIPTION
There are issues with this commit affecting users of Visual Studio Code. Reverting for now.