### PR TITLE
Remove incorrect description from rigged boxing gloves

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -82,7 +82,6 @@
   id: ClothingHandsGlovesBoxingRigged
   name: blue boxing gloves
   suffix: Rigged
-  description: Regal blue gloves, with a nice gold trim. Swanky.
   components:
   - type: StaminaDamageOnHit
     damage: 30


### PR DESCRIPTION
## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Rigged boxing gloves had the Captain's Gloves description for some reason. Removed it so it uses the default boxing gloves description, which makes it less obvious to be a traitor item.

**Media**
<!-- 
If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 
(adding clothing, items, new features, etc) must include ingame media or the PR will not be merged, in accordance with our PR guidelines.
This makes it much easier for us to merge PRs and find media for progress reports. If you include media in your pull request, we 
may potentially use it in the SS14 progress reports, with clear credit given.

Use screenshot software like Window's built in snipping tool, ShareX, Lightshot, or recording software like ShareX (gif), ScreenToGif, or Open Broadcaster Software (cross platform).
If you're unsure whether your PR will require media, ask a maintainer.

Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

🍞 

