### PR TITLE
Added accesses to Cargo jobs and Assistant

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Cargo/mail_carrier.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Cargo/mail_carrier.yml
@@ -10,6 +10,7 @@
   - Cargo
   - Maintenance
   - Mail
+  - Service
 
 - type: startingGear
   id: MailCarrierGear

--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -9,6 +9,7 @@
   access:
   - Cargo
   - Maintenance
+  - Service
   - External #should be removed once all maps update for no cargo shuttle
 
 - type: startingGear

--- a/Resources/Prototypes/Roles/Jobs/Civilian/assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/assistant.yml
@@ -6,7 +6,7 @@
   startingGear: PassengerGear
   icon: "Passenger"
   supervisors: job-supervisors-everyone
-  extendedAccess:
+  access:
   - Maintenance
 
 - type: startingGear


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->

Gave cargo jobs (QM & mail carrier) service access, and gave assistants maintenance access.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- tweak: Nanotrasen has entrusted assistants once again with access to the dank, dark maintenance shafts.