### PR TITLE
Makes it so E-Daggers have the ability to weld quietly

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -111,8 +111,7 @@
   - type: Tool
     qualities: 
         - Welding
-    useSound:
-        Collection: Welder
+
     
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -108,6 +108,12 @@
     - Write
   - type: DisarmMalus
     malus: 0
+  - type: Tool
+    qualities: 
+        - Welding
+    useSound:
+        Collection: Welder
+    
 
 - type: entity
   parent: BaseItem

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -112,8 +112,6 @@
     qualities: 
         - Welding
 
-    
-
 - type: entity
   parent: BaseItem
   id: EnergyDaggerBox


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!--  -->
This makes it so that E-Daggers can be used as welding tools without damaging the user's eyes in the process or make sounds.

**Media**
<!-- 
\



-->
![ExhibitAofWelding](https://github.com/Nyanotrasen/Nyanotrasen/assets/139474617/29b81d58-018e-47b3-a544-dee42c0820b0)

![ExhibitBOfWelding](https://github.com/Nyanotrasen/Nyanotrasen/assets/139474617/8fa3b2a2-fc73-49cb-adaf-cbd719fc9541)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: Tryded

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl: Tryded
- add: added E-Dagger's ability to weld
- remove: removed nothing!

