### PR TITLE
Fix anomaly events not adding to glimmer

### DIFF
--- a/Content.Server/Anomaly/AnomalySystem.Vessel.cs
+++ b/Content.Server/Anomaly/AnomalySystem.Vessel.cs
@@ -1,4 +1,4 @@
-﻿using Content.Server.Anomaly.Components;
+using Content.Server.Anomaly.Components;
 using Content.Server.Construction;
 using Content.Server.Power.EntitySystems;
 using Content.Server.Psionics.Glimmer;
@@ -80,6 +80,14 @@ public sealed partial class AnomalySystem
         if (!TryComp<AnomalyComponent>(anomaly, out var anomalyComponent) || anomalyComponent.ConnectedVessel != null)
             return;
 
+        // Begin Nyano-code: tie anomaly harvesting to glimmer rate.
+        if (this.IsPowered(uid, EntityManager) &&
+            TryComp<GlimmerSourceComponent>(anomaly, out var glimmerSource))
+        {
+            glimmerSource.Active = true;
+        }
+        // End Nyano-code.
+
         component.Anomaly = scanner.ScannedAnomaly;
         anomalyComponent.ConnectedVessel = uid;
         UpdateVesselAppearance(uid,  component);
@@ -88,26 +96,13 @@ public sealed partial class AnomalySystem
 
     private void OnVesselGetPointsPerSecond(EntityUid uid, AnomalyVesselComponent component, ref ResearchServerGetPointsPerSecondEvent args)
     {
-        GlimmerSourceComponent? glimmerSource = null;
-
         if (!this.IsPowered(uid, EntityManager) || component.Anomaly is not {} anomaly)
-        {
-            // Begin Nyano-code: tie anomaly vessels to glimmer rate.
-            if (TryComp<GlimmerSourceComponent>(uid, out glimmerSource))
-                glimmerSource.Active = false;
-            // End Nyano-code.
             return;
-        }
 
         // Begin Nyano-code: limit passive point generation.
         args.Sources++;
         // End Nyano-code.
         args.Points += (int) (GetAnomalyPointValue(anomaly) * component.PointMultiplier);
-
-        // Begin Nyano-code: tie anomaly vessels to glimmer rate.
-        if (TryComp<GlimmerSourceComponent>(uid, out glimmerSource))
-            glimmerSource.Active = true;
-        // End Nyano-code.
     }
 
     private void OnUnpaused(EntityUid uid, AnomalyVesselComponent component, ref EntityUnpausedEvent args)

--- a/Resources/Prototypes/Entities/Structures/Machines/anomaly_equipment.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/anomaly_equipment.yml
@@ -96,9 +96,6 @@
   - type: GuideHelp
     guides:
     - ScannersAndVessels
-  - type: GlimmerSource
-    active: false
-    secondsPerGlimmer: 10 #More effecient than probers by virtue of much higher point score...
   - type: Fixtures
     fixtures:
       fix1:

--- a/Resources/Prototypes/Entities/Structures/Specific/anomalies.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/anomalies.yml
@@ -48,6 +48,8 @@
     sound:
       path: /Audio/Effects/teleport_arrival.ogg
   - type: Psionic
+  - type: GlimmerSource
+    active: false
 
 - type: entity
   id: AnomalyPyroclastic


### PR DESCRIPTION
Improved on the previous implementation (which wasn't enabled, a mistake).