### PR TITLE
Add MailReceiver dynamically

### DIFF
--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -88,12 +88,6 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
     {
         var query = EntityQueryEnumerator<NukeopsRuleComponent, GameRuleComponent>();
 
-        // Begin Nyano-code:
-        // This is so nuclear operatives don't receive mail.
-        // This should be replaced at some point with a system that adds MailReceiver to valid mobs.
-        RemComp<MailReceiverComponent>(uid);
-        // End Nyano-code.
-
         while (query.MoveNext(out var ruleEnt, out var nukeops, out var gameRule))
         {
             if (!GameTicker.IsGameRuleAdded(ruleEnt, gameRule))

--- a/Content.Server/Nyanotrasen/Mail/Components/StationMailRouterComponent.cs
+++ b/Content.Server/Nyanotrasen/Mail/Components/StationMailRouterComponent.cs
@@ -1,0 +1,9 @@
+namespace Content.Server.Mail;
+
+/// <summary>
+/// Designates a station as a place for sending and receiving mail.
+/// </summary>
+[RegisterComponent]
+public sealed class StationMailRouterComponent : Component
+{
+}

--- a/Content.Server/Nyanotrasen/Mail/MailSystem.cs
+++ b/Content.Server/Nyanotrasen/Mail/MailSystem.cs
@@ -19,11 +19,11 @@ using Content.Server.Fluids.Components;
 using Content.Server.Item;
 using Content.Server.Mail.Components;
 using Content.Server.Mind;
-using Content.Server.Mind.Components;
 using Content.Server.Nutrition.Components;
 using Content.Server.Popups;
 using Content.Server.Power.Components;
 using Content.Server.Station.Systems;
+using Content.Server.Spawners.EntitySystems;
 using Content.Shared.Access.Components;
 using Content.Shared.Access.Systems;
 using Content.Shared.Damage;
@@ -73,6 +73,8 @@ namespace Content.Server.Mail
 
             _sawmill = Logger.GetSawmill("mail");
 
+            SubscribeLocalEvent<PlayerSpawningEvent>(OnSpawnPlayer, after: new[] { typeof(SpawnPointSystem) });
+
             SubscribeLocalEvent<MailComponent, ComponentRemove>(OnRemove);
             SubscribeLocalEvent<MailComponent, UseInHandEvent>(OnUseInHand);
             SubscribeLocalEvent<MailComponent, AfterInteractUsingEvent>(OnAfterInteractUsing);
@@ -100,6 +102,24 @@ namespace Content.Server.Mail
 
                 SpawnMail(mailTeleporter.Owner, mailTeleporter);
             }
+        }
+
+        /// <summary>
+        /// Dynamically add the MailReceiver component to appropriate entities.
+        /// </summary>
+        private void OnSpawnPlayer(PlayerSpawningEvent args)
+        {
+            if (args.SpawnResult == null ||
+                args.Job == null ||
+                args.Station is not {} station)
+            {
+                return;
+            }
+
+            if (!HasComp<StationMailRouterComponent>(station))
+                return;
+
+            AddComp<MailReceiverComponent>(args.SpawnResult.Value);
         }
 
         private void OnRemove(EntityUid uid, MailComponent component, ComponentRemove args)

--- a/Resources/Prototypes/Entities/Mobs/Player/dwarf.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dwarf.yml
@@ -25,5 +25,4 @@
     - type: NpcFactionMember
       factions:
         - NanoTrasen
-    - type: MailReceiver
     - type: PotentialPsionic

--- a/Resources/Prototypes/Entities/Mobs/Player/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/human.yml
@@ -32,7 +32,6 @@
   - type: NpcFactionMember
     factions:
     - NanoTrasen
-  - type: MailReceiver
   - type: PotentialPsionic
 
 #Syndie

--- a/Resources/Prototypes/Entities/Mobs/Player/reptilian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/reptilian.yml
@@ -24,7 +24,6 @@
     - type: NpcFactionMember
       factions:
         - NanoTrasen
-    - type: MailReceiver
     - type: PotentialPsionic
     - type: Respirator
       damage:

--- a/Resources/Prototypes/Entities/Mobs/Player/skeleton.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/skeleton.yml
@@ -20,7 +20,6 @@
     - type: CameraRecoil
     - type: Examiner
     - type: CanHostGuardian
-    - type: MailReceiver
     - type: PotentialPsionic
     - type: NpcFactionMember
       factions:

--- a/Resources/Prototypes/Entities/Mobs/Player/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/slime.yml
@@ -24,5 +24,4 @@
     - type: NpcFactionMember
       factions:
         - NanoTrasen
-    - type: MailReceiver
     - type: PotentialPsionic

--- a/Resources/Prototypes/Entities/Mobs/Player/vox.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/vox.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   save: false
   name: Vox
   parent: BaseMobVox
@@ -24,7 +24,6 @@
     - type: NpcFactionMember
       factions:
         - NanoTrasen
-    - type: MailReceiver
     - type: PotentialPsionic
     - type: Respirator
       damage:

--- a/Resources/Prototypes/Entities/Stations/nanotrasen.yml
+++ b/Resources/Prototypes/Entities/Stations/nanotrasen.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   abstract: true
   id: BaseStationNanotrasen
   components:
@@ -21,6 +21,7 @@
     - BaseStationExpeditions
     - BaseStationAllEventsEligible
     - BaseStationNanotrasen
+    - BaseStationMail
   noSpawn: true
   components:
     - type: Transform

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/arachne.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/arachne.yml
@@ -33,5 +33,4 @@
   - type: NpcFactionMember
     factions:
     - NanoTrasen
-  - type: MailReceiver
   - type: PotentialPsionic

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/felinid.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/felinid.yml
@@ -35,7 +35,6 @@
     factions:
     - NanoTrasen
   - type: Felinid #since this just adds an action...
-  - type: MailReceiver
   - type: InteractionPopup
     successChance: 1
     interactSuccessString: hugging-success-generic

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/moth.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/moth.yml
@@ -39,5 +39,4 @@
   - type: NpcFactionMember
     factions:
     - NanoTrasen
-  - type: MailReceiver
   - type: PotentialPsionic

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/oni.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/oni.yml
@@ -29,7 +29,6 @@
   - type: NpcFactionMember
     factions:
     - NanoTrasen
-  - type: MailReceiver
   - type: InteractionPopup
     successChance: 1
     interactSuccessString: hugging-success-generic

--- a/Resources/Prototypes/Nyanotrasen/Entities/Stations/mail.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Stations/mail.yml
@@ -1,0 +1,5 @@
+- type: entity
+  id: BaseStationMail
+  abstract: true
+  components:
+    - type: StationMailRouter


### PR DESCRIPTION
I've tested this, and it works for round-start spawn and late join, with and without arrivals. It does not add MailReceiver to fugitives, nuclear operatives (round start or ghost role), or evil twins.

I think it should be okay that evil twins don't get MailReceiver, since that would skew the packages in their favor, at least until some code is added to handle that case. It's small enough of an issue that it shouldn't matter much for now.

Closes #1587