### PR TITLE
Map Edits

### DIFF
--- a/Resources/Maps/arena.yml
+++ b/Resources/Maps/arena.yml
@@ -18324,14 +18324,14 @@ entities:
     - pos: 21.5023,-23.328539
       parent: 6747
       type: Transform
-  - uid: 3242
-    components:
-    - pos: 10.609187,-24.322584
-      parent: 6747
-      type: Transform
   - uid: 3714
     components:
     - pos: 10.496561,-31.37388
+      parent: 6747
+      type: Transform
+  - uid: 5587
+    components:
+    - pos: 12.421359,-21.323751
       parent: 6747
       type: Transform
 - proto: BoxLightbulb
@@ -18405,13 +18405,6 @@ entities:
     - pos: 58.825214,-22.271368
       parent: 6747
       type: Transform
-- proto: BoxPillCanister
-  entities:
-  - uid: 3673
-    components:
-    - pos: 10.515436,-23.30104
-      parent: 6747
-      type: Transform
 - proto: BoxShellTranquilizer
   entities:
   - uid: 7568
@@ -18468,11 +18461,6 @@ entities:
     - pos: 22.523132,-23.30769
       parent: 6747
       type: Transform
-  - uid: 494
-    components:
-    - pos: 10.44252,-24.31216
-      parent: 6747
-      type: Transform
   - uid: 3710
     components:
     - pos: 27.505062,-25.311308
@@ -18488,11 +18476,9 @@ entities:
     - pos: 16.505558,-21.343874
       parent: 6747
       type: Transform
-- proto: BoxSyringe
-  entities:
-  - uid: 3532
+  - uid: 5590
     components:
-    - pos: 10.598769,-23.280193
+    - pos: 12.650527,-21.355024
       parent: 6747
       type: Transform
 - proto: BoxTrashbag
@@ -53911,19 +53897,19 @@ entities:
       type: Transform
 - proto: chem_master
   entities:
+  - uid: 494
+    components:
+    - pos: 10.5,-24.5
+      parent: 6747
+      type: Transform
   - uid: 1712
     components:
     - pos: -19.5,-13.5
       parent: 6747
       type: Transform
-  - uid: 5587
+  - uid: 3673
     components:
-    - pos: 12.5,-27.5
-      parent: 6747
-      type: Transform
-  - uid: 5590
-    components:
-    - pos: 11.5,-27.5
+    - pos: 13.5,-25.5
       parent: 6747
       type: Transform
   - uid: 21533
@@ -53933,6 +53919,16 @@ entities:
       type: Transform
 - proto: ChemDispenser
   entities:
+  - uid: 3242
+    components:
+    - pos: 11.5,-27.5
+      parent: 6747
+      type: Transform
+  - uid: 3511
+    components:
+    - pos: 12.5,-27.5
+      parent: 6747
+      type: Transform
   - uid: 21534
     components:
     - pos: 54.5,-43.5
@@ -53962,14 +53958,14 @@ entities:
       type: Transform
 - proto: ChemistryHotplate
   entities:
-  - uid: 559
-    components:
-    - pos: 13.5,-25.5
-      parent: 6747
-      type: Transform
   - uid: 3187
     components:
     - pos: -24.5,-9.5
+      parent: 6747
+      type: Transform
+  - uid: 3532
+    components:
+    - pos: 13.5,-26.5
       parent: 6747
       type: Transform
   - uid: 3675
@@ -73931,6 +73927,13 @@ entities:
       type: Transform
 - proto: FloorDrain
   entities:
+  - uid: 559
+    components:
+    - pos: 10.5,-23.5
+      parent: 6747
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
   - uid: 1913
     components:
     - pos: -18.5,-27.5
@@ -117102,9 +117105,9 @@ entities:
     - pos: 10.461526,-25.160149
       parent: 6747
       type: Transform
-  - uid: 3662
+  - uid: 3529
     components:
-    - pos: 13.524026,-25.733463
+    - pos: 13.535895,-26.141413
       parent: 6747
       type: Transform
   - uid: 3988
@@ -132926,11 +132929,6 @@ entities:
     - pos: -31.5,10.5
       parent: 6747
       type: Transform
-  - uid: 3529
-    components:
-    - pos: 10.5,-23.5
-      parent: 6747
-      type: Transform
   - uid: 3713
     components:
     - pos: 22.5,-23.5
@@ -133129,7 +133127,7 @@ entities:
       type: Transform
   - uid: 5547
     components:
-    - pos: 10.5,-24.5
+    - pos: 12.5,-21.5
       parent: 6747
       type: Transform
   - uid: 5801
@@ -145771,6 +145769,12 @@ entities:
     - pos: -41.5,-5.5
       parent: 6747
       type: Transform
+  - uid: 3662
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: 10.5,-23.5
+      parent: 6747
+      type: Transform
   - uid: 3896
     components:
     - rot: -1.5707963267948966 rad
@@ -151095,11 +151099,6 @@ entities:
     - pos: 23.5,-23.5
       parent: 6747
       type: Transform
-  - uid: 3511
-    components:
-    - pos: 13.5,-25.5
-      parent: 6747
-      type: Transform
   - uid: 3718
     components:
     - pos: 13.5,-27.5
@@ -153391,13 +153390,6 @@ entities:
     - flags: SessionSpecific
       type: MetaData
     - pos: -25.5,-9.5
-      parent: 6747
-      type: Transform
-  - uid: 5643
-    components:
-    - flags: SessionSpecific
-      type: MetaData
-    - pos: 12.5,-21.5
       parent: 6747
       type: Transform
 - proto: VendingMachineCigs

--- a/Resources/Maps/hive.yml
+++ b/Resources/Maps/hive.yml
@@ -310,7 +310,7 @@ entities:
           tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAGAAAAAAAAAAAAAAAGAAAABgAAAAPQAAAD0AAAA9AAAAPQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAABgAAAAYAAAAGAAAABgAAAAYAAAAGEAAAA9AAAAPQAAAGEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAYAAAAAAAAAAAAAAAYAAAAGAAAABgAAAAYAAAAGAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAABgAAAAYAAAAGAAAABgAAAAYAAAAGAAAABgAAAAYAAAAGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
         -5,-2:
           ind: -5,-2
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYQAAAGEAAABhAAAAYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD0AAABhAAAAYQAAAD0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA9AAAAYQAAAGEAAAA9AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYQAAAGEAAABhAAAAYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABhAAAAYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYQAAAGEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAABgAAAAYAAAAGEAAAA9AAAAPQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABhAAAAYQAAAGEAAABgAAAAYAAAAGAAAABhAAAAYQAAAGEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYQAAAGEAAABhAAAAYAAAAGAAAABgAAAAYQAAAGEAAABhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGEAAABhAAAAYQAAAGEAAABhAAAAYQAAAGEAAAA9AAAAPQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABhAAAAYQAAAGEAAABgAAAAYAAAAGAAAABhAAAAYQAAAGEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYQAAAGEAAABhAAAAYAAAAGAAAABgAAAAYQAAAGEAAABhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAABgAAAAYAAAAGEAAAA9AAAAPQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYQAAAGEAAABhAAAAYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD0AAABhAAAAYQAAAD0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA9AAAAYQAAAGEAAAA9AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYQAAAGEAAABhAAAAYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABhAAAAYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYQAAAGEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAABgAAAAYAAAAGEAAAA9AAAAPQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABhAAAAYQAAAGEAAABgAAAAYAAAAGAAAABhAAAAYQAAAGEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYQAAAGEAAABhAAAAYAAAAGAAAABgAAAAYQAAAGEAAABhAAAAYAAAAGAAAABgAAAAYAAAAGAAAABgAAAAYAAAAGEAAABhAAAAYQAAAGEAAABhAAAAYQAAAGEAAAA9AAAAPQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABhAAAAYQAAAGEAAABgAAAAYAAAAGAAAABhAAAAYQAAAGEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYQAAAGEAAABhAAAAYAAAAGAAAABgAAAAYQAAAGEAAABhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAABgAAAAYAAAAGEAAAA9AAAAPQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
         5,2:
           ind: 5,2
           tiles: PQAAAGEAAAAAAAAAYAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAYAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAYAAAAAAAAABgAAAAAAAAAGAAAABgAAAAYAAAAGAAAAAAAAAAAAAAAGAAAABgAAAAYAAAAGAAAABgAAAAYAAAAGAAAAAAAAAAYAAAAAAAAABgAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAABgAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
@@ -362,6 +362,9 @@ entities:
         4,-4:
           ind: 4,-4
           tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAABgAAAAYAAAAGAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAGAAAABgAAAAYAAAAGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+        -6,-2:
+          ind: -6,-2
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYQAAAGAAAABgAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
       type: MapGrid
     - type: Broadphase
     - angularDamping: 0.05
@@ -9744,6 +9747,7 @@ entities:
             0: 240
           26,-3:
             0: 65280
+            4: 16
           26,-2:
             0: 65535
           26,-1:
@@ -9918,6 +9922,7 @@ entities:
             0: 12288
           26,4:
             0: 63
+            4: 64
           30,-2:
             0: 61715
           30,-1:
@@ -13363,9 +13368,19 @@ entities:
     - pos: 54.5,1.5
       parent: 1
       type: Transform
+  - uid: 5679
+    components:
+    - pos: -48.5,-23.5
+      parent: 1
+      type: Transform
   - uid: 5853
     components:
     - pos: -52.5,-16.5
+      parent: 1
+      type: Transform
+  - uid: 5874
+    components:
+    - pos: -48.5,-22.5
       parent: 1
       type: Transform
   - uid: 5901
@@ -14935,24 +14950,14 @@ entities:
     - pos: -54.5,-24.5
       parent: 1
       type: Transform
-  - uid: 5874
+- proto: AirlockSalvageLocked
+  entities:
+  - uid: 5675
     components:
     - pos: -47.5,-26.5
       parent: 1
       type: Transform
   - uid: 5884
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -48.5,-23.5
-      parent: 1
-      type: Transform
-  - uid: 5885
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -48.5,-22.5
-      parent: 1
-      type: Transform
-  - uid: 6809
     components:
     - pos: -54.5,-28.5
       parent: 1
@@ -19870,6 +19875,13 @@ entities:
     - pos: -63.5,-1.5
       parent: 1
       type: Transform
+  - uid: 7172
+    components:
+    - pos: -72.5,-22.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
   - uid: 9952
     components:
     - pos: -55.5,-23.5
@@ -36089,6 +36101,88 @@ entities:
   - uid: 23866
     components:
     - pos: -38.5,14.5
+      parent: 1
+      type: Transform
+  - uid: 23870
+    components:
+    - pos: -71.5,-22.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 23872
+    components:
+    - pos: -73.5,-22.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 23873
+    components:
+    - pos: -74.5,-22.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 23874
+    components:
+    - pos: -75.5,-22.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 23875
+    components:
+    - pos: -76.5,-22.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 23876
+    components:
+    - pos: -77.5,-22.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 23877
+    components:
+    - pos: -78.5,-22.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 23878
+    components:
+    - pos: -79.5,-22.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 23879
+    components:
+    - pos: -80.5,-22.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 23880
+    components:
+    - pos: -81.5,-22.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 23881
+    components:
+    - pos: -82.5,-22.5
+      parent: 1
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 23910
+    components:
+    - pos: 98.5,1.5
       parent: 1
       type: Transform
 - proto: CableApcStack
@@ -56069,9 +56163,19 @@ entities:
       type: Transform
 - proto: ChemDispenser
   entities:
+  - uid: 5885
+    components:
+    - pos: 76.5,-10.5
+      parent: 1
+      type: Transform
   - uid: 6851
     components:
     - pos: -24.5,10.5
+      parent: 1
+      type: Transform
+  - uid: 10382
+    components:
+    - pos: 70.5,-12.5
       parent: 1
       type: Transform
 - proto: ChemDispenserMachineCircuitboard
@@ -58420,6 +58524,17 @@ entities:
     - pos: 70.5,-6.5
       parent: 1
       type: Transform
+    - linkedPorts:
+        5634:
+        - MedicalScannerSender: MedicalScannerReceiver
+        5615:
+        - CloningPodSender: CloningPodReceiver
+      registeredSinks:
+        MedicalScannerSender:
+        - 5634
+        CloningPodSender:
+        - 5615
+      type: DeviceLinkSource
 - proto: ComputerComms
   entities:
   - uid: 6290
@@ -119417,10 +119532,9 @@ entities:
       type: Transform
 - proto: HyperlinkBookChemistry
   entities:
-  - uid: 10380
+  - uid: 10377
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 76.530075,-8.41775
+    - pos: 76.49405,-8.364154
       parent: 1
       type: Transform
 - proto: HyperlinkBookCooking
@@ -119844,14 +119958,14 @@ entities:
     - pos: 21.5,39.5
       parent: 1
       type: Transform
+  - uid: 10379
+    components:
+    - pos: 76.5,-9.5
+      parent: 1
+      type: Transform
   - uid: 12447
     components:
     - pos: -9.5,22.5
-      parent: 1
-      type: Transform
-  - uid: 21773
-    components:
-    - pos: 76.5,-10.5
       parent: 1
       type: Transform
 - proto: KitchenSpike
@@ -120602,6 +120716,13 @@ entities:
   - uid: 9597
     components:
     - pos: 107.5,5.5
+      parent: 1
+      type: Transform
+- proto: LockerWardenFilled
+  entities:
+  - uid: 6808
+    components:
+    - pos: 76.5,10.5
       parent: 1
       type: Transform
 - proto: LockerWeldingSuppliesFilled
@@ -121423,6 +121544,9 @@ entities:
     - pos: 71.5,-6.5
       parent: 1
       type: Transform
+    - links:
+      - 5635
+      type: DeviceLinkSink
 - proto: MedicalScannerMachineCircuitboard
   entities:
   - uid: 6608
@@ -121558,6 +121682,9 @@ entities:
     - pos: 69.5,-5.5
       parent: 1
       type: Transform
+    - links:
+      - 5635
+      type: DeviceLinkSink
 - proto: MetempsychoticMachineCircuitboard
   entities:
   - uid: 6578
@@ -121878,6 +122005,12 @@ entities:
     components:
     - rot: -1.5707963267948966 rad
       pos: -16.490408,38.664
+      parent: 1
+      type: Transform
+  - uid: 23882
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 80.6783,-8.160163
       parent: 1
       type: Transform
 - proto: NetworkConfigurator
@@ -124683,11 +124816,6 @@ entities:
     - pos: 89.5,5.5
       parent: 1
       type: Transform
-  - uid: 7172
-    components:
-    - pos: 76.5,10.5
-      parent: 1
-      type: Transform
   - uid: 7436
     components:
     - pos: 11.5,48.5
@@ -124841,6 +124969,11 @@ entities:
   - uid: 23807
     components:
     - pos: 74.5,-0.5
+      parent: 1
+      type: Transform
+  - uid: 23883
+    components:
+    - pos: 76.5,12.5
       parent: 1
       type: Transform
 - proto: PottedPlantRandomPlastic
@@ -128889,6 +129022,11 @@ entities:
     - pos: -53.5,38.5
       parent: 1
       type: Transform
+  - uid: 6809
+    components:
+    - pos: 76.5,-8.5
+      parent: 1
+      type: Transform
   - uid: 6945
     components:
     - pos: 26.5,-11.5
@@ -129103,11 +129241,6 @@ entities:
   - uid: 9802
     components:
     - pos: 111.5,-1.5
-      parent: 1
-      type: Transform
-  - uid: 10382
-    components:
-    - pos: 76.5,-9.5
       parent: 1
       type: Transform
   - uid: 11246
@@ -135169,10 +135302,10 @@ entities:
       type: Transform
 - proto: SalvageMagnet
   entities:
-  - uid: 6775
+  - uid: 23871
     components:
     - rot: 1.5707963267948966 rad
-      pos: -72.5,-22.5
+      pos: -83.5,-22.5
       parent: 1
       type: Transform
 - proto: SalvagePartsSpawnerLow
@@ -135546,9 +135679,9 @@ entities:
       pos: -11.456412,42.57039
       parent: 1
       type: Transform
-  - uid: 10377
+  - uid: 10380
     components:
-    - pos: 76.48893,-9.303487
+    - pos: 76.478424,-8.364154
       parent: 1
       type: Transform
 - proto: SheetPlasteel
@@ -139722,6 +139855,11 @@ entities:
     - pos: -46.5,7.5
       parent: 1
       type: Transform
+  - uid: 23884
+    components:
+    - pos: -0.5,-48.5
+      parent: 1
+      type: Transform
 - proto: SpawnPointBartender
   entities:
   - uid: 7087
@@ -139737,6 +139875,11 @@ entities:
   - uid: 7089
     components:
     - pos: -0.5,-35.5
+      parent: 1
+      type: Transform
+  - uid: 23885
+    components:
+    - pos: 0.5,-48.5
       parent: 1
       type: Transform
 - proto: SpawnPointBotanist
@@ -139759,6 +139902,11 @@ entities:
   - uid: 7396
     components:
     - pos: 18.5,-36.5
+      parent: 1
+      type: Transform
+  - uid: 23886
+    components:
+    - pos: 1.5,-48.5
       parent: 1
       type: Transform
 - proto: SpawnPointBoxer
@@ -139788,6 +139936,11 @@ entities:
     - pos: 27.5,23.5
       parent: 1
       type: Transform
+  - uid: 23887
+    components:
+    - pos: 2.5,-48.5
+      parent: 1
+      type: Transform
 - proto: SpawnPointCaptain
   entities:
   - uid: 6262
@@ -139807,6 +139960,11 @@ entities:
     - pos: 31.5,39.5
       parent: 1
       type: Transform
+  - uid: 23888
+    components:
+    - pos: 3.5,-48.5
+      parent: 1
+      type: Transform
 - proto: SpawnPointChaplain
   entities:
   - uid: 7342
@@ -139822,6 +139980,11 @@ entities:
   - uid: 7348
     components:
     - pos: 19.5,48.5
+      parent: 1
+      type: Transform
+  - uid: 23889
+    components:
+    - pos: 4.5,-48.5
       parent: 1
       type: Transform
 - proto: SpawnPointChef
@@ -139851,6 +140014,11 @@ entities:
     - pos: 18.5,21.5
       parent: 1
       type: Transform
+  - uid: 23890
+    components:
+    - pos: 5.5,-48.5
+      parent: 1
+      type: Transform
 - proto: SpawnPointChiefEngineer
   entities:
   - uid: 6261
@@ -139875,6 +140043,11 @@ entities:
   - uid: 7425
     components:
     - pos: 1.5,20.5
+      parent: 1
+      type: Transform
+  - uid: 23891
+    components:
+    - pos: 6.5,-48.5
       parent: 1
       type: Transform
 - proto: SpawnPointCyborg
@@ -139946,11 +140119,21 @@ entities:
     - pos: 30.5,46.5
       parent: 1
       type: Transform
+  - uid: 23892
+    components:
+    - pos: 7.5,-48.5
+      parent: 1
+      type: Transform
 - proto: SpawnPointForensicMantis
   entities:
   - uid: 7315
     components:
     - pos: 21.5,42.5
+      parent: 1
+      type: Transform
+  - uid: 23893
+    components:
+    - pos: 8.5,-48.5
       parent: 1
       type: Transform
 - proto: SpawnPointHeadOfPersonnel
@@ -139977,6 +140160,11 @@ entities:
   - uid: 22777
     components:
     - pos: -20.5,19.5
+      parent: 1
+      type: Transform
+  - uid: 23894
+    components:
+    - pos: 9.5,-48.5
       parent: 1
       type: Transform
 - proto: SpawnPointLatejoin
@@ -140021,6 +140209,11 @@ entities:
   - uid: 9076
     components:
     - pos: 45.5,8.5
+      parent: 1
+      type: Transform
+  - uid: 23895
+    components:
+    - pos: 10.5,-48.5
       parent: 1
       type: Transform
 - proto: SpawnPointLocationMidRoundAntag
@@ -140142,6 +140335,11 @@ entities:
     - pos: 7.5,-15.5
       parent: 1
       type: Transform
+  - uid: 23896
+    components:
+    - pos: -1.5,-48.5
+      parent: 1
+      type: Transform
 - proto: SpawnPointMedicalCyborg
   entities:
   - uid: 7706
@@ -140206,11 +140404,21 @@ entities:
     - pos: 86.5,-14.5
       parent: 1
       type: Transform
+  - uid: 23897
+    components:
+    - pos: -0.5,-49.5
+      parent: 1
+      type: Transform
 - proto: SpawnPointMime
   entities:
   - uid: 7426
     components:
     - pos: 7.5,24.5
+      parent: 1
+      type: Transform
+  - uid: 23898
+    components:
+    - pos: -2.5,-49.5
       parent: 1
       type: Transform
 - proto: SpawnPointMusician
@@ -140243,6 +140451,11 @@ entities:
   - uid: 20749
     components:
     - pos: -4.5,18.5
+      parent: 1
+      type: Transform
+  - uid: 23899
+    components:
+    - pos: -3.5,-49.5
       parent: 1
       type: Transform
 - proto: SpawnPointMystagogue
@@ -140316,6 +140529,11 @@ entities:
     - pos: 83.5,-16.5
       parent: 1
       type: Transform
+  - uid: 23900
+    components:
+    - pos: -2.5,-46.5
+      parent: 1
+      type: Transform
 - proto: SpawnPointPrisoner
   entities:
   - uid: 7094
@@ -140365,11 +140583,21 @@ entities:
     - pos: 89.5,13.5
       parent: 1
       type: Transform
+  - uid: 23901
+    components:
+    - pos: -0.5,-46.5
+      parent: 1
+      type: Transform
 - proto: SpawnPointPsychologist
   entities:
   - uid: 5742
     components:
     - pos: 80.5,-2.5
+      parent: 1
+      type: Transform
+  - uid: 23902
+    components:
+    - pos: 10.5,-49.5
       parent: 1
       type: Transform
 - proto: SpawnPointQuartermaster
@@ -140404,6 +140632,11 @@ entities:
     - pos: -6.5,-2.5
       parent: 1
       type: Transform
+  - uid: 23903
+    components:
+    - pos: 12.5,-49.5
+      parent: 1
+      type: Transform
 - proto: SpawnPointReporter
   entities:
   - uid: 7418
@@ -140414,6 +140647,11 @@ entities:
   - uid: 7419
     components:
     - pos: 42.5,-12.5
+      parent: 1
+      type: Transform
+  - uid: 23904
+    components:
+    - pos: 13.5,-49.5
       parent: 1
       type: Transform
 - proto: SpawnPointSalvageTechnician
@@ -140453,6 +140691,11 @@ entities:
     - pos: -50.5,-27.5
       parent: 1
       type: Transform
+  - uid: 23905
+    components:
+    - pos: 15.5,-49.5
+      parent: 1
+      type: Transform
 - proto: SpawnPointSecurityCadet
   entities:
   - uid: 9077
@@ -140463,6 +140706,11 @@ entities:
   - uid: 9078
     components:
     - pos: 68.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 23906
+    components:
+    - pos: 15.5,-46.5
       parent: 1
       type: Transform
 - proto: SpawnPointSecurityOfficer
@@ -140520,6 +140768,11 @@ entities:
   - uid: 9310
     components:
     - pos: 87.5,13.5
+      parent: 1
+      type: Transform
+  - uid: 23907
+    components:
+    - pos: 17.5,-46.5
       parent: 1
       type: Transform
 - proto: SpawnPointStationEngineer
@@ -140592,6 +140845,18 @@ entities:
   - uid: 7341
     components:
     - pos: -41.5,6.5
+      parent: 1
+      type: Transform
+  - uid: 23908
+    components:
+    - pos: 11.5,-48.5
+      parent: 1
+      type: Transform
+- proto: SpawnPointValet
+  entities:
+  - uid: 23909
+    components:
+    - pos: 14.5,-48.5
       parent: 1
       type: Transform
 - proto: SpawnPointWarden
@@ -144511,11 +144776,6 @@ entities:
     - pos: 71.5,-10.5
       parent: 1
       type: Transform
-  - uid: 5679
-    components:
-    - pos: 76.5,-10.5
-      parent: 1
-      type: Transform
   - uid: 6551
     components:
     - pos: -58.5,0.5
@@ -144525,6 +144785,11 @@ entities:
     components:
     - rot: 3.141592653589793 rad
       pos: -54.5,-3.5
+      parent: 1
+      type: Transform
+  - uid: 6775
+    components:
+    - pos: 76.5,-9.5
       parent: 1
       type: Transform
   - uid: 6852
@@ -144595,12 +144860,6 @@ entities:
   - uid: 10378
     components:
     - pos: 73.5,-12.5
-      parent: 1
-      type: Transform
-  - uid: 10379
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 76.5,-8.5
       parent: 1
       type: Transform
   - uid: 11705
@@ -145587,6 +145846,13 @@ entities:
     - pos: 28.556608,34.49917
       parent: 1
       type: Transform
+- proto: TintedWindow
+  entities:
+  - uid: 21773
+    components:
+    - pos: -54.5,-27.5
+      parent: 1
+      type: Transform
 - proto: ToiletDirtyWater
   entities:
   - uid: 990
@@ -146383,15 +146649,6 @@ entities:
     - flags: SessionSpecific
       type: MetaData
     - pos: 73.5,-9.5
-      parent: 1
-      type: Transform
-- proto: VendingMachineChemicals
-  entities:
-  - uid: 5675
-    components:
-    - flags: SessionSpecific
-      type: MetaData
-    - pos: 70.5,-12.5
       parent: 1
       type: Transform
 - proto: VendingMachineCigs
@@ -166191,11 +166448,6 @@ entities:
   - uid: 6747
     components:
     - pos: -65.5,5.5
-      parent: 1
-      type: Transform
-  - uid: 6808
-    components:
-    - pos: -54.5,-27.5
       parent: 1
       type: Transform
   - uid: 7184

--- a/Resources/Prototypes/Maps/hive.yml
+++ b/Resources/Prototypes/Maps/hive.yml
@@ -2,7 +2,7 @@
   id: TheHive
   mapName: 'The Hive'
   mapPath: /Maps/hive.yml
-  minPlayers: 20
+  minPlayers: 30
   maxPlayers: 70
   stations:
     TheHive:


### PR DESCRIPTION
Changelog:

Hive
- Adds Warden's locker
- Moves salvage magnet further into space
- Gives Chem their goldarned Chem Dispenser back
- Links metamphisics machine->console->scanner
- Some other little tweaks I'm too tired to remember

Arena
- Something about a chem dispenser

Proto for Hive
- Bumps minpop up to 30

