### PR TITLE
Remove reference to English from Sophia conversation tree

### DIFF
--- a/Resources/Locale/en-US/npc/conversation/sophia.ftl
+++ b/Resources/Locale/en-US/npc/conversation/sophia.ftl
@@ -22,7 +22,7 @@ sophia-response-sorry-3 = Maybe I know the answer, maybe I do not. Either way, I
 
 sophia-response-nature = My nature doesn't really matter, does it? I'm fulfilling my purpose. Can you say the same, or are you just wasting time?
 
-sophia-response-epi = 'Epistemics' is a word. Aspiring Hellenes they are, they wished to displace the Latin 'science.' However, in English, epistemics has undesired connotations as a study of knowledge itself, even though the Greek word is a literal replacement for 'science.'
+sophia-response-epi = 'Epistemics' is a word. Aspiring Hellenes they are, they wished to displace the Latin 'science.' However, in Galactic Common, epistemics has undesired connotations as a study of knowledge itself, even though the Greek word is a literal replacement for 'science.'
 
 sophia-response-mantis = 'Mantis' means seer, soothsayer, or prophet. They must be so named because they seek to uncover the truth. And, fittingly with their psionic aptitude, 'mantis' and 'mind' both descend, to the best of our knowledge, from an absolutely ancient word that sounded something like 'mentis.'
 

--- a/Resources/Locale/en-US/npc/conversation/sophia.ftl
+++ b/Resources/Locale/en-US/npc/conversation/sophia.ftl
@@ -56,7 +56,7 @@ sophia-response-oni = Oni, it is said, originated in Sirius. The brightest star 
 
 sophia-response-arachne = Arachne are the strangest of them. They're not fully mortal. They took the form of humans, but not their genes. Their creator wrote his name in their stead.
 
-sophia-response-moth = Moths scarecely look human, but, strangely, their genes confirm they are. Their creator shares his name with a genus of moths, and was responsible for the other outlier.
+sophia-response-moth = Moths scarcely look human, but, strangely, their genes confirm they are. Their creator shares his name with a genus of moths, and was responsible for the other outlier.
 
 sophia-response-lamiae = So, you remember? You must be remembering their mythological namesake. If you've really retained that fleeting memory over so many metempsychoses... Perhaps I've said too much.
 


### PR DESCRIPTION
## About the PR
Sophia no longer refers to English, but instead Galactic Common to fit in with the vast majority of SS13/14 lore.
Also fixes a moth typo. *chitters

**Media**
No media, no fun.

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
No CL, no fun.