### PR TITLE
Reduce zombie strengths

### DIFF
--- a/Content.Server/Zombies/ZombieSystem.cs
+++ b/Content.Server/Zombies/ZombieSystem.cs
@@ -69,9 +69,11 @@ namespace Content.Server.Zombies
             // Heal the zombified
             while (zombQuery.MoveNext(out var uid, out var comp, out var damage, out var mobState))
             {
-                // Process only once per second
-                if (comp.NextTick + TimeSpan.FromSeconds(1) > curTime)
+                // Begin Nyano-code: slow the healing rate.
+                // Process only once per two seconds
+                if (comp.NextTick + TimeSpan.FromSeconds(2) > curTime)
                     continue;
+                // End Nyano-code.
 
                 comp.NextTick = curTime;
 
@@ -81,16 +83,10 @@ namespace Content.Server.Zombies
                     continue;
                 }
 
-                if (mobState.CurrentState == MobState.Alive)
-                {
-                    // Gradual healing for living zombies.
-                    _damageable.TryChangeDamage(uid, comp.Damage, true, false, damage);
-                }
-                else if (_random.Prob(comp.ZombieReviveChance))
-                {
-                    // There's a small chance to reverse all the zombie's damage (damage.Damage) in one go
-                    _damageable.TryChangeDamage(uid, -damage.Damage, true, false, damage);
-                }
+                // Begin Nyano-code: the instant revive chance was removed here.
+                // Gradual healing for zombies.
+                _damageable.TryChangeDamage(uid, comp.Damage, true, false, damage);
+                // End Nyano-code.
             }
         }
 
@@ -211,7 +207,9 @@ namespace Content.Server.Zombies
                 if (HasComp<ZombieComponent>(entity))
                     args.BonusDamage = -args.BaseDamage * zombieComp.OtherZombieDamageCoefficient;
 
-                if ((mobState.CurrentState == MobState.Dead || mobState.CurrentState == MobState.Critical)
+                // Begin Nyano-code: only zombify the dead on damage, not the critically injured.
+                if ((mobState.CurrentState == MobState.Dead)
+                // End Nyano-code.
                     && !HasComp<ZombieComponent>(entity))
                 {
                     _zombify.ZombifyEntity(entity);

--- a/Content.Shared/Zombies/ZombieComponent.cs
+++ b/Content.Shared/Zombies/ZombieComponent.cs
@@ -44,14 +44,14 @@ namespace Content.Shared.Zombies
         /// The baseline infection chance you have if you are completely nude
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
-        public float MaxZombieInfectionChance = 0.30f;
+        public float MaxZombieInfectionChance = 0.05f;
 
         /// <summary>
         /// The minimum infection chance possible. This is simply to prevent
         /// being invincible by bundling up.
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
-        public float MinZombieInfectionChance = 0.05f;
+        public float MinZombieInfectionChance = 0.01f;
 
         [ViewVariables(VVAccess.ReadWrite)]
         public float ZombieMovementSpeedDebuff = 0.70f;

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/NPCs/zombies.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/NPCs/zombies.yml
@@ -112,8 +112,8 @@
   components:
     - type: ZombifiedOnSpawn
     - type: MovementSpeedModifier
-      baseWalkSpeed : 2.0
-      baseSprintSpeed : 4.0
+      baseWalkSpeed : 1.5
+      baseSprintSpeed : 3.0
     - type: Tool
       qualities:
         - Prying


### PR DESCRIPTION
Most of the issues surrounded their ability to instantly heal all damage when in critical condition. Healing has been slowed, and they can't instantly turn other critical mobs into zombies either. Infection chances have been greatly reduced, considering they're checked every hit. This might go too far, but we'll see.

Closes #1681