### PR TITLE
Buff Melee Energy Weapons

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -7,7 +7,8 @@
   - type: EnergySword
     litDamageBonus:
         types:
-            Heat: 17
+            Heat: 15
+            Slash: 15
             Blunt: -4.5
     litDisarmMalus: 0.6
   - type: Sprite
@@ -64,7 +65,8 @@
     secret: true
     litDamageBonus:
         types:
-            Heat: 13
+            Heat: 9
+            Slash: 9 
             Blunt: -1
     litDisarmMalus: 0.4
   - type: Sprite


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Buffed Melee Energy Weapons due to them feeling underpowered when used. -->

**Media**
<!-- 

-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
The Syndicate has improved it's energy weapons technologies in the melee field. The Energy Sword now deals 15 Heat and 15 Slash when lit and the Energy Dagger now deals 9 Heat and 9 Slash when lit.
-->

:cl:
- add: Added fun!
- remove: Removed fun!

