### PR TITLE
remove oni eye zoom

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/oni.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/oni.yml
@@ -21,8 +21,6 @@
         Asphyxiation: -1.5
   - type: Alerts
   - type: Actions
-  - type: Eye
-    zoom: "1.125, 1.125"
   - type: CameraRecoil
   - type: Examiner
   - type: CanHostGuardian


### PR DESCRIPTION
It causes a bunch of inconsistences, some people report eye strain, runs into issues related to non-integer scaling, interacts with a bunch of bugs.

:cl: Rane
- remove: Removed the zoom out on oni eyes.

