### PR TITLE
Disable starvationdamage

### DIFF
--- a/Resources/Changelog/Changelog.yml
+++ b/Resources/Changelog/Changelog.yml
@@ -1,28 +1,4 @@
 Entries:
-- author: Rane
-  changes:
-  - message: Merged upstream.
-    type: Add
-  - message: Updated maps for xenoarch.
-    type: Add
-  - message: Adjusted current content to account for xenoarchaeology.
-    type: Tweak
-  - message: Removed the buyable random artifacts; we have other sources.
-    type: Remove
-  - message: Reduced prober points per second slightly to adjust for the new xenoarch
-      source.
-    type: Tweak
-  - message: Noospheric zap's bonus chance to gain psionics halved again.
-    type: Tweak
-  - message: Glimmer prober explosion strength increased by 25%.
-    type: Tweak
-  - message: Possible glimmer loss on prober destruction changed to the upper half
-      of the current range.
-    type: Tweak
-  - message: Ifrit movement ignores gravity.
-    type: Tweak
-  id: 71
-  time: '2022-11-06T23:58:36.0000000+00:00'
 - author: Colin-Tel
   changes:
   - message: Added stuff related to the new Xeno Archeology.
@@ -3825,3 +3801,9 @@ Entries:
     type: Tweak
   id: 568
   time: '2023-07-24T17:36:44.089419+00:00'
+- author: Vordenburg
+  changes:
+  - message: Disabled starvation damage during usual station gameplay.
+    type: Tweak
+  id: 569
+  time: '2023-07-25T17:20:29.901662+00:00'

--- a/Resources/Prototypes/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/diona.yml
@@ -8,9 +8,9 @@
   - type: HumanoidAppearance
     species: Diona
   - type: Hunger
-    starvationDamage:
-      types:
-        Bloodloss: 0.5
+    # starvationDamage:
+    #   types:
+    #     Bloodloss: 0.5
   - type: Thirst
     baseDecayRate: 0.3
   - type: Icon

--- a/Resources/Prototypes/Entities/Mobs/Species/dwarf.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/dwarf.yml
@@ -6,10 +6,10 @@
   abstract: true
   components:
   - type: Hunger
-    starvationDamage:
-      types:
-        Cold: 0.5
-        Bloodloss: 0.5
+    # starvationDamage:
+    #   types:
+    #     Cold: 0.5
+    #     Bloodloss: 0.5
   - type: Thirst
   - type: Icon
     sprite: Mobs/Species/Slime/parts.rsi

--- a/Resources/Prototypes/Entities/Mobs/Species/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/human.yml
@@ -6,10 +6,10 @@
   abstract: true
   components:
   - type: Hunger
-    starvationDamage:
-      types:
-        Cold: 0.5
-        Bloodloss: 0.5
+    # starvationDamage:
+    #   types:
+    #     Cold: 0.5
+    #     Bloodloss: 0.5
   - type: Thirst
   - type: Carriable
   - type: Perishable

--- a/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
@@ -8,9 +8,9 @@
   - type: HumanoidAppearance
     species: Reptilian
   - type: Hunger
-    starvationDamage:
-      types:
-        Cold: 1
+    # starvationDamage:
+    #   types:
+    #     Cold: 1
   - type: Thirst
   - type: Icon
     sprite: Mobs/Species/Reptilian/parts.rsi

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -5,9 +5,9 @@
   abstract: true
   components:
   - type: Hunger
-    starvationDamage:
-      types:
-        Bloodloss: 0.5
+    # starvationDamage:
+    #   types:
+    #     Bloodloss: 0.5
   - type: Thirst
   - type: Icon
     sprite: Mobs/Species/Slime/parts.rsi


### PR DESCRIPTION
`DeathByStarvation` still exists as a game rule for Shipwrecked.

:cl:
- tweak: Disabled starvation damage during usual station gameplay.