### PR TITLE
Moth Less Flammable

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/moth.yml
@@ -18,7 +18,7 @@
   - type: Flammable
     damage:
       types:
-        Heat: 2 # moths should burn more easily
+        Heat: 1.5 # moths should burn more easily
   - type: Vocal
     wilhelm: "/Audio/Nyanotrasen/Voice/Moth/scream_moth.ogg"
     sounds:


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Buffs Moth


**Changelog**
Moth fire dmg modifier
2.0 -> 1.5

Requested for months on end, the damage modifier was really extreme and usually results in just immediate deaths in situations that often seem unavoidable.

Also there's just this number change yet the entire file is added and removed. Strange.

